### PR TITLE
fix flaky test in apollo-biz

### DIFF
--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/entity/JpaMapFieldJsonConverterTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/entity/JpaMapFieldJsonConverterTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
@@ -58,7 +59,7 @@ class JpaMapFieldJsonConverterTest {
 
   @Test
   void convertToDatabaseColumn_twoElement() throws IOException {
-    Map<String, String> map = new HashMap<>(8);
+    Map<String, String> map = new LinkedHashMap<>(8);
     map.put("a", "1");
     map.put("disableCheck", "true");
 


### PR DESCRIPTION
## What's the purpose of this PR

Fix flaky junit test in apollo-biz

## Which issue(s) this PR fixes:
#4617 

## Brief changelog
`HashMap` does not guarantee the order of the elements which can cause the junit test case to fail, hence using a `LinkedHashMap`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).


