### PR TITLE
Fix #4152

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Release Notes.
 Apollo 1.9.2
 
 ------------------
-* [Fix #4152](https://github.com/apolloconfig/apollo/pull/4161)
+* [Fix the issue that property placeholder doesn't work for dubbo reference beans](https://github.com/apolloconfig/apollo/pull/4161)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/10?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 Apollo 1.9.2
 
 ------------------
+* [Fix #4152](https://github.com/apolloconfig/apollo/pull/4161)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/10?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/BeanRegistrationUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/BeanRegistrationUtil.java
@@ -19,10 +19,11 @@ package com.ctrip.framework.apollo.spring.util;
 import java.util.Map;
 import java.util.Objects;
 
-import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.MethodMetadata;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -41,17 +42,15 @@ public class BeanRegistrationUtil {
 
     String[] candidates = registry.getBeanDefinitionNames();
 
-    if (registry instanceof BeanFactory) {
-      final BeanFactory beanFactory = (BeanFactory) registry;
-      for (String candidate : candidates) {
-        if (beanFactory.isTypeMatch(candidate, beanClass)) {
-          return false;
-        }
+    for (String candidate : candidates) {
+      BeanDefinition beanDefinition = registry.getBeanDefinition(candidate);
+      if (Objects.equals(beanDefinition.getBeanClassName(), beanClass.getName())) {
+        return false;
       }
-    } else {
-      for (String candidate : candidates) {
-        BeanDefinition beanDefinition = registry.getBeanDefinition(candidate);
-        if (Objects.equals(beanDefinition.getBeanClassName(), beanClass.getName())) {
+
+      if (beanDefinition instanceof AnnotatedBeanDefinition) {
+        MethodMetadata metadata = ((AnnotatedBeanDefinition) beanDefinition).getFactoryMethodMetadata();
+        if (metadata != null && Objects.equals(metadata.getReturnTypeName(), beanClass.getName())) {
           return false;
         }
       }


### PR DESCRIPTION
`beanFactory.isTypeMatch` may lead to the initialization of FactoryBean,
dubbo consumer is a ReferenceBean which implements FactoryBean.

related to #2328 #3865

## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
