### PR TITLE
feat: Portal 模块 RestTemplate 支持配置 ConnectionTimeToLive

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class RestTemplateFactory implements FactoryBean<RestTemplate>, InitializingBean {
@@ -58,7 +59,9 @@ public class RestTemplateFactory implements FactoryBean<RestTemplate>, Initializ
   }
 
   public void afterPropertiesSet() throws UnsupportedEncodingException {
-    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+    CloseableHttpClient httpClient = HttpClientBuilder.create()
+        .setConnectionTimeToLive(portalConfig.connectionTimeToLive(), TimeUnit.MILLISECONDS)
+        .build();
 
     restTemplate = new RestTemplate(httpMessageConverters.getConverters());
     HttpComponentsClientHttpRequestFactory requestFactory =

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -169,6 +169,10 @@ public class PortalConfig extends RefreshableConfig {
     return getIntProperty("api.readTimeout", 10000);
   }
 
+  public int connectionTimeToLive() {
+    return getIntProperty("api.connectionTimeToLive", -1);
+  }
+
   public List<Organization> organizations() {
 
     String organizations = getValue("organizations");


### PR DESCRIPTION
希望 Portal 模块 [RestTemplateFactory](https://github.com/apolloconfig/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java) 支持配置 ConnectionTimeToLive，详见 #5120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced network connection stability by configuring the connection time to live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->