### PR TITLE
add missing url patterns for AdminServiceAuthenticationFilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Apollo 2.4.0
 * [Feature: highlight diffs for properties](https://github.com/apolloconfig/apollo/pull/5282)
 * [Feature: Add rate limiting function to ConsumerToken](https://github.com/apolloconfig/apollo/pull/5267)
 * [Feature: add JSON formatting function in apollo-portal](https://github.com/apolloconfig/apollo/pull/5287)
+* [Fix: add missing url patterns for AdminServiceAuthenticationFilter](https://github.com/apolloconfig/apollo/pull/5291)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/15?closed=1)

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/AdminServiceAutoConfiguration.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/AdminServiceAutoConfiguration.java
@@ -36,12 +36,15 @@ public class AdminServiceAutoConfiguration {
     FilterRegistrationBean<AdminServiceAuthenticationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
 
     filterRegistrationBean.setFilter(new AdminServiceAuthenticationFilter(bizConfig));
+    filterRegistrationBean.addUrlPatterns("/apollo/audit/*");
     filterRegistrationBean.addUrlPatterns("/apps/*");
     filterRegistrationBean.addUrlPatterns("/appnamespaces/*");
     filterRegistrationBean.addUrlPatterns("/instances/*");
     filterRegistrationBean.addUrlPatterns("/items/*");
+    filterRegistrationBean.addUrlPatterns("/items-search/*");
     filterRegistrationBean.addUrlPatterns("/namespaces/*");
     filterRegistrationBean.addUrlPatterns("/releases/*");
+    filterRegistrationBean.addUrlPatterns("/server/*");
 
     return filterRegistrationBean;
   }


### PR DESCRIPTION
## What's the purpose of this PR

add missing url patterns for AdminServiceAuthenticationFilter

## Which issue(s) this PR fixes:
Fixes #5290

## Brief changelog

* add `/apollo/audit/*`, `/items-search/*` and `/server/*` url patterns for `AdminServiceAuthenticationFilter`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Global search functionality for administrators.
	- Limits and whitelists for namespace counts per app ID and cluster.
	- Rate limiting function for `ConsumerToken`.
	- JSON formatting function added to the Apollo portal.
	- Cache record statistics function in `ConfigService`.
	- Value length limit function for AppId-level configuration items.
	- New URL patterns added to `AdminServiceAuthenticationFilter`.

- **Bug Fixes**
	- Resolved issues with duplicate comments and blank lines in configuration management.
	- Fixed missing items in the published namespace link.
	- Included missing URL patterns for the `AdminServiceAuthenticationFilter`.
	- Updated XStream library to address a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->