### PR TITLE
fix update user password failure bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Apollo 2.0.0
 * [Change Copy Right year to 2022](https://github.com/apolloconfig/apollo/pull/4202)
 * [Allow disable apollo client cache](https://github.com/apolloconfig/apollo/pull/4199)
 * [Make password check not hardcoded](https://github.com/apolloconfig/apollo/pull/4207)
+* [Fix update user's password failure](https://github.com/apolloconfig/apollo/pull/4212)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Authority.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Authority.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ctrip.framework.apollo.portal.entity.po;
+
+import com.google.common.base.MoreObjects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author lepdou 2022-01-20
+ */
+@Entity
+@Table(name = "Authorities")
+public class Authority {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "Id")
+  private long   id;
+  @Column(name = "Username", nullable = false)
+  private String username;
+  @Column(name = "Authority", nullable = false)
+  private String authority;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getAuthority() {
+    return authority;
+  }
+
+  public void setAuthority(String authority) {
+    this.authority = authority;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).omitNullValues().add("id", id)
+        .add("username", username)
+        .add("authority", authority).toString();
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AuthorityRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AuthorityRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ctrip.framework.apollo.portal.repository;
+
+import com.ctrip.framework.apollo.portal.entity.po.Authority;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+/**
+ * @author lepdou 2022-01-20
+ */
+public interface AuthorityRepository extends PagingAndSortingRepository<Authority, Long> {
+
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.portal.spi.configuration;
 
 import com.ctrip.framework.apollo.common.condition.ConditionalOnMissingProfile;
 import com.ctrip.framework.apollo.core.utils.StringUtils;
+import com.ctrip.framework.apollo.portal.repository.AuthorityRepository;
 import com.ctrip.framework.apollo.portal.repository.UserRepository;
 import com.ctrip.framework.apollo.portal.spi.LogoutHandler;
 import com.ctrip.framework.apollo.portal.spi.SsoHeartbeatHandler;
@@ -137,9 +138,8 @@ public class AuthConfiguration {
     @Bean
     @ConditionalOnMissingBean(UserService.class)
     public UserService springSecurityUserService(PasswordEncoder passwordEncoder,
-        JdbcUserDetailsManager userDetailsManager,
-        UserRepository userRepository) {
-      return new SpringSecurityUserService(passwordEncoder, userDetailsManager, userRepository);
+        UserRepository userRepository, AuthorityRepository authorityRepository) {
+      return new SpringSecurityUserService(passwordEncoder, userRepository, authorityRepository);
     }
 
   }


### PR DESCRIPTION
## What's the purpose of this PR


## Which issue(s) this PR fixes:
Fix update user's password failure.

For example: 
Update user's password from 123 to 123456 by portal user manager. But password will not be changed some times.

The reason is follows：

````
@Transactional
  public void createOrUpdate(UserPO user) {
    String username = user.getUsername();

    User userDetails = new User(username, passwordEncoder.encode(user.getPassword()), authorities);

    if (userDetailsManager.userExists(username)) {
     // 1. update user's password success.
      userDetailsManager.updateUser(userDetails);
    } else {
      userDetailsManager.createUser(userDetails);
    }

   // 2. the result of finding by username sometimes is still old user object.
    UserPO managedUser = userRepository.findByUsername(username);
    managedUser.setEmail(user.getEmail());
    managedUser.setUserDisplayName(user.getUserDisplayName());

   // 3. save user will recover updated password in step1.
    userRepository.save(managedUser);
  }
````

The solution is create or update by custom repository.


## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
