### PR TITLE
Fix circular references on LdapAutoConfiguration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 Apollo 2.3.0
 
 ------------------
+* [Fix circular references on LdapAutoConfiguration](https://github.com/apolloconfig/apollo/pull/5055)
 
 
 ------------------

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -195,14 +195,11 @@ public class AuthConfiguration {
 
     private final LdapProperties properties;
     private final Environment environment;
-    private final LdapTemplate ldapTemplate;
 
     public SpringSecurityLDAPAuthAutoConfiguration(final LdapProperties properties,
-        final Environment environment,
-        final LdapTemplate ldapTemplate) {
+        final Environment environment) {
       this.properties = properties;
       this.environment = environment;
-      this.ldapTemplate = ldapTemplate;
     }
 
     @Bean
@@ -225,7 +222,7 @@ public class AuthConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(UserService.class)
-    public UserService springSecurityUserService() {
+    public UserService springSecurityUserService(LdapTemplate ldapTemplate) {
       return new LdapUserService(ldapTemplate);
     }
 

--- a/changes/changes-2.2.0.md
+++ b/changes/changes-2.2.0.md
@@ -31,7 +31,6 @@ Apollo 2.2.0
 * [Fix the issue that namespace content being cleared when identical content is pasted into the namespace](https://github.com/apolloconfig/apollo/pull/4922)
 * [feat(openapi): allow user create app via openapi](https://github.com/apolloconfig/apollo/pull/4954)
 * [Support grayscale feature for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/4952)
-* [Fix circular references on LdapAutoConfiguration](https://github.com/apolloconfig/apollo/pull/5055)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)

--- a/changes/changes-2.2.0.md
+++ b/changes/changes-2.2.0.md
@@ -31,6 +31,7 @@ Apollo 2.2.0
 * [Fix the issue that namespace content being cleared when identical content is pasted into the namespace](https://github.com/apolloconfig/apollo/pull/4922)
 * [feat(openapi): allow user create app via openapi](https://github.com/apolloconfig/apollo/pull/4954)
 * [Support grayscale feature for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/4952)
+* [Fix circular references on LdapAutoConfiguration](https://github.com/apolloconfig/apollo/pull/5055)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/13?closed=1)


### PR DESCRIPTION
## What's the purpose of this PR

Fix circular references on LdapAutoConfiguration

## Which issue(s) this PR fixes:
Fixes #https://github.com/apolloconfig/apollo/issues/5051

## Brief changelog

Update SpringSecurityLDAPAuthAutoConfiguration

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
