### PR TITLE
validate the db name for all three moudles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,5 +21,6 @@ Apollo 2.1.0
 * [Add a new API to load items with pagination](https://github.com/apolloconfig/apollo/pull/4468)
 * [fix(#4474):'openjdk:8-jre-alpine' potentially causing wrong number of cpu cores](https://github.com/apolloconfig/apollo/pull/4475)
 * [fix(#4483):Fixed overwrite JSON type configuration being empty](https://github.com/apolloconfig/apollo/pull/4486)
+* [Validate the db name for all three moudles](https://github.com/apolloconfig/apollo/pull/4496)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/initializer/ConfigValidatorInitializer.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/initializer/ConfigValidatorInitializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.initializer;
+
+import com.ctrip.framework.apollo.common.utils.ConfigValidator;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * ConfigValidator Initializer
+ *
+ * @author Lifeng Lv
+ */
+public class ConfigValidatorInitializer implements ApplicationContextInitializer {
+
+  @Override
+  public void initialize(ConfigurableApplicationContext applicationContext) {
+    new ConfigValidator(applicationContext);
+  }
+}

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/ConfigValidator.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/ConfigValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.utils;
+
+import com.ctrip.framework.apollo.core.utils.StringUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.Assert;
+
+/**
+ * Config Validator
+ *
+ * @author Lifeng Lv
+ */
+public class ConfigValidator {
+
+  private final ConfigurableApplicationContext applicationContext;
+
+  public ConfigValidator(ConfigurableApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+    checkDataBaseName();
+  }
+
+  /**
+   * if apollo.check.database-name is null or ture
+   */
+  private void checkDataBaseName() {
+    String checkFlag = applicationContext.getEnvironment().getProperty("apollo.check.database-name");
+    if (!StringUtils.isBlank(checkFlag)
+        && StringUtils.equals(Boolean.FALSE.toString(), checkFlag.toLowerCase())) {
+      return;
+    }
+    String applicationName = applicationContext.getEnvironment().getProperty("spring.application.name");
+    String dataSourceUrl = applicationContext.getEnvironment().getProperty("spring.datasource.url");
+    if (!StringUtils.isBlank(dataSourceUrl)
+        && !StringUtils.isBlank(applicationName)) {
+      String dbName = determineDatabaseName(dataSourceUrl);
+      if (!StringUtils.isEmpty(dbName)) {
+        switch (applicationName) {
+          case "apollo-adminservice":
+          case "apollo-configservice":
+            Assert.isTrue(dbName.toLowerCase().contains("config"), "Please configure the "
+                + "correct database name, it should be ApolloConfigDB! If you have changed the name of the"
+                + " database and want to disable the check, please set apollo.check.database-name to false!");
+            break;
+          case "apollo-portal":
+            Assert.isTrue(dbName.toLowerCase().contains("portal"), "Please configure the "
+                + "correct database name, it should be ApolloPortalDB! If you have changed the name of "
+                + "the database and want to disable the check, please set apollo.check.database-name to false!");
+            break;
+          default:
+        }
+      }
+    }
+  }
+
+  private String determineDatabaseName(String dataSourceUrl) {
+    // jdbc:mysql://127.0.0.1:3306/TestDB?a=b
+    // jdbc:mysql:///TestDB?a=b
+    String pattern = "jdbc:(?<type>[a-z]+)://((?<host>[a-zA-Z0-9-//.]+):(?<port>[0-9]+))?/(?<databaseName>[a-zA-Z0-9_]+)?";
+    Pattern namePattern = Pattern.compile(pattern);
+    Matcher dateMatcher = namePattern.matcher(dataSourceUrl);
+    return dateMatcher.find() ? dateMatcher.group("databaseName") : null;
+  }
+}

--- a/apollo-common/src/main/resources/META-INF/spring.factories
+++ b/apollo-common/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationContextInitializer=\
+com.ctrip.framework.apollo.common.initializer.ConfigValidatorInitializer

--- a/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/ConfigValidatorTest.java
+++ b/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/ConfigValidatorTest.java
@@ -1,0 +1,104 @@
+package com.ctrip.framework.apollo.common.utils;
+
+import com.ctrip.framework.apollo.common.initializer.ConfigValidatorInitializer;
+import java.util.Objects;
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+
+/**
+ * test ConfigValidator
+ *
+ * @author Lifeng Lv
+ */
+@Configuration
+@EnableConfigurationProperties
+public class ConfigValidatorTest {
+
+
+  /**
+   * validate the database name for apollo-adminservice.
+   */
+  @Test
+  public void validateAdminServiceDbNameSuccess() {
+    new ApplicationContextRunner()
+        .withBean(ConfigValidatorTest.class)
+        .withPropertyValues(
+            "spring.datasource.url = jdbc:mysql://127.0.0.1:3306/ApolloConfigDB",
+            "spring.application.name = apollo-adminservice",
+            "apollo.check.database-name = true"
+        )
+        .withInitializer(new ConfigValidatorInitializer())
+        .run(context -> {
+          Assert.notNull(context, "Startup failed!");
+          if (Objects.nonNull(context.getStartupFailure())) {
+            Assert.isNull(context.getStartupFailure(), context.getStartupFailure().getMessage());
+          }
+        });
+  }
+
+  /**
+   * validate the database name for apollo-adminservice.
+   */
+  @Test
+  public void validateAdminServiceDbNameFailed() {
+    new ApplicationContextRunner()
+        .withBean(ConfigValidatorTest.class)
+        .withPropertyValues(
+            "spring.datasource.url = jdbc:mysql://127.0.0.1:3306/TestDB?a=b",
+            "spring.application.name = apollo-adminservice"
+        )
+        .withInitializer(new ConfigValidatorInitializer())
+        .run(context -> {
+          Assert.notNull(context, "Startup failed!");
+          if (Objects.nonNull(context.getStartupFailure())) {
+            Assert.isNull(context.getStartupFailure(), context.getStartupFailure().getMessage());
+          }
+        });
+  }
+
+  /**
+   * validate the database name for apollo-configservice.
+   */
+  @Test
+  public void validateConfigServiceDbName() {
+    new ApplicationContextRunner()
+        .withBean(ConfigValidatorTest.class)
+        .withPropertyValues(
+            "spring.datasource.url = jdbc:mysql://127.0.0.1:3306/TestDB?a=b",
+            "spring.application.name = apollo-configservice"
+        )
+        .withInitializer(new ConfigValidatorInitializer())
+        .run(context -> {
+          Assert.notNull(context, "Startup failed!");
+          if (Objects.nonNull(context.getStartupFailure())) {
+            Assert.isNull(context.getStartupFailure(), context.getStartupFailure().getMessage());
+          }
+        });
+  }
+
+  /**
+   * validate the database name for apollo-portal.
+   */
+  @Test
+  public void validatePortalDbName() {
+    new ApplicationContextRunner()
+        .withBean(ConfigValidatorTest.class)
+        .withPropertyValues(
+            "spring.datasource.url = /TestDB?",
+            "spring.application.name = apollo-portal"
+        )
+        .withInitializer(new ConfigValidatorInitializer())
+        .run(context -> {
+          Assert.notNull(context, "Startup failed!");
+          if (Objects.nonNull(context.getStartupFailure())) {
+            Assert.isNull(context.getStartupFailure(), context.getStartupFailure().getMessage());
+          }
+        });
+  }
+
+}


### PR DESCRIPTION
## What's the purpose of this PR
validate the db name for all three moudles

## Which issue(s) this PR fixes:
Fixes #4230

## Brief changelog
If the database names of admin service and config service are missing 'config', or if the database name of portal service is missing 'portal', the startup will fail.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
