### PR TITLE
[Multi-Database Support] Move common datasource config to application.properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Apollo 2.2.0
 * [Bump springboot version from 2.7.8 to 2.7.9](https://github.com/apolloconfig/apollo/pull/4750)
 * [[Multi-Database Support] Without Reliance on globally_quoted_identifiers Variable](https://github.com/apolloconfig/apollo/pull/4749)
 * [[Multi-Database Support] Without Reliance on boolean integer compare](https://github.com/apolloconfig/apollo/pull/4757)
+* [[Multi-Database Support] Move common datasource config to application.properties](https://github.com/apolloconfig/apollo/pull/4761)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/apollo-adminservice/src/main/resources/application-github.properties
+++ b/apollo-adminservice/src/main/resources/application-github.properties
@@ -14,6 +14,4 @@
 # limitations under the License.
 #
 # DataSource
-spring.datasource.url = ${spring_datasource_url}
-spring.datasource.username = ${spring_datasource_username}
-spring.datasource.password = ${spring_datasource_password}
+spring.datasource.hikari.connection-init-sql= "set names utf8mb4"

--- a/apollo-adminservice/src/main/resources/application.yml
+++ b/apollo-adminservice/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
       enabled: false
     zookeeper:
       enabled: false
+  datasource:
+    url: ${spring_datasource_url}
+    username: ${spring_datasource_username}
+    password: ${spring_datasource_password}
   jpa:
     properties:
       hibernate:

--- a/apollo-common/src/main/resources/application.yaml
+++ b/apollo-common/src/main/resources/application.yaml
@@ -31,10 +31,6 @@ spring:
   mvc:
     converters:
       preferred-json-mapper: gson
-  # DataSource
-  datasource:
-    hikari:
-      connectionInitSql: set names utf8mb4
 
 # Tomcat configuration
 server:

--- a/apollo-configservice/src/main/resources/application-github.properties
+++ b/apollo-configservice/src/main/resources/application-github.properties
@@ -14,6 +14,3 @@
 # limitations under the License.
 #
 # DataSource
-spring.datasource.url = ${spring_datasource_url}
-spring.datasource.username = ${spring_datasource_username}
-spring.datasource.password = ${spring_datasource_password}

--- a/apollo-configservice/src/main/resources/application.yml
+++ b/apollo-configservice/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
       enabled: false
     zookeeper:
       enabled: false
+  datasource:
+    url: ${spring_datasource_url}
+    username: ${spring_datasource_username}
+    password: ${spring_datasource_password}
   jpa:
     properties:
       hibernate:

--- a/apollo-portal/src/main/resources/application-github.properties
+++ b/apollo-portal/src/main/resources/application-github.properties
@@ -14,6 +14,3 @@
 # limitations under the License.
 #
 # DataSource
-spring.datasource.url = ${spring_datasource_url}
-spring.datasource.username = ${spring_datasource_username}
-spring.datasource.password = ${spring_datasource_password}

--- a/apollo-portal/src/main/resources/application.yml
+++ b/apollo-portal/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
     name: apollo-portal
   profiles:
     active: ${apollo_profile}
+  datasource:
+    url: ${spring_datasource_url}
+    username: ${spring_datasource_username}
+    password: ${spring_datasource_password}
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## Brief changelog
Move common datasource config to application.properties, jdbcurl is a common config for different databses

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
