### PR TITLE
Fix flaky test

### DIFF
--- a/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseControllerTest.java
+++ b/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ReleaseControllerTest.java
@@ -44,6 +44,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.*;
@@ -101,7 +102,7 @@ public class ReleaseControllerTest extends AbstractControllerTest {
     Assert.assertEquals("default", release.getClusterName());
     Assert.assertEquals("application", release.getNamespaceName());
 
-    Map<String, String> configurations = new HashMap<>();
+    Map<String, String> configurations = new LinkedHashMap<>();
     configurations.put("k1", "v1");
     configurations.put("k2", "v2");
     configurations.put("k3", "v3");


### PR DESCRIPTION
The test `testReleaseBuild` in class `ReleaseControllerTest` is flakiness due to the indeterministic iteration order of `HashMap` used in line 104. Changing it to `LinkedHashMap` can solve the problem.

Using `mvn -pl apollo-adminservice edu.illinois:nondex-maven-plugin:1.1.2:nondex test -Dtest=ReleaseControllerTest#testReleaseBuild -DnondexRuns=10` can reproduce the problem.