### PR TITLE
Bump com.thoughtworks.xstream:xstream from 1.4.20 to 1.4.21 to fix CVE-2024-47072

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Apollo 2.4.0
 * [Refactor: align database ClusterName and NamespaceName fields lengths](https://github.com/apolloconfig/apollo/pull/5263)
 * [Feature: Added the value length limit function for AppId-level configuration items](https://github.com/apolloconfig/apollo/pull/5264)
 * [Fix: ensure clusters order in envClusters open api](https://github.com/apolloconfig/apollo/pull/5277)
+* [Fix: bump xstream from 1.4.20 to 1.4.21 to fix CVE-2024-47072](https://github.com/apolloconfig/apollo/pull/5280)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/15?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -200,11 +200,11 @@
 				<artifactId>commons-lang3</artifactId>
 				<version>${common-lang3.version}</version>
 			</dependency>
-			<!-- to fix CVE-2022-41966 -->
+			<!-- to fix CVE-2024-47072 -->
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>
 				<artifactId>xstream</artifactId>
-				<version>1.4.20</version>
+				<version>1.4.21</version>
 			</dependency>
 			<!--for test -->
 			<dependency>


### PR DESCRIPTION
## What's the purpose of this PR

fix CVE-2024-47072


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced global search functionality for system values.
	- Added REST template client connection pool configuration.
	- Implemented limits and whitelists for namespaces per app ID and cluster.
	- Enabled observation of status access keys for pre-checks and logging.
	- Introduced caching record statistics function for ConfigService.

- **Bug Fixes**
	- Resolved issues with duplicate comments and blank lines in configuration.
	- Fixed missing items in the published namespace link.
	- Corrected order of clusters in the envClusters open API.
	- Updated xstream library to address a critical security vulnerability.

- **Refactor**
	- Standardized Kebab style in configuration files.
	- Aligned database field lengths for ClusterName and NamespaceName.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->