### PR TITLE
fix the apollo version logic by reading the server version instead of the apollo-core version

### DIFF
--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/constants/ApolloServer.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/constants/ApolloServer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.constants;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+public class ApolloServer {
+  public final static String VERSION =
+      "java-" + ApolloServer.class.getPackage().getImplementationVersion();
+}

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/ApolloInfoController.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/ApolloInfoController.java
@@ -16,9 +16,8 @@
  */
 package com.ctrip.framework.apollo.common.controller;
 
-import com.ctrip.framework.apollo.Apollo;
+import com.ctrip.framework.apollo.common.constants.ApolloServer;
 import com.ctrip.framework.foundation.Foundation;
-
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +37,6 @@ public class ApolloInfoController {
 
   @RequestMapping("version")
   public String getVersion() {
-    return Apollo.VERSION;
+    return ApolloServer.VERSION;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/SystemInfoController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/SystemInfoController.java
@@ -16,14 +16,16 @@
  */
 package com.ctrip.framework.apollo.portal.controller;
 
-import com.ctrip.framework.apollo.Apollo;
-import com.ctrip.framework.apollo.portal.environment.PortalMetaDomainService;
+import com.ctrip.framework.apollo.common.constants.ApolloServer;
 import com.ctrip.framework.apollo.core.dto.ServiceDTO;
-import com.ctrip.framework.apollo.portal.environment.Env;
 import com.ctrip.framework.apollo.portal.component.PortalSettings;
 import com.ctrip.framework.apollo.portal.component.RestTemplateFactory;
 import com.ctrip.framework.apollo.portal.entity.vo.EnvironmentInfo;
 import com.ctrip.framework.apollo.portal.entity.vo.SystemInfo;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.environment.PortalMetaDomainService;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
@@ -33,9 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
-
-import javax.annotation.PostConstruct;
-import java.util.List;
 
 @RestController
 @RequestMapping("/system-info")
@@ -70,7 +69,7 @@ public class SystemInfoController {
   public SystemInfo getSystemInfo() {
     SystemInfo systemInfo = new SystemInfo();
 
-    String version = Apollo.VERSION;
+    String version = ApolloServer.VERSION;
     if (isValidVersion(version)) {
       systemInfo.setVersion(version);
     }


### PR DESCRIPTION
## What's the purpose of this PR

fix the apollo version logic by reading the server version instead of the apollo-core version

## Brief changelog

* Add an ApolloServer.VERSION constant
* Use ApolloServer.VERSION as the server version

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant to represent the Java version of the Apollo server.
- **Refactor**
	- Updated version information source across various controllers for consistency.
	- Improved `SystemInfoController` initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->