### PR TITLE
new feature: Synchronous to asynchronous.when the namespace has too much items,loads lowly.Now it's 80 percent less time-consuming

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/PortalApplication.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/PortalApplication.java
@@ -8,10 +8,12 @@ import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @EnableAspectJAutoProxy
 @Configuration
+@EnableAsync
 @EnableAutoConfiguration(exclude = {LdapAutoConfiguration.class})
 @EnableTransactionManagement
 @ComponentScan(basePackageClasses = {ApolloCommonConfig.class,

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceController.java
@@ -89,7 +89,6 @@ public class NamespaceController {
                                           @PathVariable String clusterName) {
 
     List<NamespaceBO> namespaceBOs = namespaceService.findNamespaceBOs(appId, Env.valueOf(env), clusterName);
-
     for (NamespaceBO namespaceBO : namespaceBOs) {
       if (permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceBO.getBaseInfo().getNamespaceName())) {
         namespaceBO.hideItems();

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncService.java
@@ -1,0 +1,73 @@
+package com.ctrip.framework.apollo.portal.service;
+
+
+import com.ctrip.framework.apollo.common.constants.GsonType;
+import com.ctrip.framework.apollo.common.dto.ItemDTO;
+import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.google.gson.Gson;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ * @author renjiahua
+ * @date 2020/12/26
+ */
+
+@Service
+public class NamespaceBoAsyncService {
+	/**
+	 * releaseService
+	 */
+	private final ReleaseService releaseService;
+
+	private final ItemService itemService;
+
+	private Gson gson = new Gson();
+
+	public NamespaceBoAsyncService(final ReleaseService releaseService,
+																 final ItemService itemService) {
+		this.releaseService = releaseService;
+		this.itemService = itemService;
+	}
+
+	/**
+	 * Get the latest release
+	 *
+	 * @param appId         appId
+	 * @param env           env
+	 * @param clusterName   cl
+	 * @param namespaceName namespaceName
+	 * @return Future<Map < String, String>>
+	 */
+	@Async("queryRemoteExecutor")
+	public Future<Map<String, String>> getLatestReleaseAsync(String appId, Env env, String clusterName, String namespaceName) {
+		ReleaseDTO latestRelease = releaseService.loadLatestRelease(appId, env, clusterName, namespaceName);
+		Map<String, String> releaseItems = new HashMap<>();
+		if (latestRelease != null) {
+			releaseItems = gson.fromJson(latestRelease.getConfigurations(), GsonType.CONFIG);
+		}
+		return new AsyncResult<>(releaseItems);
+	}
+
+	/**
+	 * Get the items
+	 *
+	 * @param appId         appId
+	 * @param env           env
+	 * @param clusterName   cl
+	 * @param namespaceName namespaceName
+	 * @return Future<Map < String, String>>
+	 */
+	@Async("queryRemoteExecutor")
+	public Future<List<ItemDTO>> getItemsAsync(String appId, Env env, String clusterName, String namespaceName) {
+		List<ItemDTO> items = itemService.findItems(appId, env, clusterName, namespaceName);
+		return new AsyncResult<>(items);
+	}
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -1,9 +1,7 @@
 package com.ctrip.framework.apollo.portal.service;
 
-import com.ctrip.framework.apollo.common.constants.GsonType;
 import com.ctrip.framework.apollo.common.dto.ItemDTO;
 import com.ctrip.framework.apollo.common.dto.NamespaceDTO;
-import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
@@ -25,51 +23,59 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 @Service
 public class NamespaceService {
 
-  private Logger logger = LoggerFactory.getLogger(NamespaceService.class);
-  private static final Gson GSON = new Gson();
+    private Logger logger = LoggerFactory.getLogger(NamespaceService.class);
+    private static final Gson GSON = new Gson();
 
-  private final PortalConfig portalConfig;
-  private final PortalSettings portalSettings;
-  private final UserInfoHolder userInfoHolder;
-  private final AdminServiceAPI.NamespaceAPI namespaceAPI;
-  private final ItemService itemService;
-  private final ReleaseService releaseService;
-  private final AppNamespaceService appNamespaceService;
-  private final InstanceService instanceService;
-  private final NamespaceBranchService branchService;
-  private final RolePermissionService rolePermissionService;
+    private final PortalConfig portalConfig;
+    private final PortalSettings portalSettings;
+    private final UserInfoHolder userInfoHolder;
+    private final AdminServiceAPI.NamespaceAPI namespaceAPI;
+    private final ItemService itemService;
+    private final ReleaseService releaseService;
+    private final AppNamespaceService appNamespaceService;
+    private final InstanceService instanceService;
+    private final NamespaceBranchService branchService;
+    private final RolePermissionService rolePermissionService;
+    private final NamespaceBoAsyncService namespaceBoAsyncService;
 
-  public NamespaceService(
-      final PortalConfig portalConfig,
-      final PortalSettings portalSettings,
-      final UserInfoHolder userInfoHolder,
-      final AdminServiceAPI.NamespaceAPI namespaceAPI,
-      final ItemService itemService,
-      final ReleaseService releaseService,
-      final AppNamespaceService appNamespaceService,
-      final InstanceService instanceService,
-      final @Lazy NamespaceBranchService branchService,
-      final RolePermissionService rolePermissionService) {
-    this.portalConfig = portalConfig;
-    this.portalSettings = portalSettings;
-    this.userInfoHolder = userInfoHolder;
-    this.namespaceAPI = namespaceAPI;
-    this.itemService = itemService;
-    this.releaseService = releaseService;
-    this.appNamespaceService = appNamespaceService;
-    this.instanceService = instanceService;
-    this.branchService = branchService;
-    this.rolePermissionService = rolePermissionService;
-  }
+    public NamespaceService(
+            final PortalConfig portalConfig,
+            final PortalSettings portalSettings,
+            final UserInfoHolder userInfoHolder,
+            final AdminServiceAPI.NamespaceAPI namespaceAPI,
+            final ItemService itemService,
+            final ReleaseService releaseService,
+            final AppNamespaceService appNamespaceService,
+            final InstanceService instanceService,
+            final @Lazy NamespaceBranchService branchService,
+            final RolePermissionService rolePermissionService,
+            final NamespaceBoAsyncService namespaceBoAsyncService) {
+        this.portalConfig = portalConfig;
+        this.portalSettings = portalSettings;
+        this.userInfoHolder = userInfoHolder;
+        this.namespaceAPI = namespaceAPI;
+        this.itemService = itemService;
+        this.releaseService = releaseService;
+        this.appNamespaceService = appNamespaceService;
+        this.instanceService = instanceService;
+        this.branchService = branchService;
+        this.rolePermissionService = rolePermissionService;
+        this.namespaceBoAsyncService = namespaceBoAsyncService;
+    }
 
 
   public NamespaceDTO createNamespace(Env env, NamespaceDTO namespace) {
@@ -127,32 +133,31 @@ public class NamespaceService {
     return namespace;
   }
 
-  /**
-   * load cluster all namespace info with items
-   */
-  public List<NamespaceBO> findNamespaceBOs(String appId, Env env, String clusterName) {
-
-    List<NamespaceDTO> namespaces = namespaceAPI.findNamespaceByCluster(appId, env, clusterName);
-    if (namespaces == null || namespaces.size() == 0) {
-      throw new BadRequestException("namespaces not exist");
+    /**
+     * load cluster all namespace info with items
+     */
+    public List<NamespaceBO> findNamespaceBOs(String appId, Env env, String clusterName) {
+        List<NamespaceDTO> namespaces = namespaceAPI.findNamespaceByCluster(appId, env, clusterName);
+        if (CollectionUtils.isEmpty(namespaces)) {
+            throw new BadRequestException("namespaces not exist");
+        }
+        //In order to solve the problem of slow processing of multiple namespace
+       // with a large number of items
+        return namespaces.parallelStream()
+                .map(
+                        namespace ->
+                        {
+                            try {
+                                return transformNamespace2BO(env, namespace);
+                            } catch (ExecutionException | InterruptedException e) {
+                                logger.error("parse namespace error. app id:{}, env:{}, clusterName:{}, namespace:{}",
+                                        appId, env, clusterName, namespace.getNamespaceName(), e);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
-
-    List<NamespaceBO> namespaceBOs = new LinkedList<>();
-    for (NamespaceDTO namespace : namespaces) {
-
-      NamespaceBO namespaceBO;
-      try {
-        namespaceBO = transformNamespace2BO(env, namespace);
-        namespaceBOs.add(namespaceBO);
-      } catch (Exception e) {
-        logger.error("parse namespace error. app id:{}, env:{}, clusterName:{}, namespace:{}",
-            appId, env, clusterName, namespace.getNamespaceName(), e);
-        throw e;
-      }
-    }
-
-    return namespaceBOs;
-  }
 
   public List<NamespaceDTO> findNamespaces(String appId, Env env, String clusterName) {
     return namespaceAPI.findNamespaceByCluster(appId, env, clusterName);
@@ -170,7 +175,13 @@ public class NamespaceService {
     if (namespace == null) {
       throw new BadRequestException("namespaces not exist");
     }
-    return transformNamespace2BO(env, namespace);
+      try {
+          return transformNamespace2BO(env, namespace);
+      } catch (ExecutionException | InterruptedException e) {
+          logger.error("load namespace error. app id:{}, env:{}, clusterName:{}, namespace:{}",
+                  appId, env, clusterName, namespace.getNamespaceName(), e);
+          return null;
+      }
   }
 
   public boolean namespaceHasInstances(String appId, Env env, String clusterName,
@@ -188,7 +199,13 @@ public class NamespaceService {
         namespaceAPI
             .findPublicNamespaceForAssociatedNamespace(env, appId, clusterName, namespaceName);
 
-    return transformNamespace2BO(env, namespace);
+      try {
+          return transformNamespace2BO(env, namespace);
+      } catch (ExecutionException | InterruptedException e) {
+          logger.error("find namespace error. app id:{}, env:{}, clusterName:{}, namespace:{}",
+                  appId, env, clusterName, namespace.getNamespaceName(), e);
+          return null;
+      }
   }
 
   public Map<String, Map<String, Boolean>> getNamespacesPublishInfo(String appId) {
@@ -204,53 +221,57 @@ public class NamespaceService {
     return result;
   }
 
-  private NamespaceBO transformNamespace2BO(Env env, NamespaceDTO namespace) {
+  private NamespaceBO transformNamespace2BO(Env env, NamespaceDTO namespace) throws ExecutionException, InterruptedException {
     NamespaceBO namespaceBO = new NamespaceBO();
     namespaceBO.setBaseInfo(namespace);
-
     String appId = namespace.getAppId();
     String clusterName = namespace.getClusterName();
     String namespaceName = namespace.getNamespaceName();
-
     fillAppNamespaceProperties(namespaceBO);
-
-    List<ItemBO> itemBOs = new LinkedList<>();
-    namespaceBO.setItems(itemBOs);
-
-    //latest Release
-    ReleaseDTO latestRelease;
     Map<String, String> releaseItems = new HashMap<>();
-    Map<String, ItemDTO> deletedItemDTOs = new HashMap<>();
-    latestRelease = releaseService.loadLatestRelease(appId, env, clusterName, namespaceName);
-    if (latestRelease != null) {
-      releaseItems = GSON.fromJson(latestRelease.getConfigurations(), GsonType.CONFIG);
+    List<ItemDTO> items = new ArrayList<>();
+    //Get the latest release asynchronously
+    Future<Map<String, String>> latestReleaseAsync = namespaceBoAsyncService
+            .getLatestReleaseAsync(appId, env, clusterName, namespaceName);
+    //Get the item list asynchronously
+    Future<List<ItemDTO>> itemsAsync = namespaceBoAsyncService.getItemsAsync(appId, env, clusterName, namespaceName);
+    //This method takes the most time, so make it in the main thread
+    List<ItemDTO> deletedItems = itemService.findDeletedItems(appId, env, clusterName, namespaceName);
+    Map<String, ItemDTO> deletedItemsMap = new HashMap<>();
+    //Convert list to map
+    if (!CollectionUtils.isEmpty(deletedItems)) {
+        deletedItems.forEach(itemDTO -> deletedItemsMap.put(itemDTO.getKey(), itemDTO));
     }
-
-    //not Release config items
-    List<ItemDTO> items = itemService.findItems(appId, env, clusterName, namespaceName);
-    int modifiedItemCnt = 0;
-    for (ItemDTO itemDTO : items) {
-
-      ItemBO itemBO = transformItem2BO(itemDTO, releaseItems);
-
-      if (itemBO.isModified()) {
-        modifiedItemCnt++;
-      }
-
-      itemBOs.add(itemBO);
+    try {
+        List<ItemDTO> list = itemsAsync.get();
+        if (!CollectionUtils.isEmpty(list)) {
+            items.addAll(list);
+        }
+        Map<String, String> releaseAsync = latestReleaseAsync.get();
+        if (Objects.nonNull(releaseAsync)) {
+            releaseItems.putAll(releaseAsync);
+        }
+    } catch (InterruptedException | ExecutionException e) {
+        logger.error("transformNamespace2BO error namespace:{}, env:{}",
+                namespace, env);
+        throw e;
     }
-
-    //deleted items
-    itemService.findDeletedItems(appId, env, clusterName, namespaceName).forEach(item -> {
-      deletedItemDTOs.put(item.getKey(),item);
-    });
-
-    List<ItemBO> deletedItems = parseDeletedItems(items, releaseItems, deletedItemDTOs);
-    itemBOs.addAll(deletedItems);
-    modifiedItemCnt += deletedItems.size();
-
-    namespaceBO.setItemModifiedCnt(modifiedItemCnt);
-
+    // Convert itemDTO' s list to ItemBO 's list
+    List<ItemBO> itemBOs = items
+            .parallelStream()
+            .map(itemDTO -> transformItem2BO(itemDTO, releaseItems))
+            .collect(Collectors.toList());
+    // Count the number of modified items
+    long modifiedItemCnt = itemBOs
+            .parallelStream()
+            .filter(ItemBO::isModified)
+            .count();
+    // Parse deleted items
+    List<ItemBO> deletedItemBos = parseDeletedItems(items, releaseItems, deletedItemsMap);
+    itemBOs.addAll(deletedItemBos);
+    namespaceBO.setItems(itemBOs);
+    // The number of items to be modified
+    namespaceBO.setItemModifiedCnt((int) modifiedItemCnt + deletedItemBos.size());
     return namespaceBO;
   }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/threadpool/ThreadTaskExecutorConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/threadpool/ThreadTaskExecutorConfig.java
@@ -1,0 +1,61 @@
+package com.ctrip.framework.apollo.portal.threadpool;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+import static java.lang.Boolean.TRUE;
+import static java.lang.Runtime.getRuntime;
+
+/**
+ * @author renjiahua
+ * @date 2020/12/26
+ */
+@Configuration
+public class ThreadTaskExecutorConfig {
+    /**
+     * Number of core threads in thread pool
+     */
+    private static final int CORE_SIZE = getRuntime().availableProcessors() * 2 + 1;
+    /**
+     * Maximum number of threads in thread pool
+     */
+    private static final int MAX_SIZE = 200;
+    /**
+     * The length of the thread pool waiting queue
+     */
+    private static final int QUEUE_CAPACITY = 300;
+    /**
+     * The keep alive time of thread pool
+     */
+    private static final int KEEP_ALIVE = 10;
+
+    /**
+     * Create a executor bean named queryRemoteExecutor
+     *
+     * @return Executor
+     */
+    @Bean
+    public Executor queryRemoteExecutor() {
+        return createExecutor();
+    }
+
+    /**
+     * Create a executor with default configurations
+     *
+     * @return Executor
+     */
+    private Executor createExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_SIZE);
+        executor.setMaxPoolSize(MAX_SIZE);
+        executor.setAllowCoreThreadTimeOut(TRUE);
+        executor.setThreadNamePrefix("query-pool-");
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setKeepAliveSeconds(KEEP_ALIVE);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncServiceTest.java
@@ -1,0 +1,78 @@
+package com.ctrip.framework.apollo.portal.service;
+
+import com.ctrip.framework.apollo.common.dto.ItemDTO;
+import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
+import com.ctrip.framework.apollo.portal.AbstractUnitTest;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author renjiahua
+ * @date 2021/1/17
+ */
+public class NamespaceBoAsyncServiceTest extends AbstractUnitTest {
+
+    @Mock
+    private ReleaseService releaseService;
+    @Mock
+    private ItemService itemService;
+    @InjectMocks
+    private NamespaceBoAsyncService namespaceBoAsyncService;
+
+    private String testAppId = "6666";
+    private String testClusterName = "default";
+    private String testNamespaceName = "application";
+    private Env testEnv = Env.DEV;
+
+    @Before
+    public void setup() {
+    }
+
+    @Test
+    public void testGetLatestReleaseAsync() throws ExecutionException, InterruptedException {
+        ReleaseDTO someRelease = new ReleaseDTO();
+        someRelease.setConfigurations("{\"a\":\"123\",\"b\":\"123\"}");
+        when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+                .thenReturn(someRelease);
+        Future<Map<String, String>> latestReleaseAsync = namespaceBoAsyncService.getLatestReleaseAsync(testAppId, testEnv, testClusterName, testNamespaceName);
+        Map<String, String> asyncRelease = latestReleaseAsync.get();
+        assertNotNull(asyncRelease);
+        assertEquals(2, asyncRelease.size());
+        assertEquals("123", asyncRelease.get("a"));
+        assertEquals("123", asyncRelease.get("b"));
+
+    }
+
+    @Test
+    public void testGetItemsAsync() throws ExecutionException, InterruptedException {
+        ItemDTO i1 = new ItemDTO("a", "123", "", 1);
+        ItemDTO i2 = new ItemDTO("b", "1", "", 2);
+        ItemDTO i3 = new ItemDTO("", "", "#dddd", 3);
+        ItemDTO i4 = new ItemDTO("c", "1", "", 4);
+        List<ItemDTO> someItems = Arrays.asList(i1, i2, i3, i4);
+        when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+                .thenReturn(someItems);
+        Future<List<ItemDTO>> itemsAsync = namespaceBoAsyncService.getItemsAsync(testAppId, testEnv, testClusterName, testNamespaceName);
+        List<ItemDTO> list = itemsAsync.get();
+        assertNotNull(list);
+        assertEquals(4, list.size());
+        assertEquals("a", list.get(0).getKey());
+        assertEquals(4, list.get(3).getLineNum());
+        assertEquals("", list.get(2).getValue());
+
+    }
+
+
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceBoAsyncServiceTest.java
@@ -57,7 +57,7 @@ public class NamespaceBoAsyncServiceTest extends AbstractUnitTest {
 
     @Test
     public void testGetItemsAsync() throws ExecutionException, InterruptedException {
-        ItemDTO i1 = new ItemDTO("a", "123", "", 1);
+        ItemDTO i1 = new ItemDTO("a", "1234", "", 1);
         ItemDTO i2 = new ItemDTO("b", "1", "", 2);
         ItemDTO i3 = new ItemDTO("", "", "#dddd", 3);
         ItemDTO i4 = new ItemDTO("c", "1", "", 4);


### PR DESCRIPTION
1.Synchronous to asynchronous.when the namespace has too much items,loads lowly.Now it's 80 percent less time-consuming

2.Compact code.

## What's the purpose of this PR

In order to reduce the time consumption of NamespaceController#findNamespaces

## Which issue(s) this PR fixes:
Fixes #
NONE

## Brief changelog
1. Add a Spring task thread pool configuration
2. Modified NamespaceService#findNamespaceBOs，serial lines changed to parallel.
3. Add a  Class with name NamespaceBoAsyncService  to provider some future methon.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
