### PR TITLE
fix NullPointerException hazard in StringUtils.join(..) method

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/StringUtils.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/StringUtils.java
@@ -344,44 +344,4 @@ public class StringUtils {
     String format(T obj);
   }
 
-  public static <T> String join(Collection<T> collection, String separator) {
-    return join(collection, separator, new StringFormatter<T>() {
-      @Override
-      public String format(T obj) {
-        return obj.toString();
-      }
-    });
-  }
-
-  public static <T> String join(Collection<T> collection, String separator,
-                                StringFormatter<T> formatter) {
-    Iterator<T> iterator = collection.iterator();
-    // handle null, zero and one elements before building a buffer
-    if (iterator == null) {
-      return null;
-    }
-    if (!iterator.hasNext()) {
-      return EMPTY;
-    }
-    T first = iterator.next();
-    if (!iterator.hasNext()) {
-      return first == null ? "" : formatter.format(first);
-    }
-
-    // two or more elements
-    StringBuilder buf = new StringBuilder(256); // Java default is 16, probably too small
-    if (first != null) {
-      buf.append(formatter.format(first));
-    }
-
-    while (iterator.hasNext()) {
-      buf.append(separator);
-      T obj = iterator.next();
-      if (obj != null) {
-        buf.append(formatter.format(obj));
-      }
-    }
-
-    return buf.toString();
-  }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/StringUtilsTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/StringUtilsTest.java
@@ -69,19 +69,6 @@ public class StringUtilsTest {
   }
 
   @Test
-  public void testJoin() {
-    Assert.assertEquals("", StringUtils.join(new ArrayList(), "1a 2b 3c"));
-
-    ArrayList collection = new ArrayList();
-    collection.add(null);
-    Assert.assertEquals("", StringUtils.join(collection, "1a 2b 3c"));
-
-    collection = new ArrayList();
-    collection.add(-2_147_483_648);
-    Assert.assertEquals("-2147483648", StringUtils.join(collection, "1a 2b 3c"));
-  }
-
-  @Test
   public void testStartsWithIgnoreCase() {
     Assert.assertFalse(StringUtils.startsWithIgnoreCase("A1B2C3", "BAZ"));
     Assert.assertFalse(StringUtils.startsWithIgnoreCase(",", "BAZ"));


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

## What's the purpose of this PR

When the `collection` is null, a `NullPointerException` is thrown here. Otherwise `iterator == null` is always false.

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

fix NullPointerException hazard in StringUtils.join(..) method.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
