### PR TITLE
clean up pom and upgrade xstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 		<nacos-discovery-api.version>1.4.0</nacos-discovery-api.version>
 		<common-lang3.version>3.12.0</common-lang3.version>
 		<mysql-connector-java.version>8.0.29</mysql-connector-java.version>
-		<cat.client.version>3.1.0</cat.client.version>
 		<!-- Plugins Version -->
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -103,11 +102,6 @@
 			<dependency>
 				<groupId>com.ctrip.framework.apollo</groupId>
 				<artifactId>apollo-core</artifactId>
-				<version>${apollo-java.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.ctrip.framework.apollo</groupId>
-				<artifactId>apollo-client</artifactId>
 				<version>${apollo-java.version}</version>
 			</dependency>
 			<dependency>
@@ -176,16 +170,11 @@
 				<artifactId>commons-lang3</artifactId>
 				<version>${common-lang3.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>com.dianping.cat</groupId>
-				<artifactId>cat-client</artifactId>
-				<version>${cat.client.version}</version>
-			</dependency>
-			<!-- to fix CVE-2020-26217 -->
+			<!-- to fix CVE-2022-41966 -->
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>
 				<artifactId>xstream</artifactId>
-				<version>1.4.19</version>
+				<version>1.4.20</version>
 			</dependency>
 			<!--for test -->
 			<dependency>


### PR DESCRIPTION
## What's the purpose of this PR

clean up pom and upgrade xstream version

## Brief changelog

* remove cat-client and apollo-client from dependencyManagement as they are not used anymore after apollo-client and apollo-demo modules were moved to a standalone repository
* upgrade xstream to 1.4.20 to fix CVE-2022-41966

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
