### PR TITLE
兼容处理（表达式或字符常量）以','分割的类型

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -26,14 +26,10 @@ import com.ctrip.framework.apollo.spring.property.SpringValue;
 import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.ctrip.framework.apollo.util.parser.Parsers;
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Set;
-
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -44,6 +40,11 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Set;
 
 /**
  * Apollo Annotation Processor for Spring Application
@@ -135,12 +136,17 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
 
     for (String namespace : namespaces) {
       final String resolvedNamespace = this.environment.resolveRequiredPlaceholders(namespace);
-      Config config = ConfigService.getConfig(resolvedNamespace);
 
-      if (interestedKeys == null && interestedKeyPrefixes == null) {
-        config.addChangeListener(configChangeListener);
-      } else {
-        config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+      String[] namespaceArr = Parsers.forStringCutting().parse(resolvedNamespace);
+      if (namespaceArr != null){
+        for (String namespaceVal : namespaceArr) {
+          Config config = ConfigService.getConfig(namespaceVal);
+          if (interestedKeys == null && interestedKeyPrefixes == null) {
+            config.addChangeListener(configChangeListener);
+          } else {
+            config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+          }
+        }
       }
     }
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
@@ -23,14 +23,15 @@ import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
+import com.ctrip.framework.apollo.util.parser.Parsers;
 import com.google.common.collect.Lists;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
+
+import java.util.*;
 
 public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrarHelper {
 
@@ -62,12 +63,15 @@ public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrar
   }
 
   private String[] resolveNamespaces(String[] namespaces) {
-    String[] resolvedNamespaces = new String[namespaces.length];
-    for (int i = 0; i < namespaces.length; i++) {
+    List<String> resolvedNamespaces = new ArrayList<>();
+    for (String namespace : namespaces) {
       // throw IllegalArgumentException if given text is null or if any placeholders are unresolvable
-      resolvedNamespaces[i] = this.environment.resolveRequiredPlaceholders(namespaces[i]);
+      String[] namespaceArr = Parsers.forStringCutting().parse(this.environment.resolveRequiredPlaceholders(namespace));
+      if (namespaceArr != null) {
+        resolvedNamespaces.addAll(Arrays.asList(namespaceArr));
+      }
     }
-    return resolvedNamespaces;
+    return resolvedNamespaces.toArray(new String[0]);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/parser/Parsers.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/parser/Parsers.java
@@ -32,6 +32,10 @@ public class Parsers {
     return DurationParser.INSTANCE;
   }
 
+  public static StringCuttingParser forStringCutting() {
+    return StringCuttingParser.INSTANCE;
+  }
+
   public enum DateParser {
     INSTANCE;
 
@@ -141,6 +145,31 @@ public class Parsers {
         return 0;
       }
       return Integer.parseInt(parsed) * multiplier;
+    }
+  }
+
+  public enum StringCuttingParser {
+    INSTANCE;
+
+    private static final String COMMA = ",";
+
+    /**
+     * Parse the text
+     *
+     * @param text   the text to parse
+     * @return the parsed String[]
+     */
+    public String[] parse(String text) {
+      if (text == null){
+        return null;
+      }
+
+      String[] outPut = text.split(COMMA);
+      for (int i = 0; i < outPut.length; i++) {
+        outPut[i] = outPut[i].trim();
+      }
+
+      return outPut;
     }
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/parser/StringCuttingParserTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/parser/StringCuttingParserTest.java
@@ -1,0 +1,18 @@
+package com.ctrip.framework.apollo.util.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringCuttingParserTest {
+
+    private Parsers.StringCuttingParser stringCuttingParser = Parsers.forStringCutting();
+
+    @Test
+    public void testParseMilliSeconds() throws Exception {
+        String text = "application,demo";
+        String[] expected = {"application", "demo"};
+
+        assertEquals(expected, stringCuttingParser.parse(text));
+    }
+}


### PR DESCRIPTION
## What's the purpose of this PR

兼容处理（表达式或字符常量）以,分割的类型
@EnableApolloConfig("application,apollo") or @EnableApolloConfig("apollo.bootstrap.namespaces")
@ApolloConfigChangeListener("application,apollo")  or @EnableApolloConfig("apollo.bootstrap.namespaces")

现在的处理办法@EnableApolloConfig(value = {"application", "${apollo.bootstrap.namespaces.other}"})

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
