### PR TITLE
optimize: pre check dataChangeCreatedBy in updateItem

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -123,6 +123,9 @@ public class ItemController {
     }
 
     if (createIfNotExists) {
+      if (StringUtils.isEmpty(item.getDataChangeCreatedBy())) {
+        throw new BadRequestException("dataChangeCreatedBy is required when createIfNotExists is true");
+      }
       this.itemOpenApiService.createOrUpdateItem(appId, env, clusterName, namespaceName, item);
     } else {
       this.itemOpenApiService.updateItem(appId, env, clusterName, namespaceName, item);


### PR DESCRIPTION
## What's the purpose of this PR

在更新配置时，如果设置了createIfNotExists，提前校验dataChangeCreatedBy，返回更友好的错误提示


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation for item updates to ensure the `dataChangeCreatedBy` field is not empty when creating items conditionally.
  - Added a check to prevent updates without a specified creator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->