### PR TITLE
Fix flaky test testGetPropertyNames.

### DIFF
--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourceTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourceTest.java
@@ -66,7 +66,7 @@ public class ConfigPropertySourceTest {
 
     verify(someConfig, times(1)).getPropertyNames();
 
-    assertArrayEquals(somePropertyNames.toArray(), result);
+    assertEquals(somePropertyNames, Sets.newHashSet(result));
   }
 
   @Test


### PR DESCRIPTION
Fix the flaky test testGetPropertyNames due to the non-deterministic iteration order of HashSet.

This flaky test is found by using Nondex, a tool used to find flaky tests in Java projects. The original assertion on Line#69 may fail because the iteration order of HashSet is non-deterministic, and the elements in the array converted from ```somePropertyNames``` may not be the same as the array ```result```. By converting ```result``` to a HashSet, the new assertion ```assertEquals``` will only check the elements are equal in both sets so that the test will always pass.