### PR TITLE
Fix flaky test testAssembleQueryConfigUrl.

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/dto/ApolloNotificationMessages.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/dto/ApolloNotificationMessages.java
@@ -28,7 +28,7 @@ public class ApolloNotificationMessages {
   private Map<String, Long> details;
 
   public ApolloNotificationMessages() {
-    this(Maps.<String, Long>newHashMap());
+    this(Maps.<String, Long>newTreeMap());
   }
 
   private ApolloNotificationMessages(Map<String, Long> details) {


### PR DESCRIPTION
Fix flaky test testAssembleQueryConfigUrl due to the non-deterministic iteration order of HashMap.

This flaky test is found by using Nondex, a tool used to find flaky tests in Java projects. The assertion on Line#361 in ```RemoteConfigRepositoryTest.java``` may fail because the order of two entries, ```someKey``` and ```anotherKey```, is non-deterministic, so the converted string of ```queryConfigUrl``` is non-deterministic, resulting in the flaky test. To fix this test, the data structure of the ```details``` field of ```ApolloNotificationMessages``` is changed from ```HashMap``` to ```TreeMap``` so that the entries of the map is sorted. As a result, the iteration order is deterministic and the test will always pass.