### PR TITLE
fix: javax.net.ssl.SSLHandshakeException: No appropriate protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,5 +50,6 @@ Apollo 2.0.0
 * [Fix the deleted items display issue in text mode](https://github.com/apolloconfig/apollo/pull/4279)
 * [Upgrade spring boot to 2.6.6 and spring cloud to 2021.0.1](https://github.com/apolloconfig/apollo/pull/4295)
 * [Fix the apollo portal start failed issue](https://github.com/apolloconfig/apollo/pull/4298)
+* [fix: javax.net.ssl.SSLHandshakeException: No appropriate protocol](https://github.com/apolloconfig/apollo/pull/4308)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/8?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<javassist.version>3.23.1-GA</javassist.version>
 		<nacos-discovery-api.version>1.4.0</nacos-discovery-api.version>
 		<common-lang3.version>3.12.0</common-lang3.version>
+		<mysql-connector-java.version>8.0.28</mysql-connector-java.version>
 		<!-- Plugins Version -->
 		<maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
@@ -168,7 +169,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.16</version>
+				<version>8.0.28</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.inject</groupId>
@@ -697,7 +698,7 @@
 							<dependency>
 								<groupId>mysql</groupId>
 								<artifactId>mysql-connector-java</artifactId>
-								<version>8.0.16</version>
+								<version>8.0.28</version>
 							</dependency>
 						</dependencies>
 						<configuration>
@@ -720,7 +721,7 @@
 							<dependency>
 								<groupId>mysql</groupId>
 								<artifactId>mysql-connector-java</artifactId>
-								<version>8.0.16</version>
+								<version>8.0.28</version>
 							</dependency>
 						</dependencies>
 						<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.28</version>
+				<version>${mysql-connector-java.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.inject</groupId>
@@ -698,7 +698,7 @@
 							<dependency>
 								<groupId>mysql</groupId>
 								<artifactId>mysql-connector-java</artifactId>
-								<version>8.0.28</version>
+								<version>${mysql-connector-java.version}</version>
 							</dependency>
 						</dependencies>
 						<configuration>
@@ -721,7 +721,7 @@
 							<dependency>
 								<groupId>mysql</groupId>
 								<artifactId>mysql-connector-java</artifactId>
-								<version>8.0.28</version>
+								<version>${mysql-connector-java.version}</version>
 							</dependency>
 						</dependencies>
 						<configuration>


### PR DESCRIPTION
## What's the purpose of this PR

Let user doesn't need add `useSSL=false` to `spring.datasource.url`'s value

## Which issue(s) this PR fixes:
Fixes https://github.com/apolloconfig/apollo/discussions/4300#discussioncomment-2535730

## Brief changelog

upgrade mysql-connector-java version from 8.0.16 to 8.0.28

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
