### PR TITLE
validate the db name for all three moudles (#4230)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,5 +17,6 @@ Apollo 2.1.0
 * [Allow users to associate multiple public namespaces at a time](https://github.com/apolloconfig/apollo/pull/4437)
 * [Move apollo-demo, scripts/docker-quick-start and scripts/apollo-on-kubernetes out of main repository](https://github.com/apolloconfig/apollo/pull/4440)
 * [Add search key when comparing Configuration items](https://github.com/apolloconfig/apollo/pull/4459)
+* [Validate the db name for all three moudles](https://github.com/apolloconfig/apollo/pull/4495)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/customize/ConfigValidatorInitializer.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/customize/ConfigValidatorInitializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.customize;
+
+import com.ctrip.framework.apollo.common.utils.ConfigValidator;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * ConfigValidator Initializer
+ *
+ * @author Lv Lifeng
+ */
+public class ConfigValidatorInitializer implements ApplicationContextInitializer {
+
+  @Override
+  public void initialize(ConfigurableApplicationContext applicationContext) {
+    new ConfigValidator(applicationContext);
+  }
+}

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/ConfigValidator.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/ConfigValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.utils;
+
+import com.ctrip.framework.apollo.core.utils.StringUtils;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.Assert;
+
+/**
+ * Config Validator
+ *
+ * @author Lv Lifeng
+ */
+public class ConfigValidator {
+
+  private final ConfigurableApplicationContext applicationContext;
+
+  public ConfigValidator(ConfigurableApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+    checkDataBaseName();
+  }
+
+  private void checkDataBaseName() {
+    String dataSourceUrl = System.getProperty("spring.datasource.url");
+    if (!StringUtils.isBlank(dataSourceUrl) && !StringUtils.isBlank(applicationContext.getId())) {
+      String dbName = dataSourceUrl.substring(dataSourceUrl.lastIndexOf("/"), dataSourceUrl.indexOf("?"));
+      if (!StringUtils.isEmpty(dbName)) {
+        switch (applicationContext.getId()) {
+          case "apollo-adminservice":
+          case "apollo-configservice":
+            Assert.isTrue(!dbName.toLowerCase().contains("config"), "Please configure the" +
+                    " correct database name, it should be ApolloConfigDB!");
+            break;
+          case "apollo-portal":
+            Assert.isTrue(!dbName.toLowerCase().contains("portal"), "Please configure the" +
+                    " correct database name, it should be ApolloPortalDB!");
+            break;
+          default:
+        }
+      }
+    }
+  }
+}

--- a/apollo-common/src/main/resources/META-INF/spring.factories
+++ b/apollo-common/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationContextInitializer=\
+com.ctrip.framework.apollo.common.customize.ConfigValidatorInitializer


### PR DESCRIPTION
## What's the purpose of this PR

validate the db name for all three moudles

## Which issue(s) this PR fixes:
Fixes #4230

## Brief changelog

If the database names of admin service and config service are missing 'config', or if the database name of portal service is missing 'portal', the startup will fail.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
