### PR TITLE
fix: -XX:HeapDumpPath doesn't ready when meet OOM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Apollo 2.3.0
 * [update the config item table column width](https://github.com/apolloconfig/apollo/pull/5131)
 * [sync apollo portal server config to apollo quick start server](https://github.com/apolloconfig/apollo/pull/5134)
 * [Fix the role permission deletion issue when appid contains '_'](https://github.com/apolloconfig/apollo/pull/5150)
+* [fix: -XX:HeapDumpPath doesn't ready when meet OOM](https://github.com/apolloconfig/apollo/pull/5157)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/14?closed=1)

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -22,6 +22,8 @@ SERVER_PORT=${SERVER_PORT:=8090}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR
+# Create directory of -XX:HeapDumpPath
+mkdir -p $LOG_DIR/HeapDumpOnOutOfMemoryError/
 
 ## Adjust memory settings if necessary
 #export JAVA_OPTS="-Xms2560m -Xmx2560m -Xss256k -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:NewSize=1536m -XX:MaxNewSize=1536m -XX:SurvivorRatio=8"

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -22,6 +22,8 @@ SERVER_PORT=${SERVER_PORT:=8080}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR
+# Create directory of -XX:HeapDumpPath
+mkdir -p $LOG_DIR/HeapDumpOnOutOfMemoryError/
 
 ## Adjust memory settings if necessary
 #export JAVA_OPTS="-Xms6144m -Xmx6144m -Xss256k -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:NewSize=4096m -XX:MaxNewSize=4096m -XX:SurvivorRatio=8"

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -22,6 +22,8 @@ SERVER_PORT=${SERVER_PORT:=8070}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR
+# Create directory of -XX:HeapDumpPath
+mkdir -p $LOG_DIR/HeapDumpOnOutOfMemoryError/
 
 ## Adjust memory settings if necessary
 #export JAVA_OPTS="-Xms2560m -Xmx2560m -Xss256k -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:NewSize=1536m -XX:MaxNewSize=1536m -XX:SurvivorRatio=8"


### PR DESCRIPTION
## What's the purpose of this PR

fix scripts/`startup.sh`

## Which issue(s) this PR fixes:

## Brief changelog

When meet OOM, the .hprof file should auto dump,
but the directory not ready, so meet some error.

This pr prepare the directory for OOM when startup.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `-XX:HeapDumpPath` was not ready when encountering an OutOfMemory error.

- **Chores**
  - Updated startup scripts to create a `HeapDumpOnOutOfMemoryError` directory under the existing log directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->