### PR TITLE
Fix the problem of deleting blank items appear at the end#4654

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Apollo 2.1.0
 * [fix Grayscale release Item Value length limit can not be synchronized with its main version](https://github.com/apolloconfig/apollo/pull/4622)
 * [feat: use can change spring.profiles.active's value without rebuild project](https://github.com/apolloconfig/apollo/pull/4616)
 * [refactor: remove app.properties and move some config file's location](https://github.com/apolloconfig/apollo/pull/4637)
+* [Fix the problem of deleting blank items appear at the end](https://github.com/apolloconfig/apollo/pull/4662)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/11?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolver.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/txtresolver/PropertyResolver.java
@@ -194,8 +194,9 @@ public class PropertyResolver implements ConfigTextResolver {
 
       //1. old is blank by now is not
       //2.old is comment by now is not exist or modified
+      //3.old is blank by now is not exist or modified
       if ((isBlankItem(oldItem) && !isBlankItem(newItem))
-          || isCommentItem(oldItem) && (newItem == null || !newItem.equals(oldItem.getComment()))) {
+              || (isCommentItem(oldItem) || isBlankItem(oldItem)) && (newItem == null || !newItem.equals(oldItem.getComment()))) {
         changeSets.addDeleteItem(oldItem);
       }
     }


### PR DESCRIPTION
## What's the purpose of this PR

Fix the problem of deleting blank items appear at the end.

## Which issue(s) this PR fixes:
Fixes #4654

## Brief changelog
1.delete blank item then it'll appear at the end
<img width="815" alt="image" src="https://user-images.githubusercontent.com/20056551/204083628-a10a26d9-da97-4f86-a56a-a0a6073e9df7.png">
<img width="870" alt="image" src="https://user-images.githubusercontent.com/20056551/204083659-aa1ca5c8-3643-4ccb-8ae9-b98c160ac524.png">


XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
