### PR TITLE
bump guava version to 31.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Apollo 2.0.0
 * [Support only show difference keys when compare namespace](https://github.com/apolloconfig/apollo/pull/4165)
 * [Fix the issue that property placeholder doesn't work for dubbo reference beans](https://github.com/apolloconfig/apollo/pull/4175)
 * [Fix the NPE occurred when using EnableApolloConfig with Spring 3.1.1](https://github.com/apolloconfig/apollo/pull/4180)
+* [Bump guava from 29.0 to 31.0.1](https://github.com/apolloconfig/apollo/pull/4182)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<!-- for jdk 7 compatibility -->
-				<version>29.0-android</version>
+				<version>31.0.1-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
## What's the purpose of this PR

Since we no longer support java7, we can bump guava version to get rid of risks(bug、security) problem

## Brief changelog

- bump guava version to 31.0.1

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
