### PR TITLE
fix: PULL_REQUEST_TEMPLATE.md old url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@ XXXXX
 
 Follow this checklist to help us incorporate your contribution quickly and easily:
 
-- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
+- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Write necessary unit tests to verify the code.
 - [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
-- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
+- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


### PR DESCRIPTION
## What's the purpose of this PR

Update the link address of the contribution guide and change document in the PR template.

Old link
```
  https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md
  https://github.com/ctripcorp/apollo/blob/master/CHANGES.md
```
Replace with new link

```
  https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md
  https://github.com/apolloconfig/apollo/blob/master/CHANGES.md
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [X] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
