### PR TITLE
use item.isDeleted to check whether the item is deleted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,5 +47,6 @@ Apollo 2.0.0
 * [fix import config bug](https://github.com/apolloconfig/apollo/pull/4262)
 * [Refactor the soft delete design](https://github.com/apolloconfig/apollo/pull/3866)
 * [Fix the potential data inconsistency issue](https://github.com/apolloconfig/apollo/pull/4256)
+* [Fix the deleted items display issue in text mode](https://github.com/apolloconfig/apollo/pull/4279)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -843,7 +843,7 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                 var itemCnt = 0;
                 namespace.items.forEach(function (item) {
                     //deleted key
-                    if (!item.item.dataChangeLastModifiedBy) {
+                    if (item.isDeleted) {
                         return;
                     }
                     if (item.item.key) {


### PR DESCRIPTION
## What's the purpose of this PR

Use `item.isDeleted` to check whether the item is deleted, as `item.dataChangeLastModifiedBy` is not null for deleted items since #2680.

## Which issue(s) this PR fixes:
Fixes #4276

## Brief changelog

* Use `item.isDeleted` to check whether the item is deleted

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
