### PR TITLE
Fix the role permission deletion issue when appid contains '_'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Apollo 2.3.0
 * [apollo assembly optimization](https://github.com/apolloconfig/apollo/pull/5035)
 * [update the config item table column width](https://github.com/apolloconfig/apollo/pull/5131)
 * [sync apollo portal server config to apollo quick start server](https://github.com/apolloconfig/apollo/pull/5134)
+* [Fix the role permission deletion issue when appid contains '_'](https://github.com/apolloconfig/apollo/pull/5150)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/14?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
@@ -40,10 +40,11 @@ public interface PermissionRepository extends PagingAndSortingRepository<Permiss
   List<Permission> findByPermissionTypeInAndTargetId(Collection<String> permissionTypes,
                                                      String targetId);
 
-  @Query("SELECT p.id from Permission p where p.targetId = ?1 or p.targetId like CONCAT(?1, '+%')")
+  @Query("SELECT p.id from Permission p where p.targetId like ?1 or p.targetId like CONCAT(?1, '+%')")
   List<Long> findPermissionIdsByAppId(String appId);
 
-  @Query("SELECT p.id from Permission p where p.targetId = CONCAT(?1, '+', ?2)")
+  @Query("SELECT p.id from Permission p where p.targetId like CONCAT(?1, '+', ?2) "
+      + "OR p.targetId like CONCAT(?1, '+', ?2, '+%')")
   List<Long> findPermissionIdsByAppIdAndNamespace(String appId, String namespaceName);
 
   @Modifying

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
@@ -32,14 +32,16 @@ public interface RoleRepository extends PagingAndSortingRepository<Role, Long> {
    */
   Role findTopByRoleName(String roleName);
 
-  @Query("SELECT r.id from Role r where (r.roleName = CONCAT('Master+', ?1) "
+  @Query("SELECT r.id from Role r where r.roleName like CONCAT('Master+', ?1) "
       + "OR r.roleName like CONCAT('ModifyNamespace+', ?1, '+%') "
       + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+%')  "
-      + "OR r.roleName = CONCAT('ManageAppMaster+', ?1))")
+      + "OR r.roleName like CONCAT('ManageAppMaster+', ?1)")
   List<Long> findRoleIdsByAppId(String appId);
 
-  @Query("SELECT r.id from Role r where (r.roleName = CONCAT('ModifyNamespace+', ?1, '+', ?2) "
-      + "OR r.roleName = CONCAT('ReleaseNamespace+', ?1, '+', ?2))")
+  @Query("SELECT r.id from Role r where r.roleName like CONCAT('ModifyNamespace+', ?1, '+', ?2) "
+      + "OR r.roleName like CONCAT('ModifyNamespace+', ?1, '+', ?2, '+%') "
+      + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+', ?2) "
+      + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+', ?2, '+%')")
   List<Long> findRoleIdsByAppIdAndNamespace(String appId, String namespaceName);
 
   @Modifying

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import org.springframework.data.jpa.repository.query.EscapeCharacter;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
@@ -286,6 +287,7 @@ public class DefaultRolePermissionService implements RolePermissionService {
     @Transactional
     @Override
     public void deleteRolePermissionsByAppId(String appId, String operator) {
+        appId = EscapeCharacter.DEFAULT.escape(appId);
         List<Long> permissionIds = permissionRepository.findPermissionIdsByAppId(appId);
 
         if (!permissionIds.isEmpty()) {
@@ -313,6 +315,7 @@ public class DefaultRolePermissionService implements RolePermissionService {
     @Transactional
     @Override
     public void deleteRolePermissionsByAppIdAndNamespace(String appId, String namespaceName, String operator) {
+        appId = EscapeCharacter.DEFAULT.escape(appId);
         List<Long> permissionIds = permissionRepository.findPermissionIdsByAppIdAndNamespace(appId, namespaceName);
 
         if (!permissionIds.isEmpty()) {


### PR DESCRIPTION
## What's the purpose of this PR

Fix the role permission deletion issue when appid contains '_'

## Which issue(s) this PR fixes:
Fixes #5143

## Brief changelog

* escape the appid used in roles and permissions queries
* use like operator to match the escaped appid in used in roles and permissions queries

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issue with role permission deletion for `appid` containing underscores (`_`).

- **Improvements**
  - Enhanced query conditions to improve flexibility by using `LIKE` instead of `=` for `targetId` and role names.
  - Improved handling of `appid` by escaping underscores for more accurate query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->