### PR TITLE
Fix in text mode only the Item line number that is changed, not to update the Item last modified time.

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolver.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolver.java
@@ -151,10 +151,9 @@ public class PropertyResolver implements ConfigTextResolver {
 
     if (oldItem == null) {//new item
       changeSets.addCreateItem(buildNormalItem(0L, namespaceId, newKey, newValue, "", lineCounter));
-    } else if (!newValue.equals(oldItem.getValue()) || lineCounter != oldItem.getLineNum()) {//update item
+    } else if (!newValue.equals(oldItem.getValue())) {//update item
       changeSets.addUpdateItem(
-          buildNormalItem(oldItem.getId(), namespaceId, newKey, newValue, oldItem.getComment(),
-              lineCounter));
+          buildNormalItem(oldItem.getId(), namespaceId, newKey, newValue, oldItem.getComment(), lineCounter));
     }
     keyMapOldItem.remove(newKey);
   }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolverTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolverTest.java
@@ -16,7 +16,6 @@
  */
 package com.ctrip.framework.apollo.portal.component.txtresolver;
 
-
 import com.ctrip.framework.apollo.common.dto.ItemChangeSets;
 import com.ctrip.framework.apollo.common.dto.ItemDTO;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
@@ -65,20 +64,22 @@ public class PropertyResolverTest extends AbstractUnitTest {
     ItemChangeSets changeSets = resolver.resolve(1, "x=y\na=b\nb=c\nc=d", mockBaseItemHas3Key());
     Assert.assertEquals("x", changeSets.getCreateItems().get(0).getKey());
     Assert.assertEquals(1, changeSets.getCreateItems().size());
-    Assert.assertEquals(3, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
   }
 
   @Test
   public void testAddCommentAndBlankItem() {
     ItemChangeSets changeSets = resolver.resolve(1, "#ddd\na=b\n\nb=c\nc=d", mockBaseItemHas3Key());
     Assert.assertEquals(2, changeSets.getCreateItems().size());
-    Assert.assertEquals(3, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
   }
 
   @Test
   public void testChangeItemNumLine() {
     ItemChangeSets changeSets = resolver.resolve(1, "b=c\nc=d\na=b", mockBaseItemHas3Key());
-    Assert.assertEquals(3, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getCreateItems().size());
+    Assert.assertEquals(0, changeSets.getDeleteItems().size());
   }
 
   @Test
@@ -92,7 +93,7 @@ public class PropertyResolverTest extends AbstractUnitTest {
   public void testDeleteCommentItem() {
     ItemChangeSets changeSets = resolver.resolve(1, "a=b\n\nb=c", mockBaseItemWith2Key1Comment1Blank());
     Assert.assertEquals(2, changeSets.getDeleteItems().size());
-    Assert.assertEquals(2, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
     Assert.assertEquals(1, changeSets.getCreateItems().size());
   }
 
@@ -100,7 +101,7 @@ public class PropertyResolverTest extends AbstractUnitTest {
   public void testDeleteBlankItem(){
     ItemChangeSets changeSets = resolver.resolve(1, "#qqqq\na=b\nb=c", mockBaseItemWith2Key1Comment1Blank());
     Assert.assertEquals(1, changeSets.getDeleteItems().size());
-    Assert.assertEquals(1, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
     Assert.assertEquals(0, changeSets.getCreateItems().size());
   }
 
@@ -126,10 +127,55 @@ public class PropertyResolverTest extends AbstractUnitTest {
   }
 
   @Test
+  public void testDeleteNonBottomItemThenOtherItemLastModifiedTimeNotUpdate() {
+    String configText = "#timeout(seconds)\n"
+        + "timeout=100\n"
+        + "jdbc.username=mghio\n"
+        + "jdbc.password=123456";
+
+    String toDeleteItemKey = "jdbc.url";
+    String toDeleteItemValue = "jdbc:mysql://localhost:3306/testdb?characterEncoding=utf8";
+    List<ItemDTO> baseItems = mockBaseItem4TestDeleteNonBottomItemThenOtherItemLastModifiedTimeNotUpdate();
+
+    ItemChangeSets changeSets = resolver.resolve(1, configText, baseItems);
+
+    Assert.assertEquals(1, changeSets.getDeleteItems().size());
+    ItemDTO toDeleteItem = changeSets.getDeleteItems().get(0);
+    Assert.assertEquals(toDeleteItemKey, toDeleteItem.getKey());
+    Assert.assertEquals(toDeleteItemValue, toDeleteItem.getValue());
+
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getCreateItems().size());
+  }
+
+  @Test
+  public void testAddNonBottomItemThenOtherItemLastModifiedTimeNotUpdate() {
+    String configText = "#timeout(seconds)\n"
+        + "jdbc.url=jdbc:mysql://localhost:3306/testdb?characterEncoding=utf8\n"
+        + "timeout=100\n"
+        + "jdbc.username=mghio\n"
+        + "jdbc.password=123456";
+
+    String toAddItemKey = "jdbc.url";
+    String toAddItemValue = "jdbc:mysql://localhost:3306/testdb?characterEncoding=utf8";
+    List<ItemDTO> baseItems = mockBaseItem4TestAddNonBottomItemThenOtherItemLastModifiedTimeNotUpdate();
+
+    ItemChangeSets changeSets = resolver.resolve(1, configText, baseItems);
+
+    Assert.assertEquals(1, changeSets.getCreateItems().size());
+    ItemDTO toAddItem = changeSets.getCreateItems().get(0);
+    Assert.assertEquals(toAddItemKey, toAddItem.getKey());
+    Assert.assertEquals(toAddItemValue, toAddItem.getValue());
+
+    Assert.assertEquals(0, changeSets.getUpdateItems().size());
+    Assert.assertEquals(0, changeSets.getDeleteItems().size());
+  }
+
+  @Test
   public void testAllSituation(){
-    ItemChangeSets changeSets = resolver.resolve(1, "#ww\nd=e\nb=c\na=b\n\nq=w\n#eee", mockBaseItemWith2Key1Comment1Blank());
+    ItemChangeSets changeSets = resolver.resolve(1, "#ww\nd=e\nb=d\na=b\n\nq=w\n#eee", mockBaseItemWith2Key1Comment1Blank());
     Assert.assertEquals(2, changeSets.getDeleteItems().size());
-    Assert.assertEquals(2, changeSets.getUpdateItems().size());
+    Assert.assertEquals(1, changeSets.getUpdateItems().size());
     Assert.assertEquals(5, changeSets.getCreateItems().size());
   }
 
@@ -156,6 +202,36 @@ public class PropertyResolverTest extends AbstractUnitTest {
     ItemDTO i4 = new ItemDTO("b", "c", "", 4);
     i4.setLineNum(4);
     return Arrays.asList(i1, i2, i3, i4);
+  }
+
+  /**
+   * #timeout(seconds)
+   * timeout=100
+   * jdbc.url=jdbc:mysql://localhost:3306/testdb?characterEncoding=utf8
+   * jdbc.username=mghio
+   * jdbc.password=123456
+   */
+  private List<ItemDTO> mockBaseItem4TestDeleteNonBottomItemThenOtherItemLastModifiedTimeNotUpdate() {
+    ItemDTO item1 = new ItemDTO("", "", "#timeout(seconds)", 1);
+    ItemDTO item2 = new ItemDTO("timeout", "100", "", 2);
+    ItemDTO item3 = new ItemDTO("jdbc.url", "jdbc:mysql://localhost:3306/testdb?characterEncoding=utf8", "", 3);
+    ItemDTO item4 = new ItemDTO("jdbc.username", "mghio", "", 4);
+    ItemDTO item5 = new ItemDTO("jdbc.password", "123456", "", 5);
+    return Arrays.asList(item1, item2, item3, item4, item5);
+  }
+
+  /**
+   * #timeout(seconds)
+   * timeout=100
+   * jdbc.username=mghio
+   * jdbc.password=123456
+   */
+  private List<ItemDTO> mockBaseItem4TestAddNonBottomItemThenOtherItemLastModifiedTimeNotUpdate() {
+    ItemDTO item1 = new ItemDTO("", "", "#timeout(seconds)", 1);
+    ItemDTO item2 = new ItemDTO("timeout", "100", "", 2);
+    ItemDTO item3 = new ItemDTO("jdbc.username", "mghio", "", 3);
+    ItemDTO item4 = new ItemDTO("jdbc.password", "123456", "", 4);
+    return Arrays.asList(item1, item2, item3, item4);
   }
 
 }


### PR DESCRIPTION
## What's the purpose of this PR

Fix in text mode only the Item line number that is changed, not to update the Item last modified time.

## Which issue(s) this PR fixes:
Fixes #4482

## Brief changelog

Remove Item lineNumber change check in PropertyResolver class.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
