### PR TITLE
Fix npe of audit log get operator

### DIFF
--- a/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/context/ApolloAuditTracer.java
+++ b/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/context/ApolloAuditTracer.java
@@ -43,7 +43,7 @@ public class ApolloAuditTracer {
     this.operatorSupplier = operatorSupplier;
   }
 
-  public ApolloAuditScopeManager scopeManager() {
+  protected ApolloAuditScopeManager scopeManager() {
     return manager;
   }
 

--- a/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/spi/defaultimpl/ApolloAuditOperatorDefaultSupplier.java
+++ b/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/spi/defaultimpl/ApolloAuditOperatorDefaultSupplier.java
@@ -32,7 +32,7 @@ public class ApolloAuditOperatorDefaultSupplier implements ApolloAuditOperatorSu
       Object tracer = requestAttributes.getAttribute(ApolloAuditConstants.TRACER,
           RequestAttributes.SCOPE_REQUEST);
       if (tracer != null) {
-        ApolloAuditSpan activeSpan = ((ApolloAuditTracer) tracer).scopeManager().activeSpan();
+        ApolloAuditSpan activeSpan = ((ApolloAuditTracer) tracer).getActiveSpan();
         return activeSpan != null ? activeSpan.operator() : "anonymous";
       } else {
         return null;

--- a/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/spi/defaultimpl/ApolloAuditOperatorDefaultSupplier.java
+++ b/apollo-audit/apollo-audit-impl/src/main/java/com/ctrip/framework/apollo/audit/spi/defaultimpl/ApolloAuditOperatorDefaultSupplier.java
@@ -17,6 +17,7 @@
 package com.ctrip.framework.apollo.audit.spi.defaultimpl;
 
 import com.ctrip.framework.apollo.audit.constants.ApolloAuditConstants;
+import com.ctrip.framework.apollo.audit.context.ApolloAuditSpan;
 import com.ctrip.framework.apollo.audit.context.ApolloAuditTracer;
 import com.ctrip.framework.apollo.audit.spi.ApolloAuditOperatorSupplier;
 import org.springframework.web.context.request.RequestAttributes;
@@ -31,7 +32,8 @@ public class ApolloAuditOperatorDefaultSupplier implements ApolloAuditOperatorSu
       Object tracer = requestAttributes.getAttribute(ApolloAuditConstants.TRACER,
           RequestAttributes.SCOPE_REQUEST);
       if (tracer != null) {
-        return ((ApolloAuditTracer) tracer).scopeManager().activeSpan().operator();
+        ApolloAuditSpan activeSpan = ((ApolloAuditTracer) tracer).scopeManager().activeSpan();
+        return activeSpan != null ? activeSpan.operator() : "anonymous";
       } else {
         return null;
       }

--- a/apollo-audit/apollo-audit-impl/src/test/java/com/ctrip/framework/apollo/audit/spi/ApolloAuditOperatorSupplierTest.java
+++ b/apollo-audit/apollo-audit-impl/src/test/java/com/ctrip/framework/apollo/audit/spi/ApolloAuditOperatorSupplierTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.audit.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.ctrip.framework.apollo.audit.constants.ApolloAuditConstants;
+import com.ctrip.framework.apollo.audit.context.ApolloAuditSpan;
+import com.ctrip.framework.apollo.audit.context.ApolloAuditSpanContext;
+import com.ctrip.framework.apollo.audit.context.ApolloAuditTracer;
+import com.ctrip.framework.apollo.audit.spi.defaultimpl.ApolloAuditOperatorDefaultSupplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@SpringBootTest
+@ContextConfiguration(classes = ApolloAuditOperatorSupplier.class)
+public class ApolloAuditOperatorSupplierTest {
+
+  @SpyBean
+  ApolloAuditOperatorDefaultSupplier defaultSupplier;
+
+  @MockBean
+  RequestAttributes requestAttributes;
+  @MockBean
+  ApolloAuditTracer tracer;
+
+  @BeforeEach
+  public void setUp() {
+    Mockito.when(requestAttributes.getAttribute(
+        Mockito.eq(ApolloAuditConstants.TRACER),
+        Mockito.eq(RequestAttributes.SCOPE_REQUEST))
+    ).thenReturn(tracer);
+    RequestContextHolder.setRequestAttributes(requestAttributes);
+  }
+
+  @Test
+  public void testGetOperatorCaseActiveSpanExist() {
+    final String operator = "test";
+    {
+      ApolloAuditSpan activeSpan = new ApolloAuditSpan();
+      activeSpan.setContext(new ApolloAuditSpanContext(null, null, operator, null, null));
+      Mockito.when(tracer.getActiveSpan()).thenReturn(activeSpan);
+    }
+
+    assertEquals(operator, defaultSupplier.getOperator());
+  }
+
+  @Test
+  public void testGetOperatorCaseActiveSpanNotExist() {
+    assertEquals("anonymous", defaultSupplier.getOperator());
+  }
+
+}


### PR DESCRIPTION
## What's the purpose of this PR

To fix existing NPE bug in audit logging

when there is no active span exists on request thread context, trying to get operator will cause NPE by continuously get().

- causing NPE codes
```java
      if (tracer != null) {
        return ((ApolloAuditTracer) tracer).scopeManager().activeSpan().operator();
      }
```

- prof by unit test

![image](https://github.com/apolloconfig/apollo/assets/94302726/e7f2a2ef-181a-4322-8f92-b13b88b25cce)


In some case this bug will appear: 

Set `audit.log.enabled=false` in Portal and `audit.log.enabled=true` in AdminService.

In this case, no activeSpan would be passed to AdminService, meanwhile AdminService would get operator through active span. And then cause NPE.


## Brief changelog

1. Fix this continuously get()
2. Reduce inelegant ways of exposing interfaces to the outside
3. Add unit test for ApolloAuditOperatorDefaultSupplier

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the retrieval of the active span's operator in audit logs, defaulting to "anonymous" if no active span exists.

- **Tests**
  - Added new test cases to ensure correct behavior when an active span is present or absent during audit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->