### PR TITLE
Fix the apollo portal start failed issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,5 +49,6 @@ Apollo 2.0.0
 * [Fix the potential data inconsistency issue](https://github.com/apolloconfig/apollo/pull/4256)
 * [Fix the deleted items display issue in text mode](https://github.com/apolloconfig/apollo/pull/4279)
 * [Upgrade spring boot to 2.6.6 and spring cloud to 2021.0.1](https://github.com/apolloconfig/apollo/pull/4295)
+* [Fix the apollo portal start failed issue](https://github.com/apolloconfig/apollo/pull/4298)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
@@ -136,6 +137,7 @@ public class AuthConfiguration {
     }
 
     @Bean
+    @DependsOn("jdbcUserDetailsManager")
     @ConditionalOnMissingBean(UserService.class)
     public UserService springSecurityUserService(PasswordEncoder passwordEncoder,
         UserRepository userRepository, AuthorityRepository authorityRepository) {

--- a/apollo-portal/src/main/resources/static/open/manage.html
+++ b/apollo-portal/src/main/resources/static/open/manage.html
@@ -57,7 +57,7 @@
                                 <small>{{'Open.Manage.ThirdAppIdTips' | translate }}</small>
                             </div>
                             <div class="col-sm-1">
-                                <button class="btn btn-info" ng-click="getTokenByAppId()">查询</button>
+                                <button class="btn btn-info" ng-click="getTokenByAppId()">{{'Common.Search' | translate }}</button>
                             </div>
                             <div class="col-sm-6">
                                 <h4 style="color: red" ng-show="consumerToken"


### PR DESCRIPTION
## What's the purpose of this PR

fix the spring security beans dependency issue brought by #4212

## Which issue(s) this PR fixes:
Fixes #4297

## Brief changelog
 
1. explicitly declare the `springSecurityUserService` bean depends on the `jdbcUserDetailsManager` bean to control the bean initialization sequence
2. fix one missing label translation

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
