### PR TITLE
fix:occur a 400 error request when openapi key's parameter contain "a[0]"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,5 +9,6 @@ Apollo 2.1.0
 * [feat(apollo-client): the spi of config service load balancer client](https://github.com/apolloconfig/apollo/pull/4394)
 * [add cat-client as optional dependency](https://github.com/apolloconfig/apollo/pull/4414)
 * [refactor Functions class with lambda](https://github.com/apolloconfig/apollo/pull/4419)
+* [fix:occur a 400 error request when openapi key's parameter contain "a[0]"](https://github.com/apolloconfig/apollo/pull/4424)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/PortalOpenApiConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/PortalOpenApiConfig.java
@@ -16,13 +16,30 @@
  */
 package com.ctrip.framework.apollo.openapi;
 
+import com.ctrip.framework.apollo.common.controller.WebMvcConfig;
+
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 @EnableAutoConfiguration
 @Configuration
 @ComponentScan(basePackageClasses = PortalOpenApiConfig.class)
 public class PortalOpenApiConfig {
 
+	@Component
+	static class PortalWebMvcConfig extends WebMvcConfig {
+		@Override
+		public void customize(TomcatServletWebServerFactory factory) {
+			final String relaxedChars = "<>[\\]^`{|}";
+			final String tomcatRelaxedpathcharsProperty = "relaxedPathChars";
+			final String tomcatRelaxedquerycharsProperty = "relaxedQueryChars";
+			factory.addConnectorCustomizers(connector -> {
+				connector.setProperty(tomcatRelaxedpathcharsProperty, relaxedChars);
+				connector.setProperty(tomcatRelaxedquerycharsProperty, relaxedChars);
+			});
+		}
+	}
 }


### PR DESCRIPTION


## What's the purpose of this PR
fix:occur a 400 error request when openapi key's parameter contain "a[0]"

## Which issue(s) this PR fixes:
Fixes #4422

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
