### PR TITLE
Fix openapi query namespaces return unreleased item value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Apollo 2.1.0
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
 * [fix the exception occurred when publish/rollback namespaces with grayrelease](https://github.com/apolloconfig/apollo/pull/4564)
 * [fix create namespace with single dot 500 error](https://github.com/apolloconfig/apollo/pull/4568)
+* [fix openapi query namespaces return unreleased item value](https://github.com/apolloconfig/apollo/pull/4580)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.util.CollectionUtils;
 import com.ctrip.framework.apollo.common.dto.ClusterDTO;
 import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleDTO;
@@ -99,8 +100,9 @@ public class OpenApiBeanUtils {
     List<OpenItemDTO> items = new LinkedList<>();
     List<ItemBO> itemBOs = namespaceBO.getItems();
     if (!CollectionUtils.isEmpty(itemBOs)) {
-      items.addAll(itemBOs.stream().map(itemBO -> transformFromItemDTO(itemBO.getItem()))
-              .collect(Collectors.toList()));
+      items.addAll(itemBOs.stream()
+          .map(OpenApiBeanUtils::transformFromItemBO)
+          .collect(Collectors.toList()));
     }
     openNamespaceDTO.setItems(items);
     return openNamespaceDTO;
@@ -188,4 +190,17 @@ public class OpenApiBeanUtils {
     Preconditions.checkArgument(openClusterDTO != null);
     return BeanUtils.transform(ClusterDTO.class, openClusterDTO);
   }
+
+  public static OpenItemDTO transformFromItemBO(ItemBO itemBO) {
+    Preconditions.checkArgument(itemBO != null);
+    Preconditions.checkArgument(itemBO.getItem() != null);
+
+    OpenItemDTO openItemDTO = BeanUtils.transform(OpenItemDTO.class, itemBO.getItem());
+    // Modified unreleased, use released value
+    if (itemBO.isModified() && Strings.isNotBlank(itemBO.getOldValue())) {
+      openItemDTO.setValue(itemBO.getOldValue());
+    }
+    return openItemDTO;
+  }
+
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtilsTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.util;
+
+import static org.junit.Assert.assertEquals;
+
+import com.ctrip.framework.apollo.common.dto.ItemDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
+import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author mghio (mghio.dev@gmail.com)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OpenApiBeanUtilsTest {
+
+  @Test
+  public void testTransformFromItemBOWithUnModifiedItem() {
+    ItemBO itemBO = this.mockUnModifiedItemBO();
+
+    OpenItemDTO expectedOpenItemDTO = new OpenItemDTO();
+    expectedOpenItemDTO.setKey(itemBO.getItem().getKey());
+    expectedOpenItemDTO.setValue(itemBO.getItem().getValue());
+    expectedOpenItemDTO.setComment(itemBO.getItem().getComment());
+
+    OpenItemDTO actualOpenItemDTO = OpenApiBeanUtils.transformFromItemBO(itemBO);
+
+    assertEquals(expectedOpenItemDTO.toString(), actualOpenItemDTO.toString());
+  }
+
+  @Test
+  public void testTransformFromItemBOWithModifiedItem() {
+    ItemBO itemBO = this.mockModifiedItemBO();
+
+    OpenItemDTO expectedOpenItemDTO = new OpenItemDTO();
+    expectedOpenItemDTO.setKey(itemBO.getItem().getKey());
+    expectedOpenItemDTO.setValue(itemBO.getOldValue());
+    expectedOpenItemDTO.setComment(itemBO.getItem().getComment());
+
+    OpenItemDTO actualOpenItemDTO = OpenApiBeanUtils.transformFromItemBO(itemBO);
+
+    assertEquals(expectedOpenItemDTO.toString(), actualOpenItemDTO.toString());
+  }
+
+  private ItemBO mockUnModifiedItemBO() {
+    ItemBO itemBO = new ItemBO();
+
+    ItemDTO itemDTO = new ItemDTO("timeout", "10", "", 2);
+    itemDTO.setId(1L);
+    itemDTO.setNamespaceId(1L);
+    itemBO.setItem(itemDTO);
+
+    itemBO.setModified(false);
+    itemBO.setDeleted(false);
+    itemBO.setOldValue(null);
+    itemBO.setNewValue(null);
+
+    return itemBO;
+  }
+
+  private ItemBO mockModifiedItemBO() {
+    ItemBO itemBO = new ItemBO();
+
+    ItemDTO itemDTO = new ItemDTO("content", "{\"k1\":newv1,\"key2\":v2}", null, 1);
+    itemDTO.setId(1L);
+    itemDTO.setNamespaceId(1L);
+    itemBO.setItem(itemDTO);
+
+    itemBO.setModified(true);
+    itemBO.setDeleted(false);
+    itemBO.setOldValue("{\"k1\":v1,\"key2\":v2}");
+    itemBO.setNewValue("{\"k1\":newv1,\"key2\":v2}");
+
+    return itemBO;
+  }
+
+}


### PR DESCRIPTION
## What's the purpose of this PR

Fix openapi query namespaces return unreleased item value.

## Which issue(s) this PR fixes:
Fixes #4578

## Brief changelog

Fix openapi query namespaces return unreleased item value.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
