### PR TITLE
Bump springcloud springboot version to solve cve problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Apollo 2.2.0
 
 ------------------
 * [Fix the problem of inconsistent length of appId column](https://github.com/apolloconfig/apollo/pull/4725)
+* [Bump springcloud springboot version to solve cve problems](https://github.com/apolloconfig/apollo/pull/4712)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,8 @@
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<apollo-java.version>2.1.0</apollo-java.version>
-		<spring-boot.version>2.6.8</spring-boot.version>
-		<spring-cloud.version>2021.0.2</spring-cloud.version>
-		<spring-security.version>5.7.3</spring-security.version>
+		<spring-boot.version>2.7.8</spring-boot.version>
+		<spring-cloud.version>2021.0.5</spring-cloud.version>
 		<jaxb.version>2.3.1</jaxb.version>
 		<javax.activation.version>1.1.1</javax.activation.version>
 		<javax.mail.version>1.6.2</javax.mail.version>
@@ -200,14 +199,6 @@
 				<artifactId>system-lambda</artifactId>
 				<version>1.2.0</version>
 				<scope>test</scope>
-			</dependency>
-			<!-- Spring-security BOMs -->
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-bom</artifactId>
-				<version>${spring-security.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
 			</dependency>
 			<!-- declare Spring BOMs in order -->
 			<dependency>


### PR DESCRIPTION
## What's the purpose of this PR
Bump springcloud springboot version to solve cve problems

## Brief changelog
- Bump springcloud version from 2021.0.2 to 2021.0.5
- Bump springboot version from 2.6.8 to 2.7.8


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
