### PR TITLE
Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Apollo 1.9.2
 ------------------
 * [Fix the issue that property placeholder doesn't work for dubbo reference beans](https://github.com/apolloconfig/apollo/pull/4161)
 * [Update xstream version to 1.4.18](https://github.com/apolloconfig/apollo/pull/4177)
+* [Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1](https://github.com/apolloconfig/apollo/pull/4179)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/10?closed=1)


### PR DESCRIPTION
## What's the purpose of this PR

Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1

## Which issue(s) this PR fixes:
Fixes #4178

## Brief changelog

* Disable namespace placeholder support for Spring version prior to 3.2.x

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
