### PR TITLE
Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Apollo 2.0.0
 * [fix gray publish refresh item status](https://github.com/apolloconfig/apollo/pull/4128)
 * [Support only show difference keys when compare namespace](https://github.com/apolloconfig/apollo/pull/4165)
 * [Fix the issue that property placeholder doesn't work for dubbo reference beans](https://github.com/apolloconfig/apollo/pull/4175)
+* [Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1](https://github.com/apolloconfig/apollo/pull/4180)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)


### PR DESCRIPTION
## What's the purpose of this PR

Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1 in master branch

## Which issue(s) this PR fixes:
Fixes #4178

## Brief changelog

* Disable namespace placeholder support for Spring version prior to 3.2.x and add necessary warn logs

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
