### PR TITLE
fix: keep clusters order in envclusters openapi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Apollo 2.4.0
 * [Feature: openapi query namespace support not fill item](https://github.com/apolloconfig/apollo/pull/5249)
 * [Refactor: align database ClusterName and NamespaceName fields lengths](https://github.com/apolloconfig/apollo/pull/5263)
 * [Feature: Added the value length limit function for AppId-level configuration items](https://github.com/apolloconfig/apollo/pull/5264)
+* [Fix: ensure clusters order in envClusters open api](https://github.com/apolloconfig/apollo/pull/5277)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/15?closed=1)

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/BeanUtils.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/BeanUtils.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -164,7 +165,7 @@ public class BeanUtils {
    */
   @SuppressWarnings("unchecked")
   public static <K> Set<K> toPropertySet(String key, List<?> list) {
-    Set<K> set = new HashSet<>();
+    Set<K> set = new LinkedHashSet<>();
     if (CollectionUtils.isEmpty(list)) {// 防止外面传入空list
       return set;
     }


### PR DESCRIPTION
## What's the purpose of this PR

The order of clusters in the API openapi/v1/apps/{appId}/envclusters was disrupted due to the use of HashSet. Changing it to LinkedHashSet resolves this issue.

## Which issue(s) this PR fixes:
Fixes #5276 

## Brief changelog

Fix: ensure clusters order in envClusters open api

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added global search functionality for values within the system.
	- Introduced REST template client connection pool configuration.
	- Implemented limits and whitelists for namespaces per app ID and cluster.
	- Added a cache record statistics function for the ConfigService.
	- Enhanced the `RefreshAdminServerAddressTask` with dynamic time interval configuration.
	- Enforced value length limits for AppId-level configuration items.
- **Bug Fixes**
	- Resolved issues with duplicate comments and blank lines in configuration management.
	- Fixed missing items in the published namespace link.
	- Ensured correct order of clusters in the `envClusters` open API.
- **Refactor**
	- Standardized Kebab style in configuration files and aligned database field lengths for ClusterName and NamespaceName.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->