### PR TITLE
Update ReleaseMessageServiceWithCacheTest.java

### DIFF
--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
@@ -22,6 +22,7 @@ import com.ctrip.framework.apollo.biz.message.Topics;
 import com.ctrip.framework.apollo.biz.repository.ReleaseMessageRepository;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -156,8 +157,8 @@ public class ReleaseMessageServiceWithCacheTest {
             .findLatestReleaseMessagesGroupByMessages(Sets.newHashSet(someMsgContent, antherMsgContent));
 
     assertEquals(2, latestReleaseMsgGroupByMsgContent.size());
-    assertEquals(500, latestReleaseMsgGroupByMsgContent.get(1).getId());
-    assertEquals(501, latestReleaseMsgGroupByMsgContent.get(0).getId());
+    Assert.assertTrue(500 == latestReleaseMsgGroupByMsgContent.get(0).getId() || 501 == latestReleaseMsgGroupByMsgContent.get(0).getId());
+    Assert.assertTrue(500 == latestReleaseMsgGroupByMsgContent.get(1).getId() || 501 == latestReleaseMsgGroupByMsgContent.get(1).getId());
   }
 
   @Test

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
@@ -22,7 +22,6 @@ import com.ctrip.framework.apollo.biz.message.Topics;
 import com.ctrip.framework.apollo.biz.repository.ReleaseMessageRepository;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -151,14 +150,15 @@ public class ReleaseMessageServiceWithCacheTest {
     assertNotNull(latestReleaseMsg);
     assertEquals(501, latestReleaseMsg.getId());
     assertEquals(antherMsgContent, latestReleaseMsg.getMessage());
-
+    
+    List<String> msgContentList = Arrays.asList(someMsgContent, antherMsgContent);
     List<ReleaseMessage> latestReleaseMsgGroupByMsgContent =
         releaseMessageServiceWithCache
-            .findLatestReleaseMessagesGroupByMessages(Sets.newHashSet(someMsgContent, antherMsgContent));
+            .findLatestReleaseMessagesGroupByMessages(Sets.newLinkedHashSet(msgContentList));
 
     assertEquals(2, latestReleaseMsgGroupByMsgContent.size());
-    Assert.assertTrue(500 == latestReleaseMsgGroupByMsgContent.get(0).getId() || 501 == latestReleaseMsgGroupByMsgContent.get(0).getId());
-    Assert.assertTrue(500 == latestReleaseMsgGroupByMsgContent.get(1).getId() || 501 == latestReleaseMsgGroupByMsgContent.get(1).getId());
+    assertEquals(500, latestReleaseMsgGroupByMsgContent.get(0).getId());
+    assertEquals(501, latestReleaseMsgGroupByMsgContent.get(1).getId());
   }
 
   @Test


### PR DESCRIPTION
Test `testWhenReleaseMsgSizeBiggerThan500` in class `ReleaseMessageServiceWithCacheTest` is flaky due to the iteration of hashset used in method `findLatestReleaseMessagesGroupByMessages`  in class `ReleaseMessageServiceWithCache`. It may occasionally fail in different JVM's or in different Java versions.

I modify the test so this test won't be affect by the flakiness of indeterministic order of iteration of hashset.

reproduce:
`mvn -pl apollo-configservice edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=ReleaseMessageServiceWithCacheTest#testWhenReleaseMsgSizeBiggerThan500 -DnondexRuns=10`