### PR TITLE
fix bug: associated namespace parse text incorrect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Apollo 2.0.0
 * [Allow disable apollo client cache](https://github.com/apolloconfig/apollo/pull/4199)
 * [Make password check not hardcoded](https://github.com/apolloconfig/apollo/pull/4207)
 * [Fix update user's password failure](https://github.com/apolloconfig/apollo/pull/4212)
+* [Fix bug: associated namespace display incorrect in text view](https://github.com/apolloconfig/apollo/pull/4219)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -352,6 +352,7 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                                     publicNamespace.hasPublishedItem = true;
                                 }
                             });
+                            publicNamespace.isPropertiesFormat = publicNamespace.format == 'properties'
                             loadParentNamespaceText(namespace);
                         });
                 }

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -352,7 +352,7 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                                     publicNamespace.hasPublishedItem = true;
                                 }
                             });
-                            publicNamespace.isPropertiesFormat = publicNamespace.format == 'properties'
+                            publicNamespace.isPropertiesFormat = publicNamespace.format == 'properties';
                             loadParentNamespaceText(namespace);
                         });
                 }


### PR DESCRIPTION

## What's the purpose of this PR

1.  associated namespace parse text incorrect because of field `publicNamespace.isPropertiesFormat`  not set

## Which issue(s) this PR fixes:
Fixes #
As below
![image](https://user-images.githubusercontent.com/20854418/151093268-77ec4e52-91dc-4951-be16-5b87ff18bb0f.png)

![image](https://user-images.githubusercontent.com/20854418/151093248-bda80bfa-2bec-47d6-8e1f-792884adb5cd.png)

## Brief changelog

associated namespace display in text incorrect

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
