### PR TITLE
[Multi-Database Support] Without Reliance on boolean integer compare

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Apollo 2.2.0
 * [rename mysql-connector-java to mysql-connector-j](https://github.com/apolloconfig/apollo/pull/4748)
 * [Bump springboot version from 2.7.8 to 2.7.9](https://github.com/apolloconfig/apollo/pull/4750)
 * [[Multi-Database Support] Without Reliance on globally_quoted_identifiers Variable](https://github.com/apolloconfig/apollo/pull/4749)
+* [[Multi-Database Support] Without Reliance on boolean integer compare](https://github.com/apolloconfig/apollo/pull/4757)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
@@ -26,8 +26,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "AccessKey")
-@SQLDelete(sql = "Update AccessKey set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update AccessKey set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class AccessKey extends BaseEntity {
 
   @Column(name = "appId", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Audit.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Audit.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Audit")
-@SQLDelete(sql = "Update Audit set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Audit set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Audit extends BaseEntity {
 
   public enum OP {

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Cluster.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Cluster.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "Cluster")
-@SQLDelete(sql = "Update Cluster set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Cluster set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Cluster extends BaseEntity implements Comparable<Cluster> {
 
   @Column(name = "Name", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Commit.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Commit.java
@@ -28,8 +28,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Commit")
-@SQLDelete(sql = "Update Commit set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Commit set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Commit extends BaseEntity {
 
   @Lob

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/GrayReleaseRule.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/GrayReleaseRule.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "GrayReleaseRule")
-@SQLDelete(sql = "Update GrayReleaseRule set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update GrayReleaseRule set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class GrayReleaseRule extends BaseEntity{
 
   @Column(name = "appId", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
@@ -28,8 +28,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Item")
-@SQLDelete(sql = "Update Item set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Item set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Item extends BaseEntity {
 
   @Column(name = "NamespaceId", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Namespace.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Namespace.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "`Namespace`")
-@SQLDelete(sql = "Update Namespace set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Namespace set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Namespace extends BaseEntity {
 
   @Column(name = "appId", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/NamespaceLock.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/NamespaceLock.java
@@ -26,7 +26,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "NamespaceLock")
-@Where(clause = "isDeleted = 0")
+@Where(clause = "isDeleted = false")
 public class NamespaceLock extends BaseEntity{
 
   @Column(name = "NamespaceId")

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Privilege.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Privilege.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Privilege")
-@SQLDelete(sql = "Update Privilege set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Privilege set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Privilege extends BaseEntity {
 
   @Column(name = "Name", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Release.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Release.java
@@ -31,8 +31,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "`Release`")
-@SQLDelete(sql = "Update Release set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Release set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Release extends BaseEntity {
   @Column(name = "ReleaseKey", nullable = false)
   private String releaseKey;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ReleaseHistory.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ReleaseHistory.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "ReleaseHistory")
-@SQLDelete(sql = "Update ReleaseHistory set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update ReleaseHistory set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class ReleaseHistory extends BaseEntity {
   @Column(name = "AppId", nullable = false)
   private String appId;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ServerConfig.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ServerConfig.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "ServerConfig")
-@SQLDelete(sql = "Update ServerConfig set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update ServerConfig set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class ServerConfig extends BaseEntity {
   @Column(name = "`Key`", nullable = false)
   private String key;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AppNamespaceRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AppNamespaceRepository.java
@@ -43,10 +43,10 @@ public interface AppNamespaceRepository extends PagingAndSortingRepository<AppNa
   List<AppNamespace> findFirst500ByIdGreaterThanOrderByIdAsc(long id);
 
   @Modifying
-  @Query("UPDATE AppNamespace SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and IsDeleted = 0")
+  @Query("UPDATE AppNamespace SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and isDeleted = false")
   int batchDeleteByAppId(String appId, String operator);
 
   @Modifying
-  @Query("UPDATE AppNamespace SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 WHERE AppId=?1 and Name = ?2 and IsDeleted = 0")
+  @Query("UPDATE AppNamespace SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 WHERE AppId=?1 and Name = ?2 and isDeleted = false")
   int delete(String appId, String namespaceName, String operator);
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/CommitRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/CommitRepository.java
@@ -35,7 +35,7 @@ public interface CommitRepository extends PagingAndSortingRepository<Commit, Lon
       String appId, String clusterName, String namespaceName, Date dataChangeLastModifiedTime, Pageable pageable);
 
   @Modifying
-  @Query("update Commit set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and IsDeleted = 0")
+  @Query("update Commit set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and isDeleted = false")
   int batchDelete(String appId, String clusterName, String namespaceName, String operator);
 
   List<Commit> findByAppIdAndClusterNameAndNamespaceNameAndChangeSetsLikeOrderByIdDesc(String appId, String clusterName, String namespaceName,String changeSets, Pageable page);

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ItemRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ItemRepository.java
@@ -44,7 +44,7 @@ public interface ItemRepository extends PagingAndSortingRepository<Item, Long> {
   Item findFirst1ByNamespaceIdOrderByLineNumDesc(Long namespaceId);
 
   @Modifying
-  @Query("update Item set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 where namespaceId = ?1 and IsDeleted = 0")
+  @Query("update Item set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 where namespaceId = ?1 and isDeleted = false")
   int deleteByNamespaceId(long namespaceId, String operator);
 
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/NamespaceRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/NamespaceRepository.java
@@ -33,7 +33,7 @@ public interface NamespaceRepository extends PagingAndSortingRepository<Namespac
   Namespace findByAppIdAndClusterNameAndNamespaceName(String appId, String clusterName, String namespaceName);
 
   @Modifying
-  @Query("update Namespace set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 where appId=?1 and clusterName=?2 and IsDeleted = 0")
+  @Query("update Namespace set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 where appId=?1 and clusterName=?2 and isDeleted = false")
   int batchDelete(String appId, String clusterName, String operator);
 
   List<Namespace> findByAppIdAndNamespaceNameOrderByIdAsc(String appId, String namespaceName);

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRepository.java
@@ -39,7 +39,7 @@ public interface ReleaseHistoryRepository extends PagingAndSortingRepository<Rel
   Page<ReleaseHistory> findByReleaseIdAndOperationInOrderByIdDesc(long releaseId, Set<Integer> operations, Pageable pageable);
 
   @Modifying
-  @Query("update ReleaseHistory set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and IsDeleted = 0")
+  @Query("update ReleaseHistory set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and isDeleted = false")
   int batchDelete(String appId, String clusterName, String namespaceName, String operator);
 
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
@@ -48,7 +48,7 @@ public interface ReleaseRepository extends PagingAndSortingRepository<Release, L
   List<Release> findByIdIn(Set<Long> releaseIds);
 
   @Modifying
-  @Query("update Release set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and IsDeleted = 0")
+  @Query("update Release set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?4 where appId=?1 and clusterName=?2 and namespaceName = ?3 and isDeleted = false")
   int batchDelete(String appId, String clusterName, String namespaceName, String operator);
 
   // For release history conversion program, need to delete after conversion it done

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/App.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/App.java
@@ -28,8 +28,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "App")
-@SQLDelete(sql = "Update App set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update App set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class App extends BaseEntity {
 
   @NotBlank(message = "Name cannot be blank")

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/AppNamespace.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/AppNamespace.java
@@ -31,8 +31,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "`AppNamespace`")
-@SQLDelete(sql = "Update AppNamespace set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update AppNamespace set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class AppNamespace extends BaseEntity {
 
   @NotBlank(message = "AppNamespace Name cannot be blank")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/Consumer.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/Consumer.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Consumer")
-@SQLDelete(sql = "Update Consumer set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Consumer set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Consumer extends BaseEntity {
 
   @Column(name = "Name", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerRole.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerRole.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "ConsumerRole")
-@SQLDelete(sql = "Update ConsumerRole set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update ConsumerRole set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class ConsumerRole extends BaseEntity {
   @Column(name = "ConsumerId", nullable = false)
   private long consumerId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerToken.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerToken.java
@@ -32,8 +32,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "ConsumerToken")
-@SQLDelete(sql = "Update ConsumerToken set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update ConsumerToken set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class ConsumerToken extends BaseEntity {
   @Column(name = "ConsumerId", nullable = false)
   private long consumerId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/repository/ConsumerRoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/repository/ConsumerRoleRepository.java
@@ -43,6 +43,6 @@ public interface ConsumerRoleRepository extends PagingAndSortingRepository<Consu
   ConsumerRole findByConsumerIdAndRoleId(long consumerId, long roleId);
 
   @Modifying
-  @Query("UPDATE ConsumerRole SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE RoleId in ?1 and IsDeleted = 0")
+  @Query("UPDATE ConsumerRole SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE RoleId in ?1 and isDeleted = false")
   Integer batchDeleteByRoleIds(List<Long> roleIds, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Favorite.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Favorite.java
@@ -27,8 +27,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "Favorite")
-@SQLDelete(sql = "Update Favorite set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Favorite set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Favorite extends BaseEntity {
 
   @Column(name = "AppId", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Permission.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Permission.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "Permission")
-@SQLDelete(sql = "Update Permission set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Permission set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Permission extends BaseEntity {
   @Column(name = "PermissionType", nullable = false)
   private String permissionType;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Role.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Role.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "Role")
-@SQLDelete(sql = "Update Role set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update Role set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class Role extends BaseEntity {
   @Column(name = "RoleName", nullable = false)
   private String roleName;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/RolePermission.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/RolePermission.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "RolePermission")
-@SQLDelete(sql = "Update RolePermission set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update RolePermission set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class RolePermission extends BaseEntity {
   @Column(name = "RoleId", nullable = false)
   private long roleId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
@@ -31,8 +31,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "ServerConfig")
-@SQLDelete(sql = "Update ServerConfig set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update ServerConfig set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class ServerConfig extends BaseEntity {
   @NotBlank(message = "ServerConfig.Key cannot be blank")
   @Column(name = "`Key`", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/UserRole.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/UserRole.java
@@ -30,8 +30,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "UserRole")
-@SQLDelete(sql = "Update UserRole set IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "Update UserRole set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
+@Where(clause = "isDeleted = false")
 public class UserRole extends BaseEntity {
   @Column(name = "UserId", nullable = false)
   private String userId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
@@ -35,10 +35,10 @@ public interface AppNamespaceRepository extends PagingAndSortingRepository<AppNa
   List<AppNamespace> findByAppId(String appId);
 
   @Modifying
-  @Query("UPDATE AppNamespace SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy=?2 WHERE AppId=?1 and IsDeleted = 0")
+  @Query("UPDATE AppNamespace SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy=?2 WHERE AppId=?1 and isDeleted = false")
   int batchDeleteByAppId(String appId, String operator);
 
   @Modifying
-  @Query("UPDATE AppNamespace SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 WHERE AppId=?1 and Name = ?2 and IsDeleted = 0")
+  @Query("UPDATE AppNamespace SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?3 WHERE AppId=?1 and Name = ?2 and isDeleted = false")
   int delete(String appId, String namespaceName, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppRepository.java
@@ -41,6 +41,6 @@ public interface AppRepository extends PagingAndSortingRepository<App, Long> {
   Page<App> findByAppIdContainingOrNameContaining(String appId, String name, Pageable pageable);
 
   @Modifying
-  @Query("UPDATE App SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and IsDeleted = 0")
+  @Query("UPDATE App SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and isDeleted = false")
   int deleteApp(String appId, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/FavoriteRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/FavoriteRepository.java
@@ -36,6 +36,6 @@ public interface FavoriteRepository extends PagingAndSortingRepository<Favorite,
   Favorite findByUserIdAndAppId(String userId, String appId);
 
   @Modifying
-  @Query("UPDATE Favorite SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and IsDeleted = 0")
+  @Query("UPDATE Favorite SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE AppId=?1 and isDeleted = false")
   int batchDeleteByAppId(String appId, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
@@ -47,6 +47,6 @@ public interface PermissionRepository extends PagingAndSortingRepository<Permiss
   List<Long> findPermissionIdsByAppIdAndNamespace(String appId, String namespaceName);
 
   @Modifying
-  @Query("UPDATE Permission SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and IsDeleted = 0")
+  @Query("UPDATE Permission SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and isDeleted = false")
   Integer batchDelete(List<Long> permissionIds, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RolePermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RolePermissionRepository.java
@@ -36,6 +36,6 @@ public interface RolePermissionRepository extends PagingAndSortingRepository<Rol
   List<RolePermission> findByRoleIdIn(Collection<Long> roleId);
 
   @Modifying
-  @Query("UPDATE RolePermission SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE PermissionId in ?1 and IsDeleted = 0")
+  @Query("UPDATE RolePermission SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE PermissionId in ?1 and isDeleted = false")
   Integer batchDeleteByPermissionIds(List<Long> permissionIds, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
@@ -43,6 +43,6 @@ public interface RoleRepository extends PagingAndSortingRepository<Role, Long> {
   List<Long> findRoleIdsByAppIdAndNamespace(String appId, String namespaceName);
 
   @Modifying
-  @Query("UPDATE Role SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and IsDeleted = 0")
+  @Query("UPDATE Role SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and isDeleted = false")
   Integer batchDelete(List<Long> roleIds, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/UserRoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/UserRoleRepository.java
@@ -45,7 +45,7 @@ public interface UserRoleRepository extends PagingAndSortingRepository<UserRole,
   List<UserRole> findByUserIdInAndRoleId(Collection<String> userId, long roleId);
 
   @Modifying
-  @Query("UPDATE UserRole SET IsDeleted = 1, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE RoleId in ?1 and IsDeleted = 0")
+  @Query("UPDATE UserRole SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE RoleId in ?1 and isDeleted = false")
   Integer batchDeleteByRoleIds(List<Long> roleIds, String operator);
 
 }


### PR DESCRIPTION
## What's the purpose of this PR
Comparing **INTEGER** type to **BOOLEAN** type is not supported by h2 database. We should avoid using this feature.


Tested on my laptop.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
