### PR TITLE
feat:namespace & release & rollback scrollbar

### DIFF
--- a/apollo-portal/src/main/resources/static/styles/common-style.css
+++ b/apollo-portal/src/main/resources/static/styles/common-style.css
@@ -532,7 +532,7 @@ table th {
     padding: 5px 0 5px 50px;
 }
 
-/*搜索框*/
+/*搜索框
 ::-webkit-scrollbar {
     width: 0;
     height: 0;
@@ -546,6 +546,12 @@ table th {
 
 ::-webkit-scrollbar-thumb:vertical:hover {
     background: rgba(255, 255, 255, 0);
+}*/
+
+.namespace-view-table-scrollbar {
+    max-height: 600px;
+    width: 100%;
+    overflow-y: scroll;
 }
 
 .app-list {

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -243,7 +243,7 @@
         <!--namespace body-->
         <section ng-show="!namespace.isConfigHidden">
             <!--table view-->
-            <div class="namespace-view-table" ng-show="namespace.viewType == 'table'">
+            <div class="namespace-view-table namespace-view-table-scrollbar" ng-show="namespace.viewType == 'table'">
 
                 <div class="J_namespace-release-tip well well-sm no-radius text-center"
                     ng-show="namespace.isLatestReleaseLoaded && !namespace.isLinkedNamespace && !namespace.latestRelease">

--- a/apollo-portal/src/main/resources/static/views/component/release-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/release-modal.html
@@ -36,7 +36,7 @@
 
             </div>
 
-            <div class="release modal-body">
+            <div class="release modal-body namespace-view-table-scrollbar">
 
                 <div class="form-group">
                     <div class="col-sm-2 control-label" ng-if="!toReleaseNamespace.isPropertiesFormat">

--- a/apollo-portal/src/main/resources/static/views/component/rollback-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/rollback-modal.html
@@ -26,7 +26,7 @@
                     <span style="font-size: 18px;" ng-bind="toRollbackNamespace.secondRelease.name"></span>
                 </div>
             </div>
-            <div class="modal-body">
+            <div class="modal-body namespace-view-table-scrollbar">
                 <div ng-if="!isRollbackTo" class="alert alert-warning" role="alert">
                     {{'Component.Rollback.Tips' | translate }}
                     <a target="_blank"


### PR DESCRIPTION
## What's the purpose of this PR

When we use the Apollo configuration, because there are too many configurations, the browser does not appear the drop-down box scroll bar when searching for the configuration. We can only scroll up and down through the mouse scroll axis.

Without a scroll bar, I don't know where the current location is. When I want to select other namespace configurations, I have to keep scrolling the mouse.

This is extremely inconvenient.

So,It is desirable to display a scroll bar and fix the height of each namespace configuration, which greatly facilitates the selection of namespace configuration and the location of the current space configuration.

## Which issue(s) this PR fixes:
Fixes #3928

## Brief changelog

remove ::-webkit-scrollbar css and fixed div height

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
