### PR TITLE
chore: change 'ctripcorp' to 'apolloconfig' in .yaml files

### DIFF
--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -52,8 +52,8 @@ entries:
     created: "2021-06-02T23:05:43.379448+08:00"
     description: A Helm chart for Apollo Portal
     digest: 5586b2597ebe098a26c94273855461891041241628d85dc13e05ce661ff5e7a2
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -68,8 +68,8 @@ entries:
     created: "2021-06-02T23:05:43.378586+08:00"
     description: A Helm chart for Apollo Portal
     digest: 8bac1b48361e2717d7d4ee669a85a14ee22ada96f249300d90ee563def63baea
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -84,8 +84,8 @@ entries:
     created: "2021-06-02T23:05:43.377736+08:00"
     description: A Helm chart for Apollo Portal
     digest: 8a55c5f3ddd76b9768067fe6eecfb34b588084557c11882e263abb2af7dfc173
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -100,8 +100,8 @@ entries:
     created: "2021-06-02T23:05:43.376846+08:00"
     description: A Helm chart for Apollo Portal
     digest: 1db8b2435e0471ef55c63c47b970e4ae059800f88ed4ac4f1ca6cd27fe502722
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -116,8 +116,8 @@ entries:
     created: "2021-06-02T23:05:43.375959+08:00"
     description: A Helm chart for Apollo Portal
     digest: 7c1b4efa13d4cc54a714b3ec836f609a8f97286c465789f6d807d1227cfc5b74
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -132,8 +132,8 @@ entries:
     created: "2021-06-02T23:05:43.37481+08:00"
     description: A Helm chart for Apollo Portal
     digest: b838e4478f0c031093691defeffb5805d51189989db0eb9caaa2dc67905c8391
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -149,8 +149,8 @@ entries:
     created: "2021-09-09T09:24:18.953677+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: e444ef8db74d8e11b7b5cfebb31ac2e1138a40d036045f432898ebf98fc33f07
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -165,8 +165,8 @@ entries:
     created: "2021-08-23T20:17:19.069986+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: 8eab8f69d2fddc8b3c930c76f9e930d2e144cc31805b4df8856cf1e945e9333a
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -181,8 +181,8 @@ entries:
     created: "2021-06-02T23:05:43.388235+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: 7291d516b94390843439bae7a2635561e713a549339a314fa2ef79ef098b6ab4
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -197,8 +197,8 @@ entries:
     created: "2021-06-02T23:05:43.387399+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: f88f0c6942353b3d49b4caa43a7580b885ccc94a646428694adc2ed3d43e49fe
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -213,8 +213,8 @@ entries:
     created: "2021-06-02T23:05:43.385355+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: 73e66c651499f93b6f3891e979dcbe2a20ad37809087e42bc98643c604c457c6
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -229,8 +229,8 @@ entries:
     created: "2021-06-02T23:05:43.38449+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: be9379611b45db416a32b7e1367527faec7c29a969493ca4a0a72b5b87a280f4
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -245,8 +245,8 @@ entries:
     created: "2021-06-02T23:05:43.381142+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: 787a26590d68735341b7839c14274492097fed4a0843fc9a1e5c692194199707
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -261,8 +261,8 @@ entries:
     created: "2021-06-02T23:05:43.380337+08:00"
     description: A Helm chart for Apollo Config Service and Apollo Admin Service
     digest: 65c08f39b54ad1ac1d849cc841ce978bd6e95b0b6cbd2423d9f17f66bc7e8d3e
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam

--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -20,8 +20,8 @@ entries:
     created: "2021-09-09T09:24:18.945869+08:00"
     description: A Helm chart for Apollo Portal
     digest: 6e50025665de4179f3485aa58ef33f24556267764afc645eaaab98810716f7ab
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam
@@ -36,8 +36,8 @@ entries:
     created: "2021-08-23T20:17:19.061588+08:00"
     description: A Helm chart for Apollo Portal
     digest: 5013793bf02482003afc17df98e5a6c62fbfb1e17f08ba49f3d27bd02fbd768d
-    home: https://github.com/ctripcorp/apollo
-    icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+    home: https://github.com/apolloconfig/apollo
+    icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
     maintainers:
     - email: nobodyiam@gmail.com
       name: nobodyiam

--- a/scripts/helm/apollo-portal/Chart.yaml
+++ b/scripts/helm/apollo-portal/Chart.yaml
@@ -19,8 +19,8 @@ description: A Helm chart for Apollo Portal
 type: application
 version: 0.4.0
 appVersion: 2.0.0-SNAPSHOT
-home: https://github.com/ctripcorp/apollo
-icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+home: https://github.com/apolloconfig/apollo
+icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
 maintainers:
 - name: nobodyiam
   email: nobodyiam@gmail.com

--- a/scripts/helm/apollo-service/Chart.yaml
+++ b/scripts/helm/apollo-service/Chart.yaml
@@ -19,8 +19,8 @@ description: A Helm chart for Apollo Config Service and Apollo Admin Service
 type: application
 version: 0.4.0
 appVersion: 2.0.0-SNAPSHOT
-home: https://github.com/ctripcorp/apollo
-icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
+home: https://github.com/apolloconfig/apollo
+icon: https://raw.githubusercontent.com/apolloconfig/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png
 maintainers:
 - name: nobodyiam
   email: nobodyiam@gmail.com


### PR DESCRIPTION
What's the purpose of this PR
The git repository has been move from ctripcorp to apolloconfig, but stil some content need to change

Which issue(s) this PR fixes:
Fixes #4078

Brief changelog
change ctripcorp to apolloconfig in three .yaml files.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the Contributing Guide before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run mvn clean test to make sure this pull request doesn't break anything.
- [ ] Update the CHANGES log.