### PR TITLE
Fix the issue that the length of private namespaces are mis-calculated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Apollo 2.3.0
 ------------------
 * [Fix circular references on LdapAutoConfiguration](https://github.com/apolloconfig/apollo/pull/5055)
 * [Add comment for clusters and UI display](https://github.com/apolloconfig/apollo/pull/5072)
+* [Fix the issue that the length of private namespaces are mis-calculated](https://github.com/apolloconfig/apollo/pull/5078)
 
 
 ------------------

--- a/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
@@ -86,7 +86,7 @@ namespace_module.controller("LinkNamespaceController",
             };
 
             function shouldAppendNamespacePrefix() {
-                return  $scope.appendNamespacePrefix;
+                return $scope.appNamespace.isPublic ? $scope.appendNamespacePrefix : false;
             }
 
             var selectedClusters = [];


### PR DESCRIPTION
## What's the purpose of this PR

Fix the issue that the length of private namespaces are mis-calculated

## Which issue(s) this PR fixes:
Fixes #5073

## Brief changelog

* Fix the logic of shouldAppendNamespacePrefix

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
