### PR TITLE
Cache key normalize

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/config/ConfigServiceWithCache.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/config/ConfigServiceWithCache.java
@@ -58,7 +58,7 @@ public class ConfigServiceWithCache extends AbstractConfigService {
 
   private KeyNormalizeCache<String, ConfigCacheEntry> configCache;
 
-  private KeyNormalizeCache<Long, Optional<Release>> configIdCache;
+  private LoadingCache<Long, Optional<Release>> configIdCache;
 
   private ConfigCacheEntry nullConfigCacheEntry;
 
@@ -106,7 +106,7 @@ public class ConfigServiceWithCache extends AbstractConfigService {
         }
       }));
 
-    configIdCache = new KeyNormalizeCache(CacheBuilder.newBuilder()
+    configIdCache = CacheBuilder.newBuilder()
       .expireAfterAccess(DEFAULT_EXPIRED_AFTER_ACCESS_IN_MINUTES, TimeUnit.MINUTES)
       .build(new CacheLoader<Long, Optional<Release>>() {
         @Override
@@ -125,7 +125,7 @@ public class ConfigServiceWithCache extends AbstractConfigService {
             transaction.complete();
           }
         }
-      }));
+      });
   }
 
   @Override

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/config/ConfigServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/config/ConfigServiceWithCacheTest.java
@@ -10,6 +10,7 @@ import com.ctrip.framework.apollo.biz.service.ReleaseMessageService;
 import com.ctrip.framework.apollo.biz.service.ReleaseService;
 import com.ctrip.framework.apollo.biz.utils.ReleaseMessageKeyGenerator;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -275,5 +276,20 @@ public class ConfigServiceWithCacheTest {
 
     verify(releaseMessageService, times(1)).findLatestReleaseMessageForMessages(Lists.newArrayList(someKey));
     verify(releaseService, times(1)).findLatestActiveRelease(someAppId, someClusterName, someNamespaceName);
+  }
+
+  @Test
+  public void testFindLatestActiveReleaseWithCaseInsensitive() throws Exception {
+
+    when(releaseService.findLatestActiveRelease(someAppId.toLowerCase() , someClusterName.toLowerCase(), someNamespaceName.toLowerCase())).thenReturn
+        (someRelease);
+
+    Release release = configServiceWithCache.findLatestActiveRelease(someAppId, someClusterName, someNamespaceName, someNotificationMessages);
+
+    assertEquals(someRelease, release);
+
+    Release releaseWithLowerCaseAppId = configServiceWithCache.findLatestActiveRelease(someAppId.toLowerCase(), someClusterName, someNamespaceName, someNotificationMessages);
+
+    assertEquals(release, releaseWithLowerCaseAppId);
   }
 }

--- a/docs/zh/development/apollo-development-guide.md
+++ b/docs/zh/development/apollo-development-guide.md
@@ -62,6 +62,21 @@ Apollo本地开发需要以下组件：
 
 ![ConfigAdminApplication-Eureka](https://raw.githubusercontent.com/ctripcorp/apollo/master/doc/images/local-development/ConfigAdminApplication-Eureka.png)
 
+> 注：还可以通过健康检查接口确认服务健康状况：
+>
+> AdminService： [http://localhost:8090/health](http://localhost:8090/health)
+> ConfigService： [http://localhost:8080/health](http://localhost:8080/health)
+>
+> 如果服务健康，返回内容中的status.code应当为`UP`：
+>
+>     {
+>       "status": {
+>         "code": "UP",
+>         ...
+>       },
+>       ...
+>     }
+
 ## 2.2 Apollo-Portal
 
 下面以Intellij Community 2016.2版本为例来说明如何在本地启动`apollo-portal`。

--- a/docs/zh/development/apollo-development-guide.md
+++ b/docs/zh/development/apollo-development-guide.md
@@ -62,12 +62,12 @@ Apollo本地开发需要以下组件：
 
 ![ConfigAdminApplication-Eureka](https://raw.githubusercontent.com/ctripcorp/apollo/master/doc/images/local-development/ConfigAdminApplication-Eureka.png)
 
-> 注：除了Eureka确认服务注册状态外，还可以通过请求健康检查接口确认服务健康状况：
+> 注：除了通过Eureka确认服务状态外，还可以通过请求健康检查接口确认服务健康状况：
 >
 > AdminService： [http://localhost:8090/health](http://localhost:8090/health)
 > ConfigService： [http://localhost:8080/health](http://localhost:8080/health)
 >
-> 如果服务健康，返回内容中的status.code应当为`UP`：
+> 如果服务健康，接口返回内容中的status.code应当为`UP`：
 >
 >     {
 >       "status": {

--- a/docs/zh/development/apollo-development-guide.md
+++ b/docs/zh/development/apollo-development-guide.md
@@ -62,7 +62,7 @@ Apollo本地开发需要以下组件：
 
 ![ConfigAdminApplication-Eureka](https://raw.githubusercontent.com/ctripcorp/apollo/master/doc/images/local-development/ConfigAdminApplication-Eureka.png)
 
-> 注：还可以通过健康检查接口确认服务健康状况：
+> 注：除了Eureka确认服务注册状态外，还可以通过请求健康检查接口确认服务健康状况：
 >
 > AdminService： [http://localhost:8090/health](http://localhost:8090/health)
 > ConfigService： [http://localhost:8080/health](http://localhost:8080/health)


### PR DESCRIPTION
## What's the purpose of this PR

修复 config-service 开启缓存后对客户端 app.id 配置大小写敏感的问题

## Which issue(s) this PR fixes:
Fixes #3529

## Brief changelog

1. 在 ConfigServiceWithCache 中定义 LoadingCache 的装饰者类，负责处理key的大小写问题
2. ConfigServiceWithCache优先取大小写敏感的结果（兼容目前的逻辑）
3. 若区分大小的key获取的值为空，则key转为小写获取对应的值

Follow this checklist to help us incorporate your contribution quickly and easily:

- [X] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit tests to verify the code.
- [X] Run `mvn clean test` to make sure this pull request doesn't break anything.
