### PR TITLE
[Multi-Database Support][pg] Where clause need escape, otherwise will request postgre use lowwer case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Apollo 2.2.0
 * [Fix OIDC logout unnecessary redirect](https://github.com/apolloconfig/apollo/pull/4773)
 * [[Multi-Database Support] Introduce h2 postgre profile properties to let user config database config](https://github.com/apolloconfig/apollo/pull/4766)
 * [[Multi-Database Support] Optimize column define case sensitivity](https://github.com/apolloconfig/apollo/pull/4776)
+* [[Multi-Database Support][pg] Where clause need escape, otherwise will request postgre use lowwer case](https://github.com/apolloconfig/apollo/pull/4780)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
@@ -27,7 +27,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`AccessKey`")
 @SQLDelete(sql = "Update AccessKey set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class AccessKey extends BaseEntity {
 
   @Column(name = "`AppId`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Audit.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Audit.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Audit`")
 @SQLDelete(sql = "Update Audit set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Audit extends BaseEntity {
 
   public enum OP {

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Cluster.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Cluster.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Cluster`")
 @SQLDelete(sql = "Update Cluster set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Cluster extends BaseEntity implements Comparable<Cluster> {
 
   @Column(name = "`Name`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Commit.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Commit.java
@@ -29,7 +29,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Commit`")
 @SQLDelete(sql = "Update Commit set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Commit extends BaseEntity {
 
   @Lob

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/GrayReleaseRule.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/GrayReleaseRule.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`GrayReleaseRule`")
 @SQLDelete(sql = "Update GrayReleaseRule set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class GrayReleaseRule extends BaseEntity{
 
   @Column(name = "`AppId`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
@@ -29,7 +29,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Item`")
 @SQLDelete(sql = "Update Item set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Item extends BaseEntity {
 
   @Column(name = "`NamespaceId`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Namespace.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Namespace.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Namespace`")
 @SQLDelete(sql = "Update Namespace set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Namespace extends BaseEntity {
 
   @Column(name = "`AppId`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/NamespaceLock.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/NamespaceLock.java
@@ -26,7 +26,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "`NamespaceLock`")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class NamespaceLock extends BaseEntity{
 
   @Column(name = "`NamespaceId`")

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Privilege.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Privilege.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Privilege`")
 @SQLDelete(sql = "Update Privilege set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Privilege extends BaseEntity {
 
   @Column(name = "`Name`", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Release.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Release.java
@@ -32,7 +32,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Release`")
 @SQLDelete(sql = "Update Release set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Release extends BaseEntity {
   @Column(name = "`ReleaseKey`", nullable = false)
   private String releaseKey;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ReleaseHistory.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ReleaseHistory.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`ReleaseHistory`")
 @SQLDelete(sql = "Update ReleaseHistory set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class ReleaseHistory extends BaseEntity {
   @Column(name = "`AppId`", nullable = false)
   private String appId;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ServerConfig.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/ServerConfig.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`ServerConfig`")
 @SQLDelete(sql = "Update ServerConfig set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class ServerConfig extends BaseEntity {
   @Column(name = "`Key`", nullable = false)
   private String key;

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/App.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/App.java
@@ -29,7 +29,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`App`")
 @SQLDelete(sql = "Update App set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class App extends BaseEntity {
 
   @NotBlank(message = "Name cannot be blank")

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/AppNamespace.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/AppNamespace.java
@@ -32,7 +32,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`AppNamespace`")
 @SQLDelete(sql = "Update AppNamespace set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class AppNamespace extends BaseEntity {
 
   @NotBlank(message = "AppNamespace Name cannot be blank")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/Consumer.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/Consumer.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Consumer`")
 @SQLDelete(sql = "Update Consumer set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Consumer extends BaseEntity {
 
   @Column(name = "`Name`", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerRole.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerRole.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`ConsumerRole`")
 @SQLDelete(sql = "Update ConsumerRole set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class ConsumerRole extends BaseEntity {
   @Column(name = "`ConsumerId`", nullable = false)
   private long consumerId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerToken.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerToken.java
@@ -33,7 +33,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`ConsumerToken`")
 @SQLDelete(sql = "Update ConsumerToken set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class ConsumerToken extends BaseEntity {
   @Column(name = "`ConsumerId`", nullable = false)
   private long consumerId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Favorite.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Favorite.java
@@ -28,7 +28,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Favorite`")
 @SQLDelete(sql = "Update Favorite set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Favorite extends BaseEntity {
 
   @Column(name = "`AppId`", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Permission.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Permission.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Permission`")
 @SQLDelete(sql = "Update Permission set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Permission extends BaseEntity {
   @Column(name = "`PermissionType`", nullable = false)
   private String permissionType;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Role.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/Role.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`Role`")
 @SQLDelete(sql = "Update Role set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class Role extends BaseEntity {
   @Column(name = "`RoleName`", nullable = false)
   private String roleName;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/RolePermission.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/RolePermission.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`RolePermission`")
 @SQLDelete(sql = "Update RolePermission set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class RolePermission extends BaseEntity {
   @Column(name = "`RoleId`", nullable = false)
   private long roleId;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
@@ -32,7 +32,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`ServerConfig`")
 @SQLDelete(sql = "Update ServerConfig set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class ServerConfig extends BaseEntity {
   @NotBlank(message = "ServerConfig.Key cannot be blank")
   @Column(name = "`Key`", nullable = false)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/UserRole.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/UserRole.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "`UserRole`")
 @SQLDelete(sql = "Update UserRole set IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000) where Id = ?")
-@Where(clause = "IsDeleted = false")
+@Where(clause = "`IsDeleted` = false")
 public class UserRole extends BaseEntity {
   @Column(name = "`UserId`", nullable = false)
   private String userId;


### PR DESCRIPTION
## What's the purpose of this PR
Where clause need escape, otherwise will request postgre use lowwer case

## Brief changelog
Add escape in where cause. Tested in postgre、mysql、unittests

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
