### PR TITLE
ci: add convertional commit lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         jdk: [8, 11, 17]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -1,0 +1,12 @@
+name: commit lint
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -28,6 +28,6 @@ jobs:
   license:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check License
       uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,4 +32,6 @@ We provide template files [intellij-java-google-style.xml](https://github.com/ct
         * `git checkout -b <some-branch-name> <remote>/master`
         * `git merge --squash <current-feature-branch>`
 
-* When writing a commit message please follow these conventions: if you are fixing an existing issue, please add Fixes #XXX at the end of the commit message (where XXX is the issue number).
+* For commits, we adhere to the conventional commits format. For more details, refer to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+* When crafting commit messages, please adhere to the following conventions: if your commit addresses an existing issue, append "Fixes #XXX" to the end of the commit message (where XXX is the issue number).


### PR DESCRIPTION
## What's the purpose of this PR

introduce conventional commit in apolloconfig[1]. It will looks like[2] 
<img width="716" alt="image" src="https://github.com/apolloconfig/apollo/assets/12933197/eb78528e-0abe-4ccb-8920-566f271addfe">


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.

[1]  https://www.conventionalcommits.org/en/v1.0.0/
[2] https://github.com/openGemini/opengemini-client-go/commits/main/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated commit message conventions to adhere to the conventional commits format and provided guidelines for addressing existing issues in commit messages.
	- Established a GitHub Actions workflow named "commit lint" to enforce commit message standards using the `commitlint-github-action` action.
	- Updated the version of the `actions/checkout` action from `v2` to `v4` in relevant GitHub Actions workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->