### PR TITLE
Simplified the `Env` class that links to `Env` enum

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/environment/Env.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/environment/Env.java
@@ -18,213 +18,233 @@ package com.ctrip.framework.apollo.portal.environment;
 
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.logging.log4j.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
+ * This class provides functionalities to manage and hold all environments of the portal.
+ * By default all the Env from {@link com.ctrip.framework.apollo.core.enums.Env} are included.
+ *
  * @author wxq
+ * @author Diego Krupitza(info@diegokrupitza.com)
  */
 public class Env {
-    
-    private static final Logger logger = LoggerFactory.getLogger(Env.class);
 
-    // name of environment, cannot be null
-    private final String name;
+  private static final Logger logger = LoggerFactory.getLogger(Env.class);
+  // use to cache Env
+  private static final Map<String, Env> STRING_ENV_MAP = new ConcurrentHashMap<>();
+  // default environments
+  public static final Env LOCAL = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.LOCAL.name());
+  public static final Env DEV = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.DEV.name());
+  public static final Env FWS = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.FWS.name());
+  public static final Env FAT = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.FAT.name());
+  public static final Env UAT = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.UAT.name());
+  public static final Env LPT = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.LPT.name());
+  public static final Env PRO = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.PRO.name());
+  public static final Env TOOLS = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.TOOLS.name());
+  public static final Env UNKNOWN = addEnvironment(
+      com.ctrip.framework.apollo.core.enums.Env.UNKNOWN.name());
+  // name of environment, cannot be null
+  private final String name;
 
-    // use to cache Env
-    private static final Map<String, Env> STRING_ENV_MAP = new ConcurrentHashMap<>();
+  /**
+   * Cannot create by other
+   *
+   * @param name
+   */
+  private Env(String name) {
+    this.name = name;
+  }
 
-    // default environments
-    public static final Env LOCAL = addEnvironment("LOCAL");
-    public static final Env DEV = addEnvironment("DEV");
-    public static final Env FWS = addEnvironment("FWS");
-    public static final Env FAT = addEnvironment("FAT");
-    public static final Env UAT = addEnvironment("UAT");
-    public static final Env LPT = addEnvironment("LPT");
-    public static final Env PRO = addEnvironment("PRO");
-    public static final Env TOOLS = addEnvironment("TOOLS");
-    public static final Env UNKNOWN = addEnvironment("UNKNOWN");
+  /**
+   * add some change to environment name trim and to upper
+   *
+   * @param envName
+   * @return
+   */
+  private static String getWellFormName(String envName) {
+    if (Strings.isBlank(envName)) {
+      return "";
+    }
+    return envName.trim().toUpperCase();
+  }
 
-    /**
-     * Cannot create by other
-     * @param name
-     */
-    private Env(String name) {
-        this.name = name;
+  /**
+   * logic same as
+   *
+   * @param envName the name we want to transform
+   * @return the env object matching the <code>envName</code>
+   * @see com.ctrip.framework.apollo.core.enums.EnvUtils transformEnv
+   */
+  public static Env transformEnv(String envName) {
+    if (StringUtils.isBlank(envName)) {
+
+      // cannot be found or blank name
+      return Env.UNKNOWN;
     }
 
-    /**
-     * add some change to environment name
-     * trim and to upper
-     * @param environmentName
-     * @return
-     */
-    private static String getWellFormName(String environmentName) {
-        return environmentName.trim().toUpperCase();
+    // special case for production in case of typo
+    if (envName.equalsIgnoreCase("PROD")) {
+      return Env.PRO;
     }
 
-    /**
-     * logic same as
-     * @see com.ctrip.framework.apollo.core.enums.EnvUtils transformEnv
-     * @param envName
-     * @return
-     */
-    public static Env transformEnv(String envName) {
-        if(Env.exists(envName)) {
-            return Env.valueOf(envName);
-        }
-        if (StringUtils.isBlank(envName)) {
-            return Env.UNKNOWN;
-        }
-        switch (envName.trim().toUpperCase()) {
-            case "LPT":
-                return Env.LPT;
-            case "FAT":
-            case "FWS":
-                return Env.FAT;
-            case "UAT":
-                return Env.UAT;
-            case "PRO":
-            case "PROD": //just in case
-                return Env.PRO;
-            case "DEV":
-                return Env.DEV;
-            case "LOCAL":
-                return Env.LOCAL;
-            case "TOOLS":
-                return Env.TOOLS;
-            default:
-                return Env.UNKNOWN;
-        }
-    }
-    
-    /**
-     * a environment name exist or not
-     * @param name
-     * @return
-     */
-    public static boolean exists(String name) {
-        name = getWellFormName(name);
-        return STRING_ENV_MAP.containsKey(name);
+    // special case that FAT & FWS should map to FAT
+    if (envName.equalsIgnoreCase("FWS")) {
+      return Env.FAT;
     }
 
-    /**
-     * add an environment
-     * @param name
-     * @return
-     */
-    public static Env addEnvironment(String name) {
-        if (StringUtils.isBlank(name)) {
-            throw new RuntimeException("Cannot add a blank environment: " + "[" + name + "]");
-        }
-
-        name = getWellFormName(name);
-        if(STRING_ENV_MAP.containsKey(name)) {
-            // has been existed
-            logger.debug("{} already exists.", name);
-        } else {
-            // not existed
-            STRING_ENV_MAP.put(name, new Env(name));
-        }
-        return STRING_ENV_MAP.get(name);
+    if (!Env.exists(envName)) {
+      return Env.UNKNOWN;
     }
 
-    /**
-     * replace valueOf in enum
-     * But what would happened if environment not exist?
-     *
-     * @param name
-     * @throws IllegalArgumentException if this existed environment has no Env with the specified name
-     * @return
-     */
-    public static Env valueOf(String name) {
-        name = getWellFormName(name);
-        if(exists(name)) {
-            return STRING_ENV_MAP.get(name);
-        } else {
-            throw new IllegalArgumentException(name + " not exist");
-        }
+    return Env.valueOf(envName);
+  }
+
+  /**
+   * a environment name exist or not
+   *
+   * @param name the name we want to check if it exists
+   * @return does the env name exists or not
+   */
+  public static boolean exists(String name) {
+    name = getWellFormName(name);
+    return STRING_ENV_MAP.containsKey(name);
+  }
+
+  /**
+   * add an environment
+   *
+   * @param name the name of the environment to add
+   * @return the newly created environment
+   */
+  public static Env addEnvironment(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new RuntimeException("Cannot add a blank environment: " + "[" + name + "]");
     }
 
-    /**
-     * Please use {@code Env.valueOf} instead this method
-     * @param env
-     * @return
-     */
-    @Deprecated
-    public static Env fromString(String env) {
-        Env environment = transformEnv(env);
-        Preconditions.checkArgument(environment != UNKNOWN, String.format("Env %s is invalid", env));
-        return environment;
+    name = getWellFormName(name);
+    if (STRING_ENV_MAP.containsKey(name)) {
+      // has been existed
+      logger.debug("{} already exists.", name);
+    } else {
+      // not existed
+      STRING_ENV_MAP.put(name, new Env(name));
     }
+    return STRING_ENV_MAP.get(name);
+  }
 
-    /**
-     * Not just name in Env,
-     * the address of Env must be same,
-     * or it will throw {@code RuntimeException}
-     * @param o
-     * @throws RuntimeException When same name but different address
-     * @return
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Env env = (Env) o;
-        if(getName().equals(env.getName())) {
-            throw new RuntimeException(getName() + " is same environment name, but their Env not same");
-        } else {
-            return false;
-        }
+  /**
+   * replace valueOf in enum But what would happened if environment not exist?
+   *
+   * @param name
+   * @return
+   * @throws IllegalArgumentException if this existed environment has no Env with the specified
+   *                                  name
+   */
+  public static Env valueOf(String name) {
+    name = getWellFormName(name);
+    if (exists(name)) {
+      return STRING_ENV_MAP.get(name);
+    } else {
+      throw new IllegalArgumentException(name + " not exist");
     }
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(getName());
-    }
+  /**
+   * Please use {@code Env.valueOf} instead this method
+   *
+   * @param env
+   * @return
+   */
+  @Deprecated
+  public static Env fromString(String env) {
+    Env environment = transformEnv(env);
+    Preconditions.checkArgument(environment != UNKNOWN, String.format("Env %s is invalid", env));
+    return environment;
+  }
 
-    /**
-     * a Env convert to string, ie its name.
-     * @return
-     */
-    @Override
-    public String toString() {
-        return name;
+  /**
+   * conversion key from {@link String} to {@link Env}
+   *
+   * @param metaServerAddresses key is environment, value is environment's meta server address
+   * @return relationship between {@link Env} and meta server address
+   */
+  static Map<Env, String> transformToEnvMap(Map<String, String> metaServerAddresses) {
+    // add to domain
+    Map<Env, String> map = new ConcurrentHashMap<>();
+    for (Map.Entry<String, String> entry : metaServerAddresses.entrySet()) {
+      // add new environment
+      Env env = Env.addEnvironment(entry.getKey());
+      // get meta server address value
+      String value = entry.getValue();
+      // put pair (Env, meta server address)
+      map.put(env, value);
     }
+    return map;
+  }
 
-    /**
-     * Backward compatibility with enum's name method
-     * @Deprecated please use {@link #getName()} instead of
-     */
-    @Deprecated
-    public String name() {
-        return name;
+  /**
+   * Not just name in Env, the address of Env must be same, or it will throw {@code
+   * RuntimeException}
+   *
+   * @param o
+   * @return
+   * @throws RuntimeException When same name but different address
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Env env = (Env) o;
+    if (getName().equals(env.getName())) {
+      throw new RuntimeException(getName() + " is same environment name, but their Env not same");
+    } else {
+      return false;
+    }
+  }
 
-    public String getName() {
-        return name;
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName());
+  }
 
-    /**
-     * conversion key from {@link String} to {@link Env}
-     * @param metaServerAddresses key is environment, value is environment's meta server address
-     * @return relationship between {@link Env} and meta server address
-     */
-    static Map<Env, String> transformToEnvMap(Map<String, String> metaServerAddresses) {
-        // add to domain
-        Map<Env, String> map = new ConcurrentHashMap<>();
-        for(Map.Entry<String, String> entry : metaServerAddresses.entrySet()) {
-            // add new environment
-            Env env = Env.addEnvironment(entry.getKey());
-            // get meta server address value
-            String value = entry.getValue();
-            // put pair (Env, meta server address)
-            map.put(env, value);
-        }
-        return map;
-    }
+  /**
+   * a Env convert to string, ie its name.
+   *
+   * @return
+   */
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  /**
+   * Backward compatibility with enum's name method
+   *
+   * @Deprecated please use {@link #getName()} instead of
+   */
+  @Deprecated
+  public String name() {
+    return name;
+  }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/environment/EnvTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/environment/EnvTest.java
@@ -54,7 +54,7 @@ public class EnvTest {
         assertEquals(Env.DEV, Env.valueOf("dEv"));
         String name = "someEEEE";
         Env.addEnvironment(name);
-        assertFalse(Env.valueOf(name).equals(Env.DEV));
+        assertNotEquals(Env.valueOf(name), Env.DEV);
     }
 
     @Test(expected = RuntimeException.class)
@@ -75,10 +75,10 @@ public class EnvTest {
 
     @Test
     public void testEqualWithoutException() {
-        assertTrue(Env.DEV.equals(Env.DEV));
-        assertTrue(Env.DEV.equals(Env.valueOf("dEV")));
-        assertFalse(Env.PRO.equals(Env.DEV));
-        assertFalse(Env.DEV.equals(Env.valueOf("uaT")));
+        assertEquals(Env.DEV, Env.DEV);
+        assertEquals(Env.DEV, Env.valueOf("dEV"));
+        assertNotEquals(Env.PRO, Env.DEV);
+        assertNotEquals(Env.DEV, Env.valueOf("uaT"));
     }
 
     @Test
@@ -96,5 +96,72 @@ public class EnvTest {
         String name = "getName";
         Env.addEnvironment(name);
         assertEquals(name.trim().toUpperCase(), Env.valueOf(name).toString());
+    }
+
+    @Test
+    public void transformEnvBlankTest() {
+        assertEquals(Env.UNKNOWN,Env.transformEnv(""));
+        assertEquals(Env.UNKNOWN,Env.transformEnv(null));
+        assertEquals(Env.UNKNOWN,Env.transformEnv("   "));
+    }
+
+    @Test
+    public void transformEnvSpecialCaseTest() {
+        // Prod/Pro
+        assertEquals(Env.PRO,Env.transformEnv("prod"));
+        assertEquals(Env.PRO,Env.transformEnv("PROD"));
+
+        //FAT/FWS
+        assertEquals(Env.FAT,Env.transformEnv("FWS"));
+        assertEquals(Env.FAT,Env.transformEnv("fws"));
+    }
+
+    @Test
+    public void transformEnvNotExistTest() {
+        assertEquals(Env.UNKNOWN,Env.transformEnv("notexisting"));
+        assertEquals(Env.LOCAL,Env.transformEnv("LOCAL"));
+    }
+
+    @Test
+    public void transformEnvValidTest() {
+        assertEquals(Env.UNKNOWN,Env.transformEnv("UNKNOWN"));
+        assertEquals(Env.LOCAL,Env.transformEnv("LOCAL"));
+        assertEquals(Env.FAT,Env.transformEnv("FAT"));
+        assertEquals(Env.FAT,Env.transformEnv("FWS"));
+        assertEquals(Env.PRO,Env.transformEnv("PRO"));
+        assertEquals(Env.PRO,Env.transformEnv("PROD"));
+        assertEquals(Env.DEV,Env.transformEnv("DEV"));
+        assertEquals(Env.LPT,Env.transformEnv("LPT"));
+        assertEquals(Env.TOOLS,Env.transformEnv("TOOLS"));
+        assertEquals(Env.UAT,Env.transformEnv("UAT"));
+
+        String testEnvName = "testEnv";
+
+        Env.addEnvironment(testEnvName);
+        Env expected = Env.valueOf(testEnvName);
+
+        assertEquals(expected,Env.transformEnv(testEnvName));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void addEnvironmentBlankStringTest() {
+        Env.addEnvironment("");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void addEnvironmentNullStringTest() {
+        Env.addEnvironment(null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void addEnvironmentSpacesStringTest() {
+        Env.addEnvironment("    ");
+    }
+
+    @Test
+    public void existsForBlankNameTest() {
+        assertFalse(Env.exists(""));
+        assertFalse(Env.exists("   "));
+        assertFalse(Env.exists(null));
     }
 }


### PR DESCRIPTION
Since the Env class in portal/environment is a class representation of
the enum Env in the apollo core project I linked them better together.
This means if important changes happen in the enum it is automatically
reflected to the class representation.

Additionall I simplified the `transformEnv` method inside the Env class.
The switch will be never reached since all those values are already
matched in the `Env.valueOf(envName)`.

Further more I added more javadoc and tests to boost up the coverage

## What's the purpose of this PR

Make the link between the class representation and the enum stronger, simplify the code and boost the test covergae

## Which issue(s) this PR fixes:
None

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [X] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
