### PR TITLE
support send email with SMTPSSLTransport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Apollo 2.2.0
 * [Fix the issue that namespace content being cleared when identical content is pasted into the namespace](https://github.com/apolloconfig/apollo/pull/4922)
 * [feat(openapi): allow user create app via openapi](https://github.com/apolloconfig/apollo/pull/4954)
 * [Support grayscale feature for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/4952)
+* [Support send email with SMTPSSLTransport](https://github.com/apolloconfig/apollo/pull/5018)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -223,6 +223,10 @@ public class PortalConfig extends RefreshableConfig {
     return getValue("email.config.host", "");
   }
 
+  public Boolean emailConfigUseSsl() {
+    return getBooleanProperty("email.config.useSsl", false);
+  }
+
   public String emailConfigUser() {
     return getValue("email.config.user", "");
   }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultEmailService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultEmailService.java
@@ -69,17 +69,17 @@ public class DefaultEmailService implements EmailService {
       String password = portalConfig.emailConfigPassword();
 
       if (useSsl) {
-        t = (SMTPTransport) session.getTransport("smtp");
-        t.connect(host, user, password);
-        msg.saveChanges();
-        t.sendMessage(msg, msg.getAllRecipients());
-        logger.debug("email response: {}", t.getLastServerResponse());
-      } else {
         tSsl = (SMTPSSLTransport) session.getTransport("smtps");
         tSsl.connect(host, user, password);
         msg.saveChanges();
         tSsl.sendMessage(msg, msg.getAllRecipients());
         logger.debug("email response: {}", tSsl.getLastServerResponse());
+      } else {
+        t = (SMTPTransport) session.getTransport("smtp");
+        t.connect(host, user, password);
+        msg.saveChanges();
+        t.sendMessage(msg, msg.getAllRecipients());
+        logger.debug("email response: {}", t.getLastServerResponse());
       }
     } catch (Exception e) {
       logger.error("send email failed.", e);


### PR DESCRIPTION
接入邮件服务发现只支持smtp（25端口），不支持smtps（465端口），估计可能会有一些使用者遇到类似的问题，故提个PR增加支持ssl方式，代码写得有点粗糙，希望该意见能得到采纳，感谢不吝赐教。

## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
