### PR TITLE
fix: assign roles to owner instead of operator

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
@@ -83,10 +83,10 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
     //assign modify、release namespace role to user
     rolePermissionService.assignRoleToUsers(
         RoleUtils.buildNamespaceRoleName(appId, ConfigConsts.NAMESPACE_APPLICATION, RoleType.MODIFY_NAMESPACE),
-        Sets.newHashSet(operator), operator);
+        Sets.newHashSet(app.getOwnerName()), operator);
     rolePermissionService.assignRoleToUsers(
         RoleUtils.buildNamespaceRoleName(appId, ConfigConsts.NAMESPACE_APPLICATION, RoleType.RELEASE_NAMESPACE),
-        Sets.newHashSet(operator), operator);
+        Sets.newHashSet(app.getOwnerName()), operator);
 
   }
 


### PR DESCRIPTION
## What's the purpose of this PR

when creating an application, assign roles to owner instead of operator

## Which issue(s) this PR fixes:
Fixes https://github.com/apolloconfig/apollo/issues/5181

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced role assignment logic to ensure that application roles are accurately assigned to the application's owner instead of a hardcoded user. This improves user access management and security within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->