### PR TITLE
bugfix: fixed urls that missing the customized prefix such as '/apollo'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,6 @@ Apollo 2.3.0
 * [apollo assembly optimization](https://github.com/apolloconfig/apollo/pull/5035)
 * [update the config item table column width](https://github.com/apolloconfig/apollo/pull/5131)
 * [sync apollo portal server config to apollo quick start server](https://github.com/apolloconfig/apollo/pull/5134)
-
+* [Fix missing **prefix path** of some URLs in Apollo Portal](https://github.com/apolloconfig/apollo/pull/5138)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/14?closed=1)

--- a/apollo-portal/src/main/resources/static/scripts/controller/ConfigExportController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/ConfigExportController.js
@@ -63,7 +63,7 @@ config_export_module.controller('ConfigExportController',
                                          }
 
                                          var selectedEnvStr = selectedEnvs.join(",");
-                                         $window.location.href = '/configs/export?envs=' + selectedEnvStr;
+                                         $window.location.href = AppUtil.prefixPath() + '/configs/export?envs=' + selectedEnvStr;
 
                                          toastr.success($translate.instant('ConfigExport.ExportSuccess'));
                                      };
@@ -93,7 +93,7 @@ config_export_module.controller('ConfigExportController',
                                          form.append('file', file);
                                          $http({
                                                    method: 'POST',
-                                                   url: '/configs/import?envs=' + selectedEnvStr + "&conflictAction="
+                                                   url: AppUtil.prefixPath() + '/configs/import?envs=' + selectedEnvStr + "&conflictAction="
                                                         + $scope.conflictAction,
                                                    data: form,
                                                    headers: {'Content-Type': undefined},

--- a/apollo-portal/src/main/resources/static/scripts/directive/import-namespace-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/import-namespace-modal-directive.js
@@ -54,7 +54,7 @@ function importNamespaceModalDirective($window, $q, $translate, $http, toastr, A
                 form.append('file', file);
                 $http({
                           method: 'POST',
-                          url: '/apps/' + toImportNamespace.baseInfo.appId + '/envs/' + scope.env + '/clusters/'
+                          url: AppUtil.prefixPath() + '/apps/' + toImportNamespace.baseInfo.appId + '/envs/' + scope.env + '/clusters/'
                                + toImportNamespace.baseInfo.clusterName
                                + '/namespaces/' + toImportNamespace.baseInfo.namespaceName + "/items/import",
                           data: form,

--- a/apollo-portal/src/main/resources/static/scripts/services/ClusterService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/ClusterService.js
@@ -14,19 +14,19 @@
  * limitations under the License.
  *
  */
-appService.service('ClusterService', ['$resource', '$q', function ($resource, $q) {
+appService.service('ClusterService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
     var cluster_resource = $resource('', {}, {
         create_cluster: {
             method: 'POST',
-            url: 'apps/:appId/envs/:env/clusters'
+            url: AppUtil.prefixPath() + 'apps/:appId/envs/:env/clusters'
         },
         load_cluster: {
             method: 'GET',
-            url: 'apps/:appId/envs/:env/clusters/:clusterName'
+            url: AppUtil.prefixPath() + 'apps/:appId/envs/:env/clusters/:clusterName'
         },
         delete_cluster: {
             method: 'DELETE',
-            url: 'apps/:appId/envs/:env/clusters/:clusterName'
+            url: AppUtil.prefixPath() + 'apps/:appId/envs/:env/clusters/:clusterName'
         }
     });
     return {

--- a/apollo-portal/src/main/resources/static/scripts/services/ExportService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/ExportService.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  *
  */
-appService.service('ExportService', ['$resource', '$q', function ($resource, $q) {
+appService.service('ExportService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
     var resource = $resource('', {}, {
         importConfig: {
             method: 'POST',
-            url: '/import',
+            url: AppUtil.prefixPath() + '/import',
             headers: {'Content-Type': undefined},
         }
     });

--- a/apollo-portal/src/main/resources/static/scripts/services/NamespaceLockService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/NamespaceLockService.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  *
  */
-appService.service('NamespaceLockService', ['$resource', '$q', function ($resource, $q) {
+appService.service('NamespaceLockService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
     var resource = $resource('', {}, {
         get_namespace_lock: {
             method: 'GET',
-            url: 'apps/:appId/envs/:env/clusters/:clusterName/namespaces/:namespaceName/lock-info'
+            url: AppUtil.prefixPath() + 'apps/:appId/envs/:env/clusters/:clusterName/namespaces/:namespaceName/lock-info'
         }
     });
 


### PR DESCRIPTION
## What's the purpose of this PR

Fix bug while importing the configuration's file

## Which issue(s) this PR fixes:
Fixes [#5137 ](https://github.com/apolloconfig/apollo/issues/5137) 


## Brief changelog

Add the **prefix path** such as **/apollo** to those urls that were missed in apollo-portal

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced URL construction across various services for configuration export, import, and namespace management to ensure consistency and reliability in different environments.

- **Refactor**
  - Integrated `AppUtil` prefix path method across multiple services to standardize URL generation and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->