### PR TITLE
Add usage instructions for multiple  appid in the Apollo client

### DIFF
--- a/docs/en/client/java-sdk-user-guide.md
+++ b/docs/en/client/java-sdk-user-guide.md
@@ -611,6 +611,17 @@ ConfigFile configFile = ConfigService.getConfigFile("test", ConfigFileFormat.XML
 String content = configFile.getContent();
 ```
 
+### 3.1.5 Read the configuration corresponding to multiple appid and their namespaces.(added in version 2.4.0)
+Specify the corresponding appid and namespace to retrieve the config, and then obtain the properties.
+```java
+String someAppId = "Animal";
+String somePublicNamespace = "CAT";
+Config config = ConfigService.getConfig(someAppId, somePublicNamespace);
+String someKey = "someKeyFromPublicNamespace";
+String someDefaultValue = "someDefaultValueForTheKey";
+String value = config.getProperty(someKey, someDefaultValue);
+```
+
 ## 3.2 Spring integration approach
 
 ### 3.2.1 Configuration
@@ -747,6 +758,18 @@ public class SomeAppConfig {
 @Configuration
 @EnableApolloConfig(value = {"FX.apollo", "application.yml"}, order = 1)
 public class AnotherAppConfig {}
+```
+
+4.Support for multiple appid (added in version 2.4.0)
+```java
+// Added support for loading multiple appid their corresponding namespaces. 
+// Note that when using multiple appid, if there are keys that are the same, 
+// only the key from the prioritized loaded appid will be retrieved
+@Configuration
+@EnableApolloConfig(value = {"FX.apollo", "application.yml"},
+        multipleConfigs = {@MultipleConfig( appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
+)
+public class SomeAppConfig {}
 ```
 
 #### 3.2.1.3 Spring Boot integration methods (recommended)

--- a/docs/en/client/java-sdk-user-guide.md
+++ b/docs/en/client/java-sdk-user-guide.md
@@ -767,7 +767,7 @@ public class AnotherAppConfig {}
 // only the key from the prioritized loaded appid will be retrieved
 @Configuration
 @EnableApolloConfig(value = {"FX.apollo", "application.yml"},
-        multipleConfigs = {@MultipleConfig( appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
+        multipleConfigs = {@MultipleConfig(appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
 )
 public class SomeAppConfig {}
 ```

--- a/docs/zh/client/java-sdk-user-guide.md
+++ b/docs/zh/client/java-sdk-user-guide.md
@@ -1,4 +1,4 @@
-~~>注意：本文档适用对象是Apollo系统的使用者，如果你是公司内Apollo系统的开发者/维护人员，建议先参考[Apollo开发指南](zh/contribution/apollo-development-guide)。
+>注意：本文档适用对象是Apollo系统的使用者，如果你是公司内Apollo系统的开发者/维护人员，建议先参考[Apollo开发指南](zh/contribution/apollo-development-guide)。
 
 # &nbsp;
 # 一、准备工作
@@ -1333,4 +1333,4 @@ interface是`com.ctrip.framework.apollo.spi.ConfigServiceLoadBalancerClient`。
 
 输入是meta server返回的多个ConfigService，输出是1个ConfigService。
 
-默认服务提供是`com.ctrip.framework.apollo.spi.RandomConfigServiceLoadBalancerClient`，使用random策略，也就是随机从多个ConfigService中选择1个ConfigService。~~
+默认服务提供是`com.ctrip.framework.apollo.spi.RandomConfigServiceLoadBalancerClient`，使用random策略，也就是随机从多个ConfigService中选择1个ConfigService。

--- a/docs/zh/client/java-sdk-user-guide.md
+++ b/docs/zh/client/java-sdk-user-guide.md
@@ -735,7 +735,7 @@ public class AnotherAppConfig {}
 // 新增支持了多appId和对应namespace的加载，注意使用多appId的情况下，key相同的情况，只会取优先加载appId的那一个key
 @Configuration
 @EnableApolloConfig(value = {"FX.apollo", "application.yml"},
-        multipleConfigs = {@MultipleConfig( appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
+        multipleConfigs = {@MultipleConfig(appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
 )
 public class SomeAppConfig {}
 ```

--- a/docs/zh/client/java-sdk-user-guide.md
+++ b/docs/zh/client/java-sdk-user-guide.md
@@ -1,4 +1,4 @@
->注意：本文档适用对象是Apollo系统的使用者，如果你是公司内Apollo系统的开发者/维护人员，建议先参考[Apollo开发指南](zh/contribution/apollo-development-guide)。
+~~>注意：本文档适用对象是Apollo系统的使用者，如果你是公司内Apollo系统的开发者/维护人员，建议先参考[Apollo开发指南](zh/contribution/apollo-development-guide)。
 
 # &nbsp;
 # 一、准备工作
@@ -583,6 +583,17 @@ ConfigFile configFile = ConfigService.getConfigFile("test", ConfigFileFormat.XML
 String content = configFile.getContent();
 ```
 
+### 3.1.5 读取多AppId对应namespace的配置
+指定对应的AppId和namespace来获取Config，再获取属性
+```java
+String someAppId = "Animal";
+String somePublicNamespace = "CAT";
+Config config = ConfigService.getConfig(someAppId, somePublicNamespace);
+String someKey = "someKeyFromPublicNamespace";
+String someDefaultValue = "someDefaultValueForTheKey";
+String value = config.getProperty(someKey, someDefaultValue);
+```
+
 ## 3.2 Spring整合方式
 
 ### 3.2.1 配置
@@ -718,6 +729,17 @@ public class SomeAppConfig {
 @EnableApolloConfig(value = {"FX.apollo", "application.yml"}, order = 1)
 public class AnotherAppConfig {}
 ```
+
+4.多appId的支持(新增于2.4.0版本)
+```java
+// 新增支持了多appId和对应namespace的加载，注意使用多appId的情况下，key相同的情况，只会取优先加载appId的那一个key
+@Configuration
+@EnableApolloConfig(value = {"FX.apollo", "application.yml"},
+        multipleConfigs = {@MultipleConfig( appid = "ORDER_SERVICE", namespaces = {"ORDER.apollo"})}
+)
+public class SomeAppConfig {}
+```
+
 
 #### 3.2.1.3 Spring Boot集成方式（推荐）
 
@@ -1311,4 +1333,4 @@ interface是`com.ctrip.framework.apollo.spi.ConfigServiceLoadBalancerClient`。
 
 输入是meta server返回的多个ConfigService，输出是1个ConfigService。
 
-默认服务提供是`com.ctrip.framework.apollo.spi.RandomConfigServiceLoadBalancerClient`，使用random策略，也就是随机从多个ConfigService中选择1个ConfigService。
+默认服务提供是`com.ctrip.framework.apollo.spi.RandomConfigServiceLoadBalancerClient`，使用random策略，也就是随机从多个ConfigService中选择1个ConfigService。~~


### PR DESCRIPTION
## What's the purpose of this PR

Add usage instructions for multiple  appid in the Apollo client

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

update docs for java client

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for Apollo client configuration and usage.
	- Added support for multiple AppIds and namespaces.
	- Introduced new configuration options and methods for `AppId` and `Apollo Meta Server`.
	- Expanded sections on caching paths and environment configurations.
	- New annotations for easier Spring integration and configuration management.
	- Added instructions for using the Apollo mock server for unit testing.

- **Bug Fixes**
	- Clarified Java and Guava version requirements.

- **Documentation**
	- Significant updates to both English and Chinese user guides, including clearer instructions and additional examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->