### PR TITLE
Fix #4152

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Apollo 2.0.0
 * [Split helm chart into another repo](https://github.com/apolloconfig/apollo/pull/4125)
 * [fix gray publish refresh item status](https://github.com/apolloconfig/apollo/pull/4128)
 * [Support only show difference keys when compare namespace](https://github.com/apolloconfig/apollo/pull/4165)
+* [Fix the issue that property placeholder doesn't work for dubbo reference beans](https://github.com/apolloconfig/apollo/pull/4175)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)


### PR DESCRIPTION
`beanFactory.isTypeMatch` may lead to the initialization of FactoryBean,
dubbo consumer is a ReferenceBean which implements FactoryBean.
support spring 3

related to #2328 #3865 #4161 #4164

## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
