### PR TITLE
Fix the npe issue for old version of gray release rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,5 +7,6 @@ Apollo 2.0.1
 ------------------
 * [Upgrade spring boot to fix search user issue](https://github.com/apolloconfig/apollo/pull/4366)
 * [Fix search user duplication issue](https://github.com/apolloconfig/apollo/pull/4371)
+* [Fix the npe issue for old version of gray release rules](https://github.com/apolloconfig/apollo/pull/4382)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/12?closed=1)

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
@@ -94,7 +94,7 @@ public class NamespaceBranchServiceTest extends AbstractIntegrationTest {
     namespaceBranchService.updateBranchGrayRules(testApp, testCluster, testNamespace, testBranchName, firstRule);
 
     GrayReleaseRule secondRule = instanceGrayReleaseRule();
-    secondRule.setRules("[{\"clientAppId\":\"branch-test\",\"clientIpList\":[\"10.38.57.112\"]}]");
+    secondRule.setRules("[{\"clientAppId\":\"branch-test\",\"clientIpList\":[\"10.38.57.112\"],\"clientLabelList\":[\"branch-test\"]}]");
     namespaceBranchService.updateBranchGrayRules(testApp, testCluster, testNamespace, testBranchName, secondRule);
 
     GrayReleaseRule
@@ -200,7 +200,7 @@ public class NamespaceBranchServiceTest extends AbstractIntegrationTest {
     rule.setNamespaceName(testNamespace);
     rule.setBranchName(testBranchName);
     rule.setBranchStatus(NamespaceBranchStatus.ACTIVE);
-    rule.setRules("[{\"clientAppId\":\"test\",\"clientIpList\":[\"1.0.0.4\"]}]");
+    rule.setRules("[{\"clientAppId\":\"test\",\"clientIpList\":[\"1.0.0.4\"],\"clientLabelList\":[]}]");
     return rule;
   }
 

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/dto/GrayReleaseRuleItemDTO.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/dto/GrayReleaseRuleItemDTO.java
@@ -33,6 +33,11 @@ public class GrayReleaseRuleItemDTO {
   private Set<String> clientIpList;
   private Set<String> clientLabelList;
 
+  // this default constructor is for json deserialize use, to make sure all fields are initialized
+  public GrayReleaseRuleItemDTO() {
+    this("");
+  }
+
   public GrayReleaseRuleItemDTO(String clientAppId) {
     this(clientAppId, Sets.newHashSet(), Sets.newHashSet());
   }


### PR DESCRIPTION
## What's the purpose of this PR

Fix the npe issue for old version of gray release rules, e.g. `[{"clientAppId":"appidA","clientIpList":["127.0.0.1"]}]`.

## Which issue(s) this PR fixes:
Fixes #4380

## Brief changelog

* add default constructor for GrayReleaseRuleItemDTO so that `clientIpList` and `clientLabelList` will be initialized to empty set.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
