### PR TITLE
More flexible adding namespace:separated by comma

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -26,6 +26,7 @@ import com.ctrip.framework.apollo.spring.property.SpringValue;
 import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.ctrip.framework.apollo.util.parser.Parsers;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import java.lang.reflect.Field;
@@ -135,12 +136,10 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
 
     for (String namespace : namespaces) {
       final String resolvedNamespace = this.environment.resolveRequiredPlaceholders(namespace);
-      Config config = ConfigService.getConfig(resolvedNamespace);
 
-      if (interestedKeys == null && interestedKeyPrefixes == null) {
-        config.addChangeListener(configChangeListener);
-      } else {
-        config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+      String[] namespaceArr = Parsers.forStringCutting().parse(resolvedNamespace);
+      if (namespaceArr != null){
+        this.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes, namespaceArr);
       }
     }
   }
@@ -218,6 +217,19 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
     } catch (Throwable ex) {
       logger.error("Parsing json '{}' to type {} failed!", json, targetType, ex);
       throw ex;
+    }
+  }
+
+  private void addChangeListener(ConfigChangeListener configChangeListener, Set<String> interestedKeys,
+                                 Set<String> interestedKeyPrefixes,
+                                 String[] namespaceArr) {
+    for (String namespaceVal : namespaceArr) {
+      Config config = ConfigService.getConfig(namespaceVal);
+      if (interestedKeys == null && interestedKeyPrefixes == null) {
+        config.addChangeListener(configChangeListener);
+      } else {
+        config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+      }
     }
   }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
@@ -23,14 +23,18 @@ import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
+import com.ctrip.framework.apollo.util.parser.Parsers;
 import com.google.common.collect.Lists;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrarHelper {
 
@@ -62,12 +66,15 @@ public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrar
   }
 
   private String[] resolveNamespaces(String[] namespaces) {
-    String[] resolvedNamespaces = new String[namespaces.length];
-    for (int i = 0; i < namespaces.length; i++) {
+    List<String> resolvedNamespaces = Lists.newArrayList();
+    for (String namespace : namespaces) {
       // throw IllegalArgumentException if given text is null or if any placeholders are unresolvable
-      resolvedNamespaces[i] = this.environment.resolveRequiredPlaceholders(namespaces[i]);
+      String[] namespaceArr = Parsers.forStringCutting().parse(this.environment.resolveRequiredPlaceholders(namespace));
+      if (namespaceArr != null) {
+        resolvedNamespaces.addAll(Arrays.asList(namespaceArr));
+      }
     }
-    return resolvedNamespaces;
+    return resolvedNamespaces.toArray(new String[0]);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/parser/Parsers.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/parser/Parsers.java
@@ -32,6 +32,10 @@ public class Parsers {
     return DurationParser.INSTANCE;
   }
 
+  public static StringCuttingParser forStringCutting() {
+    return StringCuttingParser.INSTANCE;
+  }
+
   public enum DateParser {
     INSTANCE;
 
@@ -141,6 +145,31 @@ public class Parsers {
         return 0;
       }
       return Integer.parseInt(parsed) * multiplier;
+    }
+  }
+
+  public enum StringCuttingParser {
+    INSTANCE;
+
+    private static final String COMMA = ",";
+
+    /**
+     * Parse the text
+     *
+     * @param text   the text to parse
+     * @return the parsed String[]
+     */
+    public String[] parse(String text) {
+      if (text == null){
+        return null;
+      }
+
+      String[] outPut = text.split(COMMA);
+      for (int i = 0; i < outPut.length; i++) {
+        outPut[i] = outPut[i].trim();
+      }
+
+      return outPut;
     }
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/parser/StringCuttingParserTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/parser/StringCuttingParserTest.java
@@ -1,0 +1,19 @@
+package com.ctrip.framework.apollo.util.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+
+public class StringCuttingParserTest {
+
+    private Parsers.StringCuttingParser stringCuttingParser = Parsers.forStringCutting();
+
+    @Test
+    public void testParseStr() throws Exception {
+        String text = "application,apollo";
+        String[] expected = {"application", "apollo"};
+
+        assertArrayEquals(expected, stringCuttingParser.parse(text));
+    }
+}


### PR DESCRIPTION
## What's the purpose of this PR

More flexible adding namespace:separated by comma

Before:
@EnableApolloConfig({"application", "${apollo.bootstrap.namespaces}"})
@ApolloConfigChangeListener({"application", "${apollo.bootstrap.namespaces}"})

After :
@EnableApolloConfig("application,apollo") or @EnableApolloConfig("${apollo.bootstrap.namespaces.other}")
@ApolloConfigChangeListener("application,apollo") or @ApolloConfigChangeListener("${apollo.bootstrap.namespaces.other}")

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
