### PR TITLE
fix: The configfile interface cannot correctly obtain configuration t…

### DIFF
--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/grayReleaseRule/GrayReleaseRulesHolderTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/grayReleaseRule/GrayReleaseRulesHolderTest.java
@@ -109,18 +109,18 @@ public class GrayReleaseRulesHolderTest {
     assertNull(grayReleaseRulesHolder.findReleaseIdFromGrayReleaseRule(anotherClientAppId,
         anotherClientIp, anotherClientLabel, someAppId, someClusterName, someNamespaceName));
 
-    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClientIp,
+    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClusterName, someClientIp, someClientLabel,
         someNamespaceName));
-    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId.toUpperCase(), someClientIp,
+    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId.toUpperCase(), someClusterName, someClientIp, someClientLabel,
         someNamespaceName.toUpperCase()));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, anotherClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClusterName, anotherClientIp, someClientLabel,
         someNamespaceName));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClusterName, someClientIp, someClientLabel,
         anotherNamespaceName));
 
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, anotherClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClusterName, anotherClientIp, someClientLabel,
         someNamespaceName));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, anotherClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClusterName, anotherClientIp, someClientLabel,
         anotherNamespaceName));
 
     GrayReleaseRule anotherRule = assembleGrayReleaseRule(someAppId, someClusterName,
@@ -144,16 +144,16 @@ public class GrayReleaseRulesHolderTest {
         (anotherClientAppId, anotherClientIp, anotherClientLabel, someAppId, someClusterName, someNamespaceName));
 
 
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClusterName, someClientIp, someClientLabel,
         someNamespaceName));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(someClientAppId, someClusterName, someClientIp, someClientLabel,
         anotherNamespaceName));
 
-    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, anotherClientIp,
+    assertTrue(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClusterName, anotherClientIp, someClientLabel,
         someNamespaceName));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClusterName, someClientIp, someClientLabel,
         someNamespaceName));
-    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, anotherClientIp,
+    assertFalse(grayReleaseRulesHolder.hasGrayReleaseRule(anotherClientAppId, someClusterName, anotherClientIp, someClientLabel,
         anotherNamespaceName));
   }
 

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileController.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileController.java
@@ -149,7 +149,6 @@ public class ConfigFileController implements ReleaseMessageListener {
                                                   HttpServletRequest request,
                                                   HttpServletResponse response) throws IOException {
 
-    System.out.println("requeset1: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
     String result =
         queryConfig(ConfigFileOutputFormat.JSON, appId, clusterName, namespace, dataCenter,
             clientIp, clientLabel, request, response);
@@ -182,7 +181,6 @@ public class ConfigFileController implements ReleaseMessageListener {
     //2. try to load gray release and return
     if (hasGrayReleaseRule) {
       Tracer.logEvent("ConfigFile.Cache.GrayRelease", cacheKey);
-      System.out.println("requeset2: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
       return loadConfig(outputFormat, appId, clusterName, namespace, dataCenter, clientIp, clientLabel,
           request, response);
     }
@@ -193,7 +191,6 @@ public class ConfigFileController implements ReleaseMessageListener {
     //4. if not exists, load from ConfigController
     if (Strings.isNullOrEmpty(result)) {
       Tracer.logEvent("ConfigFile.Cache.Miss", cacheKey);
-      System.out.println("requeset3: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
       result = loadConfig(outputFormat, appId, clusterName, namespace, dataCenter, clientIp, clientLabel,
           request, response);
 

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileController.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileController.java
@@ -149,6 +149,7 @@ public class ConfigFileController implements ReleaseMessageListener {
                                                   HttpServletRequest request,
                                                   HttpServletResponse response) throws IOException {
 
+    System.out.println("requeset1: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
     String result =
         queryConfig(ConfigFileOutputFormat.JSON, appId, clusterName, namespace, dataCenter,
             clientIp, clientLabel, request, response);
@@ -174,14 +175,14 @@ public class ConfigFileController implements ReleaseMessageListener {
     }
 
     //1. check whether this client has gray release rules
-    boolean hasGrayReleaseRule = grayReleaseRulesHolder.hasGrayReleaseRule(appId, clientIp,
-        namespace);
+    boolean hasGrayReleaseRule = grayReleaseRulesHolder.hasGrayReleaseRule(appId, clusterName, clientIp, clientLabel, namespace);
 
     String cacheKey = assembleCacheKey(outputFormat, appId, clusterName, namespace, dataCenter);
 
     //2. try to load gray release and return
     if (hasGrayReleaseRule) {
       Tracer.logEvent("ConfigFile.Cache.GrayRelease", cacheKey);
+      System.out.println("requeset2: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
       return loadConfig(outputFormat, appId, clusterName, namespace, dataCenter, clientIp, clientLabel,
           request, response);
     }
@@ -192,6 +193,7 @@ public class ConfigFileController implements ReleaseMessageListener {
     //4. if not exists, load from ConfigController
     if (Strings.isNullOrEmpty(result)) {
       Tracer.logEvent("ConfigFile.Cache.Miss", cacheKey);
+      System.out.println("requeset3: " + appId + " " + clusterName + " " + namespace + " " + dataCenter + " " + clientIp + " " + clientLabel);
       result = loadConfig(outputFormat, appId, clusterName, namespace, dataCenter, clientIp, clientLabel,
           request, response);
 
@@ -200,7 +202,7 @@ public class ConfigFileController implements ReleaseMessageListener {
       }
       //5. Double check if this client needs to load gray release, if yes, load from db again
       //This step is mainly to avoid cache pollution
-      if (grayReleaseRulesHolder.hasGrayReleaseRule(appId, clientIp, namespace)) {
+      if (grayReleaseRulesHolder.hasGrayReleaseRule(appId, clusterName, clientIp, clientLabel, namespace)) {
         Tracer.logEvent("ConfigFile.Cache.GrayReleaseConflict", cacheKey);
         return loadConfig(outputFormat, appId, clusterName, namespace, dataCenter, clientIp, clientLabel,
             request, response);

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileControllerTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/ConfigFileControllerTest.java
@@ -95,7 +95,7 @@ public class ConfigFileControllerTest {
 
     when(namespaceUtil.filterNamespaceName(someNamespace)).thenReturn(someNamespace);
     when(namespaceUtil.normalizeNamespace(someAppId, someNamespace)).thenReturn(someNamespace);
-    when(grayReleaseRulesHolder.hasGrayReleaseRule(anyString(), anyString(), anyString()))
+    when(grayReleaseRulesHolder.hasGrayReleaseRule(anyString(), anyString(), anyString(), anyString(), anyString()))
         .thenReturn(false);
 
     watchedKeys2CacheKey =
@@ -199,7 +199,7 @@ public class ConfigFileControllerTest {
     Map<String, String> configurations =
         ImmutableMap.of(someKey, someValue);
 
-    when(grayReleaseRulesHolder.hasGrayReleaseRule(someAppId, someClientIp, someNamespace))
+    when(grayReleaseRulesHolder.hasGrayReleaseRule(someAppId, someClusterName, someClientIp, someClientLabel, someNamespace))
         .thenReturn(true);
 
     ApolloConfig someApolloConfig = mock(ApolloConfig.class);


### PR DESCRIPTION
…hrough grayscale labels

## What's the purpose of this PR
fix configfile interface cannot recognize grayscale labels 

XXXXX

## Which issue(s) this PR fixes:
fix configservice

Follow this checklist to help us incorporate your contribution quickly and easily: 

write rule, the cache of reversedGrayReleaseRuleCache hadn't concept  of allIp 
![image](https://github.com/user-attachments/assets/e6d4c3cc-248b-4bd6-9de1-2a46d8aea3e5)

read rule, There is no solution identified by gray label
![image](https://github.com/user-attachments/assets/5c8b91b8-7e71-4f29-b2f7-440dea32844d)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced gray release rule functionality by adding support for new parameters: `clusterName` and `clientLabel`.

- **Bug Fixes**
  - Improved validation of gray release rules, ensuring more comprehensive checks based on the updated parameters.

- **Tests**
  - Updated test cases to reflect changes in the method signatures for better validation of gray release rules functionality.

- **Documentation**
  - Added logging for debugging purposes within the query methods for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->