### PR TITLE
feat: support portal restTemplate Client connection pool config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Apollo 2.4.0
 
 ------------------
 * [Update the server config link in system info page](https://github.com/apolloconfig/apollo/pull/5204)
+* [Feature support portal restTemplate Client connection pool config](https://github.com/apolloconfig/apollo/pull/5200)
+
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/15?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Apollo 2.3.0
 * [Fix the role permission deletion issue when appid contains '_'](https://github.com/apolloconfig/apollo/pull/5150)
 * [fix: -XX:HeapDumpPath doesn't ready when meet OOM](https://github.com/apolloconfig/apollo/pull/5157)
 * [Fix the error occurred when using configuration retention feature](https://github.com/apolloconfig/apollo/pull/5162)
+* [Feature support portal restTemplate Client connection pool config](https://github.com/apolloconfig/apollo/pull/5200)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/14?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
@@ -20,6 +20,7 @@ import com.ctrip.framework.apollo.audit.component.ApolloAuditHttpInterceptor;
 import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
@@ -59,8 +60,14 @@ public class RestTemplateFactory implements FactoryBean<RestTemplate>, Initializ
   }
 
   public void afterPropertiesSet() throws UnsupportedEncodingException {
+
+    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+    connectionManager.setMaxTotal(portalConfig.connectPoolMaxTotal()); //最大连接数
+    connectionManager.setDefaultMaxPerRoute(portalConfig.connectPoolMaxPerRoute()); //每个路由（域名）最大连接数
+
     CloseableHttpClient httpClient = HttpClientBuilder.create()
         .setConnectionTimeToLive(portalConfig.connectionTimeToLive(), TimeUnit.MILLISECONDS)
+        .setConnectionManager(connectionManager)
         .build();
 
     restTemplate = new RestTemplate(httpMessageConverters.getConverters());

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RestTemplateFactory.java
@@ -62,8 +62,8 @@ public class RestTemplateFactory implements FactoryBean<RestTemplate>, Initializ
   public void afterPropertiesSet() throws UnsupportedEncodingException {
 
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-    connectionManager.setMaxTotal(portalConfig.connectPoolMaxTotal()); //最大连接数
-    connectionManager.setDefaultMaxPerRoute(portalConfig.connectPoolMaxPerRoute()); //每个路由（域名）最大连接数
+    connectionManager.setMaxTotal(portalConfig.connectPoolMaxTotal());
+    connectionManager.setDefaultMaxPerRoute(portalConfig.connectPoolMaxPerRoute());
 
     CloseableHttpClient httpClient = HttpClientBuilder.create()
         .setConnectionTimeToLive(portalConfig.connectionTimeToLive(), TimeUnit.MILLISECONDS)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -173,6 +173,14 @@ public class PortalConfig extends RefreshableConfig {
     return getIntProperty("api.connectionTimeToLive", -1);
   }
 
+  public int connectPoolMaxTotal() {
+    return getIntProperty("api.pool.max.total", 20);
+  }
+
+  public int connectPoolMaxPerRoute() {
+    return getIntProperty("api.pool.max.per.route", 2);
+  }
+
   public List<Organization> organizations() {
 
     String organizations = getValue("organizations");


### PR DESCRIPTION
## What's the purpose of this PR

Portal 模块 RestTemplate 支持配置 HTTP最大连接池和每个路由的连接大小 详见 #5199

## Which issue(s) this PR fixes:
Fixes #5199

## Brief changelog
support portal restTemplate Client connection pool config

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for configuring a connection pool for the HTTP client, enhancing performance and efficiency in handling multiple connections.
	- Introduced new configuration methods to manage connection pooling parameters.

- **Documentation**
	- Updated changelog to reflect the addition of connection pool configuration support for the HTTP client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->