### PR TITLE
fix(sec): upgrade fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
 			<id>nacos-discovery</id>
 			<properties>
 				<nacos.discovery.version>0.2.7</nacos.discovery.version>
-				<fastjson.version>1.2.75</fastjson.version>
+				<fastjson.version>1.2.83</fastjson.version>
 			</properties>
 			<dependencyManagement>
 				<dependencies>


### PR DESCRIPTION
## What's the purpose of this PR

Upgrade fastjson from 1.2.75 to 1.2.83 for vulnerability fix:
- [CVE-2022-25845](https://www.oscs1024.com/hd/MPS-2022-54205)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
