### PR TITLE
Support grayscale feature for non-properties namespaces(#4316)

### DIFF
--- a/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
@@ -251,7 +251,7 @@ function controller($rootScope, $scope, $translate, toastr, AppUtil, EventManage
 
         $scope.item = _.clone(toEditItem);
         $scope.item.type = String($scope.item.type || 0)
-        if (namespace.isBranch || namespace.isLinkedNamespace) {
+        if (namespace.isLinkedNamespace) {
             var existedItem = false;
             namespace.items.forEach(function (item) {
                 if (!item.isDeleted && item.item.key == toEditItem.key) {

--- a/apollo-portal/src/main/resources/static/views/component/item-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/item-modal.html
@@ -48,7 +48,7 @@
                         {{'Component.ConfigItem.ItemTypeName' | translate }}
                     </label>
                     <div class="col-sm-10" valdr-form-group>
-                        <select class="form-control" name="type" ng-model="item.type" ng-change="changeType()">
+                        <select class="form-control" name="type" ng-model="item.type" ng-change="changeType()" ng-disabled="!toOperationNamespace.isPropertiesFormat">
                             <option value="0">{{'Component.ConfigItem.ItemTypeString' | translate }}</option>
                             <option value="1">{{'Component.ConfigItem.ItemTypeNumber' | translate }}</option>
                             <option value="2">{{'Component.ConfigItem.ItemTypeBoolean' | translate }}</option>
@@ -86,9 +86,9 @@
 
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-2 control-label">{{'Component.ConfigItem.ItemComment' | translate }}</label>
+                    <label class="col-sm-2 control-label" ng-show="toOperationNamespace.isPropertiesFormat">{{'Component.ConfigItem.ItemComment' | translate }}</label>
                     <div class="col-sm-10" valdr-form-group>
-                        <textarea class="form-control" name="comment" ng-model="item.comment" tabindex="3" rows="2">
+                        <textarea class="form-control" name="comment" ng-model="item.comment" tabindex="3" rows="2" ng-show="toOperationNamespace.isPropertiesFormat">
                         </textarea>
                     </div>
                 </div>

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
@@ -69,8 +69,7 @@
             <div class="row">
                 <div class="col-md-12 pull-left">
                     <ul class="nav nav-tabs">
-                        <li role="presentation" ng-click="switchView(namespace.branch, 'table')"
-                            ng-show="namespace.isPropertiesFormat">
+                        <li role="presentation" ng-click="switchView(namespace.branch, 'table')">
                             <a ng-class="{node_active:namespace.branch.viewType == 'table'}">
                                 <img src="img/table.png">
                                 {{'Component.Namespace.Branch.Tab.Configuration' | translate }}
@@ -111,7 +110,7 @@
                     <div class="panel-heading">
                         {{'Component.Namespace.Branch.Body.Item' | translate }}
                         <button type="button" class="btn btn-primary btn-sm pull-right" style="margin-top: -4px;"
-                            ng-show="namespace.hasModifyPermission" ng-click="createItem(namespace.branch)">
+                            ng-show="namespace.isPropertiesFormat && namespace.hasModifyPermission" ng-click="createItem(namespace.branch)">
                             <img src="img/plus.png">
                             {{'Component.Namespace.Branch.Body.AddedItem' | translate }}
                         </button>

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -91,7 +91,7 @@
 
                 <a type="button" class="btn btn-default btn-sm" data-tooltip="tooltip" data-placement="bottom"
                     title="{{'Component.Namespace.Master.Items.GrayscaleTips' | translate }}"
-                    ng-show="!namespace.hasBranch && namespace.isPropertiesFormat && namespace.hasModifyPermission"
+                    ng-show="!namespace.hasBranch && namespace.hasModifyPermission"
                     ng-click="preCreateBranch(namespace)">
                     <img src="img/test.png">
                     {{'Component.Namespace.Master.Items.Grayscale' | translate }}


### PR DESCRIPTION
## What's the purpose of this PR

Support grayscale feature for non-properties namespaces 

## Which issue(s) this PR fixes:
Fixes #4316

## Brief changelog

1. Non-properties namespace displays grayscale buttons. 
Modify src/main/resources/static/views/component/namespace-panel-master-tab.html
2. Non-properties namespace grayscale version displays the configuration Tab and hides the new configuration button.
Modify src/main/resources/static/views/component/namespace-panel-branch-tab.html
3. When the non-properties namespace is modified, the key and type cannot be modified and the comment is hidden.
Modify src/main/resources/static/views/component/item-modal.html
4. Modify the grayscale version of the Modify configuration dialog, showing modified configuration instead of new configuration. 
Modify src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
