### PR TITLE
Remove the usage of Env.name() using Env.getName()

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -180,7 +180,7 @@ public class PortalConfig extends RefreshableConfig {
   }
 
   public boolean isEmergencyPublishAllowed(Env env) {
-    String targetEnv = env.name();
+    String targetEnv = env.getName();
 
     String[] emergencyPublishSupportedEnvs = getArrayProperty("emergencyPublish.supported.envs", new String[0]);
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
@@ -183,7 +183,7 @@ public class ItemController {
       }
 
       if (permissionValidator
-          .shouldHideConfigToCurrentUser(namespace.getAppId(), namespace.getEnv().name(), namespace.getNamespaceName())) {
+          .shouldHideConfigToCurrentUser(namespace.getAppId(), namespace.getEnv().getName(), namespace.getNamespaceName())) {
         diff.setDiffs(new ItemChangeSets());
         diff.setExtInfo("You are not this project's administrator, nor you have edit or release permission for the namespace in environment: " + namespace.getEnv());
       }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/environment/Env.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/environment/Env.java
@@ -227,16 +227,6 @@ public class Env {
     return name;
   }
 
-  /**
-   * Backward compatibility with enum's name method
-   *
-   * @Deprecated please use {@link #getName()} instead of
-   */
-  @Deprecated
-  public String name() {
-    return name;
-  }
-
   public String getName() {
     return name;
   }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/environment/EnvTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/environment/EnvTest.java
@@ -91,7 +91,7 @@ public class EnvTest {
 
   @Test
   public void name() {
-    assertEquals("DEV", Env.DEV.name());
+    assertEquals("DEV", Env.DEV.getName());
   }
 
   @Test


### PR DESCRIPTION
## What's the purpose of this PR
Rmove the deprecated method, and delete it. If an internal method has been deprecated for a significant period of time, it may be preferable to remove it. If necessary, we can easily restore it using git.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
