### PR TITLE
Bump okhttp3 from 3.11.0 to 4.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,5 +9,6 @@ Apollo 2.0.1
 * [Fix search user duplication issue](https://github.com/apolloconfig/apollo/pull/4371)
 * [Fix the npe issue for old version of gray release rules](https://github.com/apolloconfig/apollo/pull/4382)
 * [Fix the delete AppNamespace failed issue](https://github.com/apolloconfig/apollo/pull/4388)
+* [Bump okhttp3 from 3.11.0 to 4.9.3](https://github.com/apolloconfig/apollo/pull/4392)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/12?closed=1)

--- a/apollo-mockserver/pom.xml
+++ b/apollo-mockserver/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <github.path>${project.artifactId}</github.path>
+    <okhttp3.version>4.9.3</okhttp3.version>
   </properties>
 
   <dependencyManagement>
@@ -37,12 +38,12 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>3.11.0</version>
+        <version>${okhttp3.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
-        <version>3.11.0</version>
+        <version>${okhttp3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What's the purpose of this PR
Sine okhttp3 3.x is not maintained, update to 4.x

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
