### PR TITLE
add cat-client as optional dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,5 +6,6 @@ Apollo 2.1.0
 
 ------------------
 * [Add a config adjust the property source overriden behavior](https://github.com/apolloconfig/apollo/pull/4409)
+* [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4414)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -31,6 +31,11 @@
 		<github.path>${project.artifactId}</github.path>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>com.dianping.cat</groupId>
+			<artifactId>cat-client</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- json -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatMessageProducer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatMessageProducer.java
@@ -18,83 +18,35 @@ package com.ctrip.framework.apollo.tracer.internals.cat;
 
 import com.ctrip.framework.apollo.tracer.spi.MessageProducer;
 import com.ctrip.framework.apollo.tracer.spi.Transaction;
-
-import java.lang.reflect.Method;
+import com.dianping.cat.Cat;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 public class CatMessageProducer implements MessageProducer {
-  private static Class CAT_CLASS;
-  private static Method LOG_ERROR_WITH_CAUSE;
-  private static Method LOG_ERROR_WITH_MESSAGE_AND_CAUSE;
-  private static Method LOG_EVENT_WITH_TYPE_AND_NAME;
-  private static Method LOG_EVENT_WITH_TYPE_AND_NAME_AND_STATUS_AND_NAME_VALUE_PAIRS;
-  private static Method NEW_TRANSACTION_WITH_TYPE_AND_NAME;
-
-  static {
-    try {
-      CAT_CLASS = Class.forName(CatNames.CAT_CLASS);
-      LOG_ERROR_WITH_CAUSE = CAT_CLASS.getMethod(CatNames.LOG_ERROR_METHOD, Throwable.class);
-      LOG_ERROR_WITH_MESSAGE_AND_CAUSE = CAT_CLASS.getMethod(CatNames.LOG_ERROR_METHOD,
-          String.class, Throwable.class);
-      LOG_EVENT_WITH_TYPE_AND_NAME = CAT_CLASS.getMethod(CatNames.LOG_EVENT_METHOD,
-          String.class, String.class);
-      LOG_EVENT_WITH_TYPE_AND_NAME_AND_STATUS_AND_NAME_VALUE_PAIRS =
-          CAT_CLASS.getMethod(CatNames.LOG_EVENT_METHOD, String.class, String.class,
-              String.class, String.class);
-      NEW_TRANSACTION_WITH_TYPE_AND_NAME = CAT_CLASS.getMethod(
-          CatNames.NEW_TRANSACTION_METHOD, String.class, String.class);
-      //eager init CatTransaction
-      CatTransaction.init();
-    } catch (Throwable ex) {
-      throw new IllegalStateException("Initialize Cat message producer failed", ex);
-    }
-  }
-
   @Override
   public void logError(Throwable cause) {
-    try {
-      LOG_ERROR_WITH_CAUSE.invoke(null, cause);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    Cat.logError(cause);
   }
 
   @Override
   public void logError(String message, Throwable cause) {
-    try {
-      LOG_ERROR_WITH_MESSAGE_AND_CAUSE.invoke(null, message, cause);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    Cat.logError(message, cause);
   }
 
   @Override
   public void logEvent(String type, String name) {
-    try {
-      LOG_EVENT_WITH_TYPE_AND_NAME.invoke(null, type, name);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+      Cat.logEvent(type, name);
   }
 
   @Override
   public void logEvent(String type, String name, String status, String nameValuePairs) {
-    try {
-      LOG_EVENT_WITH_TYPE_AND_NAME_AND_STATUS_AND_NAME_VALUE_PAIRS.invoke(null, type, name,
+    Cat.logEvent(type, name,
           status, nameValuePairs);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
   }
 
   @Override
   public Transaction newTransaction(String type, String name) {
-    try {
-      return new CatTransaction(NEW_TRANSACTION_WITH_TYPE_AND_NAME.invoke(null, type, name));
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    return new CatTransaction(Cat.newTransaction(type, name));
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatNames.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatNames.java
@@ -21,12 +21,4 @@ package com.ctrip.framework.apollo.tracer.internals.cat;
  */
 public interface CatNames {
   String CAT_CLASS = "com.dianping.cat.Cat";
-  String LOG_ERROR_METHOD = "logError";
-  String LOG_EVENT_METHOD = "logEvent";
-  String NEW_TRANSACTION_METHOD = "newTransaction";
-
-  String CAT_TRANSACTION_CLASS = "com.dianping.cat.message.Transaction";
-  String SET_STATUS_METHOD = "setStatus";
-  String ADD_DATA_METHOD = "addData";
-  String COMPLETE_METHOD = "complete";
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatTransaction.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatTransaction.java
@@ -24,69 +24,30 @@ import java.lang.reflect.Method;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class CatTransaction implements Transaction {
-  private static Class CAT_TRANSACTION_CLASS;
-  private static Method SET_STATUS_WITH_STRING;
-  private static Method SET_STATUS_WITH_THROWABLE;
-  private static Method ADD_DATA_WITH_KEY_AND_VALUE;
-  private static Method COMPLETE;
 
-  private Object catTransaction;
+  private com.dianping.cat.message.Transaction catTransaction;
 
-  static {
-    try {
-      CAT_TRANSACTION_CLASS = Class.forName(CatNames.CAT_TRANSACTION_CLASS);
-      SET_STATUS_WITH_STRING = CAT_TRANSACTION_CLASS.getMethod(CatNames.SET_STATUS_METHOD, String.class);
-      SET_STATUS_WITH_THROWABLE = CAT_TRANSACTION_CLASS.getMethod(CatNames.SET_STATUS_METHOD,
-          Throwable.class);
-      ADD_DATA_WITH_KEY_AND_VALUE = CAT_TRANSACTION_CLASS.getMethod(CatNames.ADD_DATA_METHOD,
-          String.class, Object.class);
-      COMPLETE = CAT_TRANSACTION_CLASS.getMethod(CatNames.COMPLETE_METHOD);
-    } catch (Throwable ex) {
-      throw new IllegalStateException("Initialize Cat transaction failed", ex);
-    }
-  }
-
-  static void init() {
-    //do nothing, just to initialize the static variables
-  }
-
-  public CatTransaction(Object catTransaction) {
+  public CatTransaction(com.dianping.cat.message.Transaction catTransaction) {
     this.catTransaction = catTransaction;
   }
 
   @Override
   public void setStatus(String status) {
-    try {
-      SET_STATUS_WITH_STRING.invoke(catTransaction, status);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+      catTransaction.setStatus(status);
   }
 
   @Override
   public void setStatus(Throwable status) {
-    try {
-      SET_STATUS_WITH_THROWABLE.invoke(catTransaction, status);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    catTransaction.setStatus(status);
   }
 
   @Override
   public void addData(String key, Object value) {
-    try {
-      ADD_DATA_WITH_KEY_AND_VALUE.invoke(catTransaction, key, value);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    catTransaction.addData(key, value);
   }
 
   @Override
   public void complete() {
-    try {
-      COMPLETE.invoke(catTransaction);
-    } catch (Throwable ex) {
-      throw new IllegalStateException(ex);
-    }
+    catTransaction.complete();
   }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/DefaultMessageProducerManagerTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/DefaultMessageProducerManagerTest.java
@@ -16,6 +16,7 @@
  */
 package com.ctrip.framework.apollo.tracer.internals;
 
+import com.ctrip.framework.apollo.tracer.internals.cat.CatMessageProducer;
 import com.ctrip.framework.apollo.tracer.spi.MessageProducerManager;
 
 import org.junit.Before;
@@ -36,7 +37,7 @@ public class DefaultMessageProducerManagerTest {
 
   @Test
   public void testGetProducer() throws Exception {
-    assertTrue(messageProducerManager.getProducer() instanceof NullMessageProducer);
+    assertTrue(messageProducerManager.getProducer() instanceof CatMessageProducer);
   }
 
 }

--- a/changes/changes-2.1.0.md
+++ b/changes/changes-2.1.0.md
@@ -1,9 +1,0 @@
-Changes by Version
-==================
-Release Notes.
-
-Apollo 2.1.0
-------------------
-* [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4414)
-------------------
-All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/12?closed=1)

--- a/changes/changes-2.1.0.md
+++ b/changes/changes-2.1.0.md
@@ -1,0 +1,9 @@
+Changes by Version
+==================
+Release Notes.
+
+Apollo 2.1.0
+------------------
+* [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4368)
+------------------
+All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/12?closed=1)

--- a/changes/changes-2.1.0.md
+++ b/changes/changes-2.1.0.md
@@ -4,6 +4,6 @@ Release Notes.
 
 Apollo 2.1.0
 ------------------
-* [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4368)
+* [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4414)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/12?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<nacos-discovery-api.version>1.4.0</nacos-discovery-api.version>
 		<common-lang3.version>3.12.0</common-lang3.version>
 		<mysql-connector-java.version>8.0.28</mysql-connector-java.version>
+		<cat.client.version>3.1.0</cat.client.version>
 		<!-- Plugins Version -->
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -181,6 +182,11 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>${common-lang3.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.dianping.cat</groupId>
+				<artifactId>cat-client</artifactId>
+				<version>${cat.client.version}</version>
 			</dependency>
 			<!-- to fix CVE-2020-26217 -->
 			<dependency>
@@ -807,4 +813,3 @@
 		</snapshotRepository>
 	</distributionManagement>
 </project>
-


### PR DESCRIPTION
通过在apollo-core 模块中，通过provided的方式引入cat-client，这样子可以在core模块中去掉cat相关的反射调用。同时还可以解决由于反射导致的cat 客户端上报心跳多次的问题。