### PR TITLE
Catch LinkageError for ClassLoaderUtil.isClassPresent in case class is present but is failed to load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Apollo 2.0.0
 * [Support Java 17](https://github.com/apolloconfig/apollo/pull/4060)
 * [Optimize top navbar style](https://github.com/apolloconfig/apollo/pull/4073)
 * [Support export/import configs by apollo env](https://github.com/apolloconfig/apollo/pull/3947)
+* [Catch LinkageError for ClassLoaderUtil.isClassPresent in case class is present but is failed to load](https://github.com/apolloconfig/apollo/pull/4097)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/ClassLoaderUtil.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/ClassLoaderUtil.java
@@ -61,7 +61,6 @@ public class ClassLoaderUtil {
     return loader;
   }
 
-
   public static String getClassPath() {
     return classPath;
   }
@@ -71,6 +70,11 @@ public class ClassLoaderUtil {
       Class.forName(className);
       return true;
     } catch (ClassNotFoundException ex) {
+      // ignore expected exception
+      return false;
+    } catch (LinkageError ex) {
+      // unexpected error, need to let the user know the actual error
+      logger.error("Failed to load class: {}", className, ex);
       return false;
     }
   }

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ClassLoaderUtilTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ClassLoaderUtilTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.core.utils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class ClassLoaderUtilTest {
+  private static boolean shouldFailInInitialization = false;
+  @Test
+  public void testGetClassLoader() {
+    assertNotNull(ClassLoaderUtil.getLoader());
+  }
+
+  @Test
+  public void testIsClassPresent() {
+    assertTrue(ClassLoaderUtil.isClassPresent("java.lang.String"));
+  }
+
+  @Test
+  public void testIsClassPresentWithClassNotFound() {
+    assertFalse(ClassLoaderUtil.isClassPresent("java.lang.StringNotFound"));
+  }
+
+  @Test
+  public void testIsClassPresentWithLinkageError() {
+    shouldFailInInitialization = true;
+    assertFalse(ClassLoaderUtil.isClassPresent(ClassWithInitializationError.class.getName()));
+  }
+
+  public static class ClassWithInitializationError {
+    static {
+      if (ClassLoaderUtilTest.shouldFailInInitialization) {
+        throw new RuntimeException("Some initialization exception");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What's the purpose of this PR

Catch LinkageError for ClassLoaderUtil.isClassPresent in case class is present but is failed to load

## Which issue(s) this PR fixes:
Fixes #4086

## Brief changelog

* Catch LinkageError and log error for ClassLoaderUtil.isClassPresent

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
