### PR TITLE
Replace the deprecated SHA-1 algorithm for generating open-api token

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/service/ConsumerService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/service/ConsumerService.java
@@ -250,9 +250,9 @@ public class ConsumerService {
         .getDataChangeCreatedTime(), portalConfig.consumerTokenSalt()));
   }
 
-  String generateToken(String consumerAppId, Date generationTime, String
-      consumerTokenSalt) {
-    return Hashing.sha1().hashString(KEY_JOINER.join(consumerAppId, TIMESTAMP_FORMAT.format
+  @SuppressWarnings("UnstableApiUsage")
+  String generateToken(String consumerAppId, Date generationTime, String consumerTokenSalt) {
+    return Hashing.sha256().hashString(KEY_JOINER.join(consumerAppId, TIMESTAMP_FORMAT.format
         (generationTime), consumerTokenSalt), Charsets.UTF_8).toString();
   }
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/service/ConsumerServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/service/ConsumerServiceTest.java
@@ -66,7 +66,6 @@ public class ConsumerServiceTest extends AbstractUnitTest {
   @InjectMocks
   private ConsumerService consumerService;
 
-
   private String someTokenSalt = "someTokenSalt";
   private String testAppId = "testAppId";
   private String testConsumerName = "testConsumerName";
@@ -75,7 +74,6 @@ public class ConsumerServiceTest extends AbstractUnitTest {
   @Before
   public void setUp() throws Exception {
     when(portalConfig.consumerTokenSalt()).thenReturn(someTokenSalt);
-
   }
 
   @Test
@@ -126,9 +124,11 @@ public class ConsumerServiceTest extends AbstractUnitTest {
     String someConsumerAppId = "100003171";
     Date generationTime = new GregorianCalendar(2016, Calendar.AUGUST, 9, 12, 10, 50).getTime();
     String tokenSalt = "apollo";
+    String expectedToken = "151067a53d08d70de161fa06b455623741877ce2f019f6e3018844c1a16dd8c6";
 
-    assertEquals("d0da35292dd5079eeb73cc3a5f7c0759afabd806", consumerService
-        .generateToken(someConsumerAppId, generationTime, tokenSalt));
+    String actualToken = consumerService.generateToken(someConsumerAppId, generationTime, tokenSalt);
+
+    assertEquals(expectedToken, actualToken);
   }
 
   @Test


### PR DESCRIPTION
## What's the purpose of this PR

Replace the deprecated SHA-1 algorithm for generating open-api token.

## Which issue(s) this PR fixes:
Fixes #4503

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
