### PR TITLE
[Multi-Database Support][h2] add h2 init sql

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Apollo 2.2.0
 * [Fix OIDC logout unnecessary redirect](https://github.com/apolloconfig/apollo/pull/4773)
 * [[Multi-Database Support] Introduce h2 postgre profile properties to let user config database config](https://github.com/apolloconfig/apollo/pull/4766)
 * [[Multi-Database Support] Optimize column define case sensitivity](https://github.com/apolloconfig/apollo/pull/4776)
+* [[Multi-Database Support][h2] add h2 init sql](https://github.com/apolloconfig/apollo/pull/4775)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/BizDBPropertySource.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/BizDBPropertySource.java
@@ -57,7 +57,7 @@ public class BizDBPropertySource extends RefreshablePropertySource {
   }
 
   @Override
-  protected void refresh() {
+  public void refresh() {
     Iterable<ServerConfig> dbConfigs = serverConfigRepository.findAll();
 
     Map<String, Object> newConfigs = Maps.newHashMap();

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/config/RefreshablePropertySource.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/config/RefreshablePropertySource.java
@@ -35,6 +35,6 @@ public abstract class RefreshablePropertySource extends MapPropertySource {
   /**
    * refresh property
    */
-  protected abstract void refresh();
+  public abstract void refresh();
 
 }

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/jpa/h2/ConfigH2InitService.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/jpa/h2/ConfigH2InitService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.configservice.service.jpa.h2;
+
+import com.ctrip.framework.apollo.biz.service.BizDBPropertySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
+@Configuration
+@Profile("h2")
+public class ConfigH2InitService {
+
+    @Autowired
+    private BizDBPropertySource dbPropertySource;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @PostConstruct
+    public void runSqlScript() throws Exception {
+        Resource resource = new ClassPathResource("jpa/init.h2.sql");
+        DatabasePopulatorUtils.execute(new ResourceDatabasePopulator(resource), dataSource);
+        dbPropertySource.refresh();
+    }
+}

--- a/apollo-configservice/src/main/resources/jpa/init.h2.sql
+++ b/apollo-configservice/src/main/resources/jpa/init.h2.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2023 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+INSERT INTO "ServerConfig" ("Key", "Cluster", "Value", "Comment", "DataChange_CreatedBy", "DataChange_CreatedTime")
+VALUES
+    ('eureka.service.url', 'default', 'http://localhost:8080/eureka/', 'Eureka服务Url，多个service以英文逗号分隔', 'default', '1970-01-01 00:00:00'),
+    ('namespace.lock.switch', 'default', 'false', '一次发布只能有一个人修改开关', 'default', '1970-01-01 00:00:00'),
+    ('item.key.length.limit', 'default', '128', 'item key 最大长度限制', 'default', '1970-01-01 00:00:00'),
+    ('item.value.length.limit', 'default', '20000', 'item value最大长度限制', 'default', '1970-01-01 00:00:00'),
+    ('config-service.cache.enabled', 'default', 'false', 'ConfigService是否开启缓存，开启后能提高性能，但是会增大内存消耗！', 'default', '1970-01-01 00:00:00');

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -180,7 +180,7 @@ public class PortalConfig extends RefreshableConfig {
   }
 
   public boolean isEmergencyPublishAllowed(Env env) {
-    String targetEnv = env.name();
+    String targetEnv = env.getName();
 
     String[] emergencyPublishSupportedEnvs = getArrayProperty("emergencyPublish.supported.envs", new String[0]);
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/PortalDBPropertySource.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/PortalDBPropertySource.java
@@ -50,7 +50,7 @@ public class PortalDBPropertySource extends RefreshablePropertySource {
   }
 
   @Override
-  protected void refresh() {
+  public void refresh() {
     Iterable<ServerConfig> dbConfigs = serverConfigRepository.findAll();
 
     for (ServerConfig config: dbConfigs) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/jpa/h2/PortalH2InitService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/jpa/h2/PortalH2InitService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.portal.service.jpa.h2;
+
+import com.ctrip.framework.apollo.portal.service.PortalDBPropertySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
+@Configuration
+@Profile("h2")
+public class PortalH2InitService {
+
+    @Autowired
+    private PortalDBPropertySource dbPropertySource;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @PostConstruct
+    public void runSqlScript() throws Exception {
+        Resource resource = new ClassPathResource("jpa/init.h2.sql");
+        DatabasePopulatorUtils.execute(new ResourceDatabasePopulator(resource), dataSource);
+        dbPropertySource.refresh();
+    }
+}

--- a/apollo-portal/src/main/resources/jpa/init.h2.sql
+++ b/apollo-portal/src/main/resources/jpa/init.h2.sql
@@ -1,0 +1,58 @@
+--
+-- Copyright 2023 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+CREATE TABLE SPRING_SESSION
+(
+    PRIMARY_ID            VARCHAR(255) NOT NULL,
+    SESSION_ID            VARCHAR(255) NOT NULL,
+    CREATION_TIME         BIGINT       NOT NULL,
+    LAST_ACCESS_TIME      BIGINT       NOT NULL,
+    MAX_INACTIVE_INTERVAL INT          NOT NULL,
+    EXPIRY_TIME           BIGINT       NOT NULL,
+    PRINCIPAL_NAME        VARCHAR(100),
+    CONSTRAINT SPRING_SESSION_PK PRIMARY KEY (PRIMARY_ID)
+);
+
+CREATE UNIQUE INDEX SPRING_SESSION_IX1 ON SPRING_SESSION (SESSION_ID);
+CREATE INDEX SPRING_SESSION_IX2 ON SPRING_SESSION (EXPIRY_TIME);
+CREATE INDEX SPRING_SESSION_IX3 ON SPRING_SESSION (PRINCIPAL_NAME);
+
+CREATE TABLE SPRING_SESSION_ATTRIBUTES
+(
+    SESSION_PRIMARY_ID VARCHAR(255) NOT NULL,
+    ATTRIBUTE_NAME     VARCHAR(200) NOT NULL,
+    ATTRIBUTE_BYTES    BLOB         NOT NULL,
+    CONSTRAINT SPRING_SESSION_ATTRIBUTES_PK PRIMARY KEY (SESSION_PRIMARY_ID, ATTRIBUTE_NAME),
+    CONSTRAINT SPRING_SESSION_ATTRIBUTES_FK FOREIGN KEY (SESSION_PRIMARY_ID) REFERENCES SPRING_SESSION (PRIMARY_ID) ON DELETE CASCADE
+);
+
+INSERT INTO "ServerConfig" ("Key", "Value", "Comment", "DataChange_CreatedBy", "DataChange_CreatedTime")
+VALUES
+    ('apollo.portal.envs', 'dev', '可支持的环境列表', 'default', '1970-01-01 00:00:00'),
+    ('organizations', '[{"orgId":"TEST1","orgName":"样例部门1"},{"orgId":"TEST2","orgName":"样例部门2"}]', '部门列表', 'default', '1970-01-01 00:00:00'),
+    ('superAdmin', 'apollo', 'Portal超级管理员', 'default', '1970-01-01 00:00:00'),
+    ('api.readTimeout', '10000', 'http接口read timeout', 'default', '1970-01-01 00:00:00'),
+    ('consumer.token.salt', 'someSalt', 'consumer token salt', 'default', '1970-01-01 00:00:00'),
+    ('admin.createPrivateNamespace.switch', 'true', '是否允许项目管理员创建私有namespace', 'default', '1970-01-01 00:00:00'),
+    ('configView.memberOnly.envs', 'pro', '只对项目成员显示配置信息的环境列表，多个env以英文逗号分隔', 'default', '1970-01-01 00:00:00'),
+    ('apollo.portal.meta.servers', '{}', '各环境Meta Service列表', 'default', '1970-01-01 00:00:00');
+
+INSERT INTO "Users" ("Username", "Password", "UserDisplayName", "Email", "Enabled")
+VALUES
+    ('apollo', '$2a$10$7r20uS.BQ9uBpf3Baj3uQOZvMVvB1RN3PYoKE94gtz2.WAOuiiwXS', 'apollo', 'apollo@acme.com', 1);
+
+INSERT INTO "Authorities" ("Username", "Authority")
+VALUES
+    ('apollo', 'ROLE_user');


### PR DESCRIPTION
## What's the purpose of this PR
add h2 init sql to complete h2 support.

## Brief changelog
- add h2 init sql when profile is h2
- refresh ServerConfig immediately when write in to h2.

## How to local quick start h2
### configservice
```
-Dapollo_profile=github,database-discovery
-Dspring.profiles.group.github=h2
-Dspring.datasource.url=jdbc:h2:mem:testdb;DATABASE_TO_UPPER=FALSE
-Dspring.datasource.username=sa
-Dspring.datasource.password=
```
### adminservice
```
-Dapollo_profile=github,database-discovery
-Dspring.profiles.group.github=h2
-Dspring.datasource.url=jdbc:h2:mem:testdb;DATABASE_TO_UPPER=FALSE
-Dspring.datasource.username=sa
-Dspring.datasource.password=
```
### portal
```
-Dapollo_profile=github,database-discovery
-Dspring.profiles.group.github=h2
-Dspring.datasource.url=jdbc:h2:mem:testdb;DATABASE_TO_UPPER=FALSE
-Dspring.datasource.username=sa
-Dspring.datasource.password=
-Ddev_meta=http://localhost:8080/
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
