### PR TITLE
Broadcast ConfigChangeEvent using Spring ApplicationEvent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,5 +52,6 @@ Apollo 2.0.0
 * [Fix the apollo portal start failed issue](https://github.com/apolloconfig/apollo/pull/4298)
 * [fix: javax.net.ssl.SSLHandshakeException: No appropriate protocol](https://github.com/apolloconfig/apollo/pull/4308)
 * [Upgrade flyway to 8.0.5](https://github.com/apolloconfig/apollo/pull/4312)
+* [Broadcast ConfigChangeEvent using Spring ApplicationEvent](https://github.com/apolloconfig/apollo/pull/4305)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/events/ApolloConfigChangeEvent.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/events/ApolloConfigChangeEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.events;
+
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * A Spring Application Event that is fired when Apollo config changes.
+ */
+public class ApolloConfigChangeEvent extends ApplicationEvent {
+
+  public ApolloConfigChangeEvent(ConfigChangeEvent source) {
+    super(source);
+  }
+
+  public ConfigChangeEvent getConfigChangeEvent() {
+    return (ConfigChangeEvent) getSource();
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
@@ -21,6 +21,7 @@ import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
 import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
+import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
 import com.google.common.collect.Lists;
@@ -55,6 +56,8 @@ public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrar
 
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
         PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry,
+        AutoUpdateConfigChangeListener.class.getName(), AutoUpdateConfigChangeListener.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesProcessor.class.getName(),
         PropertySourcesProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.spring.spi;
 import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
 import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
+import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
 import java.util.HashMap;
@@ -37,6 +38,8 @@ public class DefaultConfigPropertySourcesProcessorHelper implements ConfigProper
 
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
         PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry,
+        AutoUpdateConfigChangeListener.class.getName(), AutoUpdateConfigChangeListener.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
         ApolloAnnotationProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(),

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessorTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ctrip.framework.apollo.Config;
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.AbstractSpringIntegrationTest;
+import com.ctrip.framework.apollo.spring.events.ApolloConfigChangeEvent;
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+
+public class PropertySourcesProcessorTest extends AbstractSpringIntegrationTest {
+
+  private ConfigurableEnvironment environment;
+  private ConfigurableListableBeanFactory beanFactory;
+  private PropertySourcesProcessor processor;
+  private MutablePropertySources propertySources;
+  private ApplicationEventPublisher applicationEventPublisher;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    propertySources = mock(MutablePropertySources.class);
+    environment = mock(ConfigurableEnvironment.class);
+    when(environment.getPropertySources()).thenReturn(propertySources);
+    beanFactory = mock(ConfigurableListableBeanFactory.class);
+    applicationEventPublisher = mock(ApplicationEventPublisher.class);
+    processor = new PropertySourcesProcessor();
+    processor.setEnvironment(environment);
+    processor.setApplicationEventPublisher(applicationEventPublisher);
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    PropertySourcesProcessor.reset();
+  }
+
+  @Test
+  public void testInitializePropertySources() {
+    String namespaceName = "someNamespace";
+    String anotherNamespaceName = "anotherNamespace";
+    Config config = mock(Config.class);
+    Config anotherConfig = mock(Config.class);
+    mockConfig(namespaceName, config);
+    mockConfig(anotherNamespaceName, anotherConfig);
+    PropertySourcesProcessor.addNamespaces(Lists.newArrayList(namespaceName, anotherNamespaceName),
+        0);
+
+    processor.postProcessBeanFactory(beanFactory);
+
+    ArgumentCaptor<CompositePropertySource> argumentCaptor = ArgumentCaptor.forClass(
+        CompositePropertySource.class);
+    verify(propertySources).addFirst(argumentCaptor.capture());
+
+    CompositePropertySource compositePropertySource = argumentCaptor.getValue();
+    assertEquals(2, compositePropertySource.getPropertySources().size());
+
+    ConfigPropertySource propertySource = (ConfigPropertySource) Lists.newArrayList(
+        compositePropertySource.getPropertySources()).get(0);
+    ConfigPropertySource anotherPropertySource = (ConfigPropertySource) Lists.newArrayList(
+        compositePropertySource.getPropertySources()).get(1);
+
+    assertEquals(namespaceName, propertySource.getName());
+    assertSame(config, propertySource.getSource());
+    assertEquals(anotherNamespaceName, anotherPropertySource.getName());
+    assertSame(anotherConfig, anotherPropertySource.getSource());
+  }
+
+  @Test
+  public void testApplicationEvent() {
+    String namespaceName = "someNamespace";
+    Config config = mock(Config.class);
+    mockConfig(namespaceName, config);
+    PropertySourcesProcessor.addNamespaces(Lists.newArrayList(namespaceName), 0);
+    ConfigChangeEvent someConfigChangeEvent = mock(ConfigChangeEvent.class);
+
+    processor.postProcessBeanFactory(beanFactory);
+
+    ArgumentCaptor<ConfigChangeListener> argumentCaptor = ArgumentCaptor.forClass(
+        ConfigChangeListener.class);
+    verify(config).addChangeListener(argumentCaptor.capture());
+
+    ConfigChangeListener listener = argumentCaptor.getValue();
+    listener.onChange(someConfigChangeEvent);
+
+    ArgumentCaptor<ApolloConfigChangeEvent> eventCaptor = ArgumentCaptor.forClass(
+        ApolloConfigChangeEvent.class);
+    verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+
+    ApolloConfigChangeEvent event = eventCaptor.getValue();
+    assertSame(someConfigChangeEvent, event.getConfigChangeEvent());
+  }
+}


### PR DESCRIPTION
## What's the purpose of this PR

Broadcast ConfigChangeEvent using Spring ApplicationEvent so that it's easy to customize the logic to handle config changes.

## Brief changelog

* Add ApolloConfigChangeEvent class
* Refactor PropertySourcesProcessor to publish ApolloConfigChangeEvent when config changes

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
