### PR TITLE
fix the exception occurred when publish/rollback namespaces with grayrelease

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Apollo 2.1.0
 * [Add index for table ReleaseHistory](https://github.com/apolloconfig/apollo/pull/4550)
 * [add an option to custom oidc userDisplayName](https://github.com/apolloconfig/apollo/pull/4507)
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
+* [fix the exception occurred when publish/rollback namespaces with grayrelease](https://github.com/apolloconfig/apollo/pull/4564)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
@@ -39,6 +39,15 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -46,9 +55,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
-
-import java.lang.reflect.Type;
-import java.util.*;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -62,7 +68,7 @@ public class ReleaseService {
       .newHashSet(ReleaseOperation.GRAY_RELEASE, ReleaseOperation.MASTER_NORMAL_RELEASE_MERGE_TO_GRAY,
           ReleaseOperation.MATER_ROLLBACK_MERGE_TO_GRAY);
   private static final Pageable FIRST_ITEM = PageRequest.of(0, 1);
-  private static final Type OPERATION_CONTEXT_TYPE_REFERENCE = new TypeToken<Map<String, Collection<String>>>() { }.getType();
+  private static final Type OPERATION_CONTEXT_TYPE_REFERENCE = new TypeToken<Map<String, Object>>() { }.getType();
 
   private final ReleaseRepository releaseRepository;
   private final ItemService itemService;
@@ -329,14 +335,14 @@ public class ReleaseService {
       return null;
     }
 
-    Map<String, Collection<String>> operationContext = GSON
-        .fromJson(operationContextJson, OPERATION_CONTEXT_TYPE_REFERENCE);
+    Map<String, Object> operationContext = GSON.fromJson(operationContextJson,
+        OPERATION_CONTEXT_TYPE_REFERENCE);
 
     if (operationContext == null) {
       return null;
     }
 
-    return operationContext.get(ReleaseOperationContext.BRANCH_RELEASE_KEYS);
+    return (Collection<String>) operationContext.get(ReleaseOperationContext.BRANCH_RELEASE_KEYS);
   }
 
   private Release publishBranchNamespace(Namespace parentNamespace, Namespace childNamespace,


### PR DESCRIPTION
## What's the purpose of this PR

fix the exception occurred when publish/rollback namespaces with grayrelease

## Which issue(s) this PR fixes:
Fixes #4563

## Brief changelog

* revert the OPERATION_CONTEXT_TYPE_REFERENCE to `new TypeToken<Map<String, Object>>() { }.getType()`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
