### PR TITLE
Allow disable apollo client cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Apollo 2.0.0
 * [The release history of namespaces that are not properties will also show comments and release times](https://github.com/apolloconfig/apollo/pull/4198)
 * [Add unit tests for Utils](https://github.com/apolloconfig/apollo/pull/4193)
 * [Change Copy Right year to 2022](https://github.com/apolloconfig/apollo/pull/4202)
+* [Allow disable apollo client cache](https://github.com/apolloconfig/apollo/pull/4199)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
@@ -76,7 +76,7 @@ public class DefaultConfigFactory implements ConfigFactory {
         format != ConfigFileFormat.Properties) {
       configRepository = createPropertiesCompatibleFileConfigRepository(namespace, format);
     } else {
-      configRepository = createLocalConfigRepository(namespace);
+      configRepository = createConfigRepository(namespace);
     }
 
     logger.debug("Created a configuration repository of type [{}] for namespace [{}]",
@@ -91,7 +91,7 @@ public class DefaultConfigFactory implements ConfigFactory {
 
   @Override
   public ConfigFile createConfigFile(String namespace, ConfigFileFormat configFileFormat) {
-    ConfigRepository configRepository = createLocalConfigRepository(namespace);
+    ConfigRepository configRepository = createConfigRepository(namespace);
     switch (configFileFormat) {
       case Properties:
         return new PropertiesConfigFile(namespace, configRepository);
@@ -108,6 +108,13 @@ public class DefaultConfigFactory implements ConfigFactory {
     }
 
     return null;
+  }
+
+  ConfigRepository createConfigRepository(String namespace) {
+    if (m_configUtil.isPropertyFileCacheEnabled()) {
+      return createLocalConfigRepository(namespace);
+    }
+    return createRemoteConfigRepository(namespace);
   }
 
   /**

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryFileCachePropertyTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryFileCachePropertyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spi;
+
+import com.ctrip.framework.apollo.build.MockInjector;
+import com.ctrip.framework.apollo.internals.ConfigRepository;
+import com.ctrip.framework.apollo.internals.LocalFileConfigRepository;
+import com.ctrip.framework.apollo.internals.RemoteConfigRepository;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class DefaultConfigFactoryFileCachePropertyTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testCreateFileEnableConfigRepository() throws Exception {
+        MockInjector.setInstance(ConfigUtil.class, new MockFileCacheEnableConfigUtil());
+        DefaultConfigFactory defaultConfigFactory = new DefaultConfigFactory();
+        ConfigRepository configRepository = defaultConfigFactory.createConfigRepository("namespace");
+        Assertions.assertTrue(configRepository instanceof LocalFileConfigRepository);
+    }
+
+    @Test
+    public void testCreateFileDisableConfigRepository() throws Exception {
+        MockInjector.setInstance(ConfigUtil.class, new MockFileCacheDisableConfigUtil());
+        DefaultConfigFactory defaultConfigFactory = new DefaultConfigFactory();
+        ConfigRepository configRepository = defaultConfigFactory.createConfigRepository("namespace");
+        Assertions.assertTrue(configRepository instanceof RemoteConfigRepository);
+    }
+
+    public static class MockFileCacheEnableConfigUtil extends ConfigUtil {
+        @Override
+        public boolean isPropertyFileCacheEnabled() {
+            return true;
+        }
+    }
+
+    public static class MockFileCacheDisableConfigUtil extends ConfigUtil {
+        @Override
+        public boolean isPropertyFileCacheEnabled() {
+            return false;
+        }
+    }
+
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryFileCachePropertyTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryFileCachePropertyTest.java
@@ -21,6 +21,7 @@ import com.ctrip.framework.apollo.internals.ConfigRepository;
 import com.ctrip.framework.apollo.internals.LocalFileConfigRepository;
 import com.ctrip.framework.apollo.internals.RemoteConfigRepository;
 import com.ctrip.framework.apollo.util.ConfigUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -45,6 +46,11 @@ public class DefaultConfigFactoryFileCachePropertyTest {
         DefaultConfigFactory defaultConfigFactory = new DefaultConfigFactory();
         ConfigRepository configRepository = defaultConfigFactory.createConfigRepository("namespace");
         Assertions.assertTrue(configRepository instanceof RemoteConfigRepository);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MockInjector.reset();
     }
 
     public static class MockFileCacheEnableConfigUtil extends ConfigUtil {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
@@ -80,7 +80,7 @@ public class DefaultConfigFactoryTest {
     LocalFileConfigRepository someLocalConfigRepo = mock(LocalFileConfigRepository.class);
     when(someLocalConfigRepo.getConfig()).thenReturn(someProperties);
 
-    doReturn(someLocalConfigRepo).when(defaultConfigFactory).createLocalConfigRepository(someNamespace);
+    doReturn(someLocalConfigRepo).when(defaultConfigFactory).createConfigRepository(someNamespace);
 
     Config result = defaultConfigFactory.create(someNamespace);
 

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ApolloClientSystemConsts.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ApolloClientSystemConsts.java
@@ -146,4 +146,14 @@ public class ApolloClientSystemConsts {
    * enable property names cache environment variables
    */
   public static final String APOLLO_PROPERTY_NAMES_CACHE_ENABLE_ENVIRONMENT_VARIABLES = "APOLLO_PROPERTY_NAMES_CACHE_ENABLE";
+
+  /**
+   * enable property names cache
+   */
+  public static final String APOLLO_CACHE_FILE_ENABLE = "apollo.cache.file.enable";
+
+  /**
+   * enable property names cache environment variables
+   */
+  public static final String APOLLO_CACHE_FILE_ENABLE_ENVIRONMENT_VARIABLES = "APOLLO_CACHE_FILE_ENABLE";
 }


### PR DESCRIPTION
## Which issue(s) this PR fixes:
Fixes #4181 

## Brief changelog
- add config `apollo.property.file.cache.enable`
- if `apollo.property.file.cache.enable` is false, use `RemoteConfigRepository`
- add corresponding unit tests

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
