### PR TITLE
fix get the openapi interface that contains namespace information for deleted items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Apollo 2.1.0
 * [fix create namespace with single dot 500 error](https://github.com/apolloconfig/apollo/pull/4568)
 * [Add nodejs client sdk and fix doc](https://github.com/apolloconfig/apollo/pull/4590)
 * [Move apollo-core, apollo-client, apollo-mockserver, apollo-openapi and apollo-client-config-data to apollo-java repo](https://github.com/apolloconfig/apollo/pull/4594)
+* [fix get the openapi interface that contains namespace information for deleted items](https://github.com/apolloconfig/apollo/pull/4596)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerNamespaceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerNamespaceOpenApiService.java
@@ -71,7 +71,7 @@ public class ServerNamespaceOpenApiService implements NamespaceOpenApiService {
   public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
     return OpenApiBeanUtils
         .batchTransformFromNamespaceBOs(namespaceService.findNamespaceBOs(appId, Env
-            .valueOf(env), clusterName));
+            .valueOf(env), clusterName, false));
   }
 
   @Override

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerNamespaceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerNamespaceOpenApiService.java
@@ -60,7 +60,7 @@ public class ServerNamespaceOpenApiService implements NamespaceOpenApiService {
   public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName,
       String namespaceName) {
     NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(appId, Env.valueOf
-        (env), clusterName, namespaceName);
+        (env), clusterName, namespaceName, false);
     if (namespaceBO == null) {
       return null;
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConfigsExportController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConfigsExportController.java
@@ -93,7 +93,7 @@ public class ConfigsExportController {
     }
 
     NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(appId, Env.valueOf
-        (env), clusterName, namespaceName);
+        (env), clusterName, namespaceName, false);
 
     //generate a file.
     res.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + fileName);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ConfigsExportService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ConfigsExportService.java
@@ -235,7 +235,7 @@ public class ConfigsExportService {
                                 ZipOutputStream zipOutputStream) {
     String clusterName = exportCluster.getName();
 
-    List<NamespaceBO> namespaceBOS = namespaceService.findNamespaceBOs(exportApp.getAppId(), env, clusterName);
+    List<NamespaceBO> namespaceBOS = namespaceService.findNamespaceBOs(exportApp.getAppId(), env, clusterName, false);
 
     if (CollectionUtils.isEmpty(namespaceBOS)) {
       return;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -250,7 +250,7 @@ public class NamespaceService {
   }
 
   public NamespaceBO loadNamespaceBO(String appId, Env env, String clusterName,
-          String namespaceName, boolean includeDeletedItems) {
+      String namespaceName, boolean includeDeletedItems) {
     NamespaceDTO namespace = namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName);
     if (namespace == null) {
       throw new BadRequestException("namespaces not exist");

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -186,7 +186,7 @@ public class NamespaceService {
   /**
    * load cluster all namespace info with items
    */
-  public List<NamespaceBO> findNamespaceBOs(String appId, Env env, String clusterName) {
+  public List<NamespaceBO> findNamespaceBOs(String appId, Env env, String clusterName, boolean includeDeletedItems) {
 
     List<NamespaceDTO> namespaces = namespaceAPI.findNamespaceByCluster(appId, env, clusterName);
     if (namespaces == null || namespaces.size() == 0) {
@@ -200,7 +200,7 @@ public class NamespaceService {
       executorService.submit(() -> {
         NamespaceBO namespaceBO;
         try {
-          namespaceBO = transformNamespace2BO(env, namespace);
+          namespaceBO = transformNamespace2BO(env, namespace, includeDeletedItems);
           namespaceBOs.add(namespaceBO);
         } catch (Exception e) {
           LOGGER.error("parse namespace error. app id:{}, env:{}, clusterName:{}, namespace:{}",
@@ -226,6 +226,10 @@ public class NamespaceService {
     return namespaceBOs.stream()
         .sorted(Comparator.comparing(o -> o.getBaseInfo().getId()))
         .collect(Collectors.toList());
+  }
+
+  public List<NamespaceBO> findNamespaceBOs(String appId, Env env, String clusterName) {
+    return findNamespaceBOs(appId, env, clusterName, true);
   }
 
   public List<NamespaceDTO> findNamespaces(String appId, Env env, String clusterName) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -246,12 +246,17 @@ public class NamespaceService {
   }
 
   public NamespaceBO loadNamespaceBO(String appId, Env env, String clusterName,
-      String namespaceName) {
+          String namespaceName, boolean includeDeletedItems) {
     NamespaceDTO namespace = namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName);
     if (namespace == null) {
       throw new BadRequestException("namespaces not exist");
     }
-    return transformNamespace2BO(env, namespace);
+    return transformNamespace2BO(env, namespace, includeDeletedItems);
+  }
+
+  public NamespaceBO loadNamespaceBO(String appId, Env env, String clusterName,
+      String namespaceName) {
+    return loadNamespaceBO(appId, env, clusterName, namespaceName, true);
   }
 
   public boolean publicAppNamespaceHasAssociatedNamespace(String publicNamespaceName, Env env) {
@@ -284,7 +289,7 @@ public class NamespaceService {
     return result;
   }
 
-  private NamespaceBO transformNamespace2BO(Env env, NamespaceDTO namespace) {
+  private NamespaceBO transformNamespace2BO(Env env, NamespaceDTO namespace, boolean includeDeletedItems) {
     NamespaceBO namespaceBO = new NamespaceBO();
     namespaceBO.setBaseInfo(namespace);
 
@@ -322,18 +327,24 @@ public class NamespaceService {
       itemBOs.add(itemBO);
     }
 
-    //deleted items
-    itemService.findDeletedItems(appId, env, clusterName, namespaceName).forEach(item -> {
-      deletedItemDTOs.put(item.getKey(),item);
-    });
+    if (includeDeletedItems) {
+      //deleted items
+      itemService.findDeletedItems(appId, env, clusterName, namespaceName).forEach(item -> {
+        deletedItemDTOs.put(item.getKey(), item);
+      });
 
-    List<ItemBO> deletedItems = parseDeletedItems(items, releaseItems, deletedItemDTOs);
-    itemBOs.addAll(deletedItems);
-    modifiedItemCnt += deletedItems.size();
+      List<ItemBO> deletedItems = parseDeletedItems(items, releaseItems, deletedItemDTOs);
+      itemBOs.addAll(deletedItems);
+      modifiedItemCnt += deletedItems.size();
+    }
 
     namespaceBO.setItemModifiedCnt(modifiedItemCnt);
 
     return namespaceBO;
+  }
+
+  private NamespaceBO transformNamespace2BO(Env env, NamespaceDTO namespace) {
+    return transformNamespace2BO(env, namespace, true);
   }
 
   private void fillAppNamespaceProperties(NamespaceBO namespace) {

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigsExportServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigsExportServiceTest.java
@@ -147,10 +147,10 @@ public class ConfigsExportServiceTest extends AbstractUnitTest {
     when(permissionValidator.isAppAdmin(any())).thenReturn(true);
     when(clusterService.findClusters(env, appId1)).thenReturn(app1Clusters);
     when(clusterService.findClusters(env, appId2)).thenReturn(app2Clusters);
-    when(namespaceService.findNamespaceBOs(appId1, Env.DEV, clusterName1)).thenReturn(app1Cluster1Namespace);
-    when(namespaceService.findNamespaceBOs(appId1, Env.DEV, clusterName2)).thenReturn(app1Cluster2Namespace);
-    when(namespaceService.findNamespaceBOs(appId2, Env.DEV, clusterName1)).thenReturn(app2Cluster1Namespace);
-    when(namespaceService.findNamespaceBOs(appId2, Env.DEV, clusterName2)).thenReturn(app2Cluster2Namespace);
+    when(namespaceService.findNamespaceBOs(appId1, Env.DEV, clusterName1, false)).thenReturn(app1Cluster1Namespace);
+    when(namespaceService.findNamespaceBOs(appId1, Env.DEV, clusterName2, false)).thenReturn(app1Cluster2Namespace);
+    when(namespaceService.findNamespaceBOs(appId2, Env.DEV, clusterName1, false)).thenReturn(app2Cluster1Namespace);
+    when(namespaceService.findNamespaceBOs(appId2, Env.DEV, clusterName2, false)).thenReturn(app2Cluster2Namespace);
 
     FileOutputStream fileOutputStream = new FileOutputStream("/tmp/apollo.zip");
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mock;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -258,8 +259,17 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     deletedItemDTOList.add(deletedItemDTO);
     when(itemService.findDeletedItems(any(), any(), any(), any())).thenReturn(deletedItemDTOList);
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
-    assertThat(namespaceBO.getItemModifiedCnt()).isEqualTo(3);
+    NamespaceBO namespaceBO1 = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+    List<String> namespaceKey1 = namespaceBO1.getItems().stream().map(s -> s.getItem().getKey()).collect(Collectors.toList());
+    assertThat(namespaceBO1.getItemModifiedCnt()).isEqualTo(3);
+    assertThat(namespaceBO1.getItems().size()).isEqualTo(3);
+    assertThat(namespaceKey1).isEqualTo(Arrays.asList("k1", "k2", "k3"));
+
+    NamespaceBO namespaceBO2 = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, false);
+    List<String> namespaceKey2 = namespaceBO2.getItems().stream().map(s -> s.getItem().getKey()).collect(Collectors.toList());
+    assertThat(namespaceBO2.getItemModifiedCnt()).isEqualTo(2);
+    assertThat(namespaceBO2.getItems().size()).isEqualTo(2);
+    assertThat(namespaceKey2).isEqualTo(Arrays.asList("k1", "k2"));
   }
 
   private AppNamespace createAppNamespace(String appId, String name, boolean isPublic) {

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -223,6 +224,43 @@ public class NamespaceServiceTest extends AbstractUnitTest {
 
   }
 
+  @Test
+  public void testLoadNamespaceBO() {
+    String branchName = "branch";
+    NamespaceDTO namespaceDTO = createNamespace(testAppId, branchName, testNamespaceName);
+    when(namespaceAPI.loadNamespace(any(), any(), any(), any())).thenReturn(namespaceDTO);
+
+    ReleaseDTO releaseDTO = new ReleaseDTO();
+    releaseDTO.setConfigurations("{\"k1\":\"k1\",\"k2\":\"k2\", \"k3\":\"\"}");
+    when(releaseService.loadLatestRelease(any(), any(), any(), any())).thenReturn(releaseDTO);
+
+    List<ItemDTO> itemDTOList = Lists.newArrayList();
+    ItemDTO itemDTO1 = new ItemDTO();
+    itemDTO1.setId(1);
+    itemDTO1.setNamespaceId(1);
+    itemDTO1.setKey("k1");
+    itemDTO1.setValue(String.valueOf(1));
+    itemDTOList.add(itemDTO1);
+
+    ItemDTO itemDTO2 = new ItemDTO();
+    itemDTO2.setId(1);
+    itemDTO2.setNamespaceId(2);
+    itemDTO2.setKey("k2");
+    itemDTO2.setValue(String.valueOf(2));
+    itemDTOList.add(itemDTO2);
+    when(itemService.findItems(any(), any(), any(), any())).thenReturn(itemDTOList);
+
+    List<ItemDTO> deletedItemDTOList = Lists.newArrayList();
+    ItemDTO deletedItemDTO = new ItemDTO();
+    deletedItemDTO.setId(3);
+    deletedItemDTO.setNamespaceId(3);
+    deletedItemDTO.setKey("k3");
+    deletedItemDTOList.add(deletedItemDTO);
+    when(itemService.findDeletedItems(any(), any(), any(), any())).thenReturn(deletedItemDTOList);
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+    assertThat(namespaceBO.getItemModifiedCnt()).isEqualTo(3);
+  }
 
   private AppNamespace createAppNamespace(String appId, String name, boolean isPublic) {
     AppNamespace instance = new AppNamespace();

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -243,7 +243,7 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     itemDTOList.add(itemDTO1);
 
     ItemDTO itemDTO2 = new ItemDTO();
-    itemDTO2.setId(1);
+    itemDTO2.setId(2);
     itemDTO2.setNamespaceId(2);
     itemDTO2.setKey("k2");
     itemDTO2.setValue(String.valueOf(2));


### PR DESCRIPTION
## What's the purpose of this PR
fix get the openapi interface that contains namespace information for deleted items.


## Which issue(s) this PR fixes:
Fixes #4593

## Brief changelog
fix get the openapi interface that contains namespace information for deleted items

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
