### PR TITLE
Make the constructor of AbstractApolloHttpException implementation class to support string template

### DIFF
--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/InstanceConfigController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/InstanceConfigController.java
@@ -123,7 +123,7 @@ public class InstanceConfigController {
     List<Release> releases = releaseService.findByReleaseIds(releaseIdSet);
 
     if (CollectionUtils.isEmpty(releases)) {
-      throw new NotFoundException(String.format("releases not found for %s", releaseIds));
+      throw new NotFoundException("releases not found for %s", releaseIds);
     }
 
     Set<String> releaseKeys = releases.stream().map(Release::getReleaseKey).collect(Collectors

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
@@ -197,15 +197,14 @@ public class ItemController {
 
   @GetMapping("/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/{key:.+}")
   public ItemDTO get(@PathVariable("appId") String appId,
-                     @PathVariable("clusterName") String clusterName,
-                     @PathVariable("namespaceName") String namespaceName, @PathVariable("key") String key) {
+      @PathVariable("clusterName") String clusterName,
+      @PathVariable("namespaceName") String namespaceName, @PathVariable("key") String key) {
     Item item = itemService.findOne(appId, clusterName, namespaceName, key);
     if (item == null) {
-      throw new NotFoundException(
-          String.format("item not found for %s %s %s %s", appId, clusterName, namespaceName, key));
+      throw new NotFoundException("item not found for %s %s %s %s", appId, clusterName,
+          namespaceName, key);
     }
     return BeanUtils.transform(ItemDTO.class, item);
   }
-
 
 }

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceBranchController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceBranchController.java
@@ -147,9 +147,9 @@ public class NamespaceBranchController {
     //2. check child namespace
     Namespace childNamespace = namespaceService.findOne(appId, branchName, namespaceName);
     if (childNamespace == null) {
-      throw new BadRequestException(String.format("Namespace's branch not exist. AppId = %s, ClusterName = %s, "
-                                                  + "NamespaceName = %s, BranchName = %s",
-                                                  appId, clusterName, namespaceName, branchName));
+      throw new BadRequestException(
+          "Namespace's branch not exist. AppId = %s, ClusterName = %s, NamespaceName = %s, BranchName = %s",
+          appId, clusterName, namespaceName, branchName);
     }
 
   }
@@ -157,8 +157,9 @@ public class NamespaceBranchController {
   private void checkNamespace(String appId, String clusterName, String namespaceName) {
     Namespace parentNamespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (parentNamespace == null) {
-      throw new BadRequestException(String.format("Namespace not exist. AppId = %s, ClusterName = %s, NamespaceName = %s", appId,
-                                                  clusterName, namespaceName));
+      throw new BadRequestException(
+          "Namespace not exist. AppId = %s, ClusterName = %s, NamespaceName = %s", appId,
+          clusterName, namespaceName);
     }
   }
 

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceController.java
@@ -68,8 +68,8 @@ public class NamespaceController {
                      @PathVariable("namespaceName") String namespaceName, @RequestParam String operator) {
     Namespace entity = namespaceService.findOne(appId, clusterName, namespaceName);
     if (entity == null) {
-        throw new NotFoundException(
-                String.format("namespace not found for %s %s %s", appId, clusterName, namespaceName));
+      throw new NotFoundException("namespace not found for %s %s %s", appId, clusterName,
+          namespaceName);
     }
 
     namespaceService.deleteNamespace(entity, operator);
@@ -86,7 +86,7 @@ public class NamespaceController {
   public NamespaceDTO get(@PathVariable("namespaceId") Long namespaceId) {
     Namespace namespace = namespaceService.findOne(namespaceId);
     if (namespace == null) {
-        throw new NotFoundException(String.format("namespace not found for %s", namespaceId));
+        throw new NotFoundException("namespace not found for %s", namespaceId);
     }
     return BeanUtils.transform(NamespaceDTO.class, namespace);
   }
@@ -109,8 +109,8 @@ public class NamespaceController {
                           @PathVariable("namespaceName") String namespaceName) {
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace == null) {
-        throw new NotFoundException(
-                String.format("namespace not found for %s %s %s", appId, clusterName, namespaceName));
+      throw new NotFoundException("namespace not found for %s %s %s", appId, clusterName,
+          namespaceName);
     }
     return BeanUtils.transform(NamespaceDTO.class, namespace);
   }
@@ -122,7 +122,7 @@ public class NamespaceController {
     Namespace namespace = namespaceService.findPublicNamespaceForAssociatedNamespace(clusterName, namespaceName);
 
     if (namespace == null) {
-      throw new NotFoundException(String.format("public namespace not found. namespace:%s", namespaceName));
+      throw new NotFoundException("public namespace not found. namespace:%s", namespaceName);
     }
 
     return BeanUtils.transform(NamespaceDTO.class, namespace);

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseController.java
@@ -72,7 +72,7 @@ public class ReleaseController {
   public ReleaseDTO get(@PathVariable("releaseId") long releaseId) {
     Release release = releaseService.findOne(releaseId);
     if (release == null) {
-      throw new NotFoundException(String.format("release not found for %s", releaseId));
+      throw new NotFoundException("release not found for %s", releaseId);
     }
     return BeanUtils.transform(ReleaseDTO.class, release);
   }
@@ -125,8 +125,8 @@ public class ReleaseController {
                             @RequestParam(name = "isEmergencyPublish", defaultValue = "false") boolean isEmergencyPublish) {
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace == null) {
-      throw new NotFoundException(String.format("Could not find namespace for %s %s %s", appId,
-                                                clusterName, namespaceName));
+      throw new NotFoundException("Could not find namespace for %s %s %s", appId, clusterName,
+          namespaceName);
     }
     Release release = releaseService.publish(namespace, releaseName, releaseComment, operator, isEmergencyPublish);
 
@@ -162,8 +162,8 @@ public class ReleaseController {
                                      @RequestBody ItemChangeSets changeSets) {
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace == null) {
-      throw new NotFoundException(String.format("Could not find namespace for %s %s %s", appId,
-                                                clusterName, namespaceName));
+      throw new NotFoundException("Could not find namespace for %s %s %s", appId, clusterName,
+          namespaceName);
     }
 
     Release release = releaseService.mergeBranchChangeSetsAndRelease(namespace, branchName, releaseName,
@@ -214,11 +214,12 @@ public class ReleaseController {
                             @RequestParam(name = "grayDelKeys") Set<String> grayDelKeys){
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace == null) {
-      throw new NotFoundException(String.format("Could not find namespace for %s %s %s", appId,
-              clusterName, namespaceName));
+      throw new NotFoundException("Could not find namespace for %s %s %s", appId, clusterName, 
+          namespaceName);
     }
 
-    Release release = releaseService.grayDeletionPublish(namespace, releaseName, releaseComment, operator, isEmergencyPublish, grayDelKeys);
+    Release release = releaseService.grayDeletionPublish(namespace, releaseName, releaseComment, 
+        operator, isEmergencyPublish, grayDelKeys);
 
     //send release message
     Namespace parentNamespace = namespaceService.findParentNamespace(namespace);

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseHistoryController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseHistoryController.java
@@ -43,7 +43,7 @@ public class ReleaseHistoryController {
 
   private static final Gson GSON = new Gson();
 
-  private Type configurationTypeReference = new TypeToken<Map<String, Object>>() {
+  private final Type configurationTypeReference = new TypeToken<Map<String, Object>>() {
   }.getType();
 
   private final ReleaseHistoryService releaseHistoryService;

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/AbstractApolloHttpException.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/AbstractApolloHttpException.java
@@ -16,6 +16,7 @@
  */
 package com.ctrip.framework.apollo.common.exception;
 
+import com.google.common.base.Strings;
 import org.springframework.http.HttpStatus;
 
 public abstract class AbstractApolloHttpException extends RuntimeException{
@@ -24,8 +25,15 @@ public abstract class AbstractApolloHttpException extends RuntimeException{
   
   protected HttpStatus httpStatus;
 
-  public AbstractApolloHttpException(String msg){
-    super(msg);
+  /**
+   * When args not empty, use {@link com.google.common.base.Strings#lenientFormat(String, Object...)}
+   * to replace %s in msgtpl with args to set the error message. Otherwise, use msgtpl 
+   * to set the error message. e.g.: 
+   * <pre>{@code new NotFoundException("... %s ... %s ... %s", "str", 0, 0.1)}</pre>
+   * If the number of '%s' in `msgtpl` does not match args length, the '%s' string will be printed.
+   */
+  public AbstractApolloHttpException(String msgtpl, Object... args){
+    super(args == null || args.length == 0 ? msgtpl : Strings.lenientFormat(msgtpl, args));
   }
   
   public AbstractApolloHttpException(String msg, Exception e){

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/BadRequestException.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/BadRequestException.java
@@ -21,9 +21,12 @@ import org.springframework.http.HttpStatus;
 
 public class BadRequestException extends AbstractApolloHttpException {
 
-
-  public BadRequestException(String str) {
-    super(str);
+  /**
+   * @see AbstractApolloHttpException#AbstractApolloHttpException(String, Object...) 
+   */
+  public BadRequestException(String msgtpl, Object... args) {
+    super(msgtpl, args);
     setHttpStatus(HttpStatus.BAD_REQUEST);
   }
+
 }

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/ServiceException.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/exception/ServiceException.java
@@ -20,8 +20,11 @@ import org.springframework.http.HttpStatus;
 
 public class ServiceException extends AbstractApolloHttpException {
 
-  public ServiceException(String str) {
-    super(str);
+  /**
+   * @see AbstractApolloHttpException#AbstractApolloHttpException(String, Object...)
+   */
+  public ServiceException(String msgtpl, Object... args) {
+    super(msgtpl, args);
     setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 

--- a/apollo-common/src/test/java/com/ctrip/framework/apollo/common/exception/NotFoundExceptionTest.java
+++ b/apollo-common/src/test/java/com/ctrip/framework/apollo/common/exception/NotFoundExceptionTest.java
@@ -16,15 +16,23 @@
  */
 package com.ctrip.framework.apollo.common.exception;
 
-import org.springframework.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class NotFoundException extends AbstractApolloHttpException {
+public class NotFoundExceptionTest {
 
-  /**
-   * @see AbstractApolloHttpException#AbstractApolloHttpException(String, Object...)
-   */
-  public NotFoundException(String msgtpl, Object... args) {
-    super(msgtpl, args);
-    setHttpStatus(HttpStatus.NOT_FOUND);
+  @Test
+  public void testConstructor() {
+    String appId = "app-1001";
+    String clusterName = "test";
+    String namespaceName = "application";
+    String key = "test.key";
+    NotFoundException e1, e2;
+    e1 = new NotFoundException("item not found for %s %s %s %s", appId,
+        clusterName, namespaceName, key);
+    e2 = new NotFoundException(
+        String.format("item not found for %s %s %s %s", appId, clusterName, namespaceName, key));
+    Assert.assertEquals(e1.getMessage(), e2.getMessage());
   }
+
 }


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

## What's the purpose of this PR

Make the constructor of `AbstractApolloHttpException` implementation class to support string template. The method `com.google.common.base.Strings.lenientFormat(..)` performs better than `String.format(..)`.

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

Make the constructor of AbstractApolloHttpException implementation class to support string template

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
