### PR TITLE
feat: 新增K8S集群中服务接入方式

### DIFF
--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -31,6 +31,7 @@
   - [PHP Client Usage Guide](en/client/php-sdks-user-guide.md)
   - [C Client Usage Guide](en/client/c-sdks-user-guide.md)
   - [Rust Client Usage Guide](en/client/rust-sdks-user-guide.md)
+  - [K8S ConfigMap Integration Usage Guide](en/client/k8s-configmap-user-guide.md)
   - [HTTP API Guide](en/client/other-language-client-user-guide.md)
 
 - Extension Guide

--- a/docs/en/client/k8s-configmap-user-guide.md
+++ b/docs/en/client/k8s-configmap-user-guide.md
@@ -1,0 +1,5 @@
+### Apollo K8S ConfigMap Integration
+
+Automatically sync Apollo configurations to K8S ConfigMap.
+
+Project URL: [apollo-configmap](https://github.com/adamswanglin/apollo-configmap)

--- a/docs/zh/_sidebar.md
+++ b/docs/zh/_sidebar.md
@@ -31,6 +31,7 @@
   - [PHP 客户端使用指南](zh/client/php-sdks-user-guide.md)
   - [C 客户端使用指南](zh/client/c-sdks-user-guide.md)
   - [Rust 客户端使用指南](zh/client/rust-sdks-user-guide.md)
+  - [K8S ConfigMap接入指南](zh/client/k8s-configmap-user-guide.md)
   - [HTTP API 接入指南](zh/client/other-language-client-user-guide.md)
 
 - 扩展开发

--- a/docs/zh/client/k8s-configmap-user-guide.md
+++ b/docs/zh/client/k8s-configmap-user-guide.md
@@ -1,0 +1,5 @@
+### Apollo K8S ConfigMap接入
+
+自动同步 Apollo 配置到 K8S ConfigMap 中
+
+项目地址：[apollo-configmap](https://github.com/adamswanglin/apollo-configmap)


### PR DESCRIPTION
## What's the purpose of this PR

新增ConfigMap接入方式

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

新增ConfigMap接入方式：自动同步 Apollo 配置到 K8S ConfigMap 中

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new guide for K8S ConfigMap integration in both English and Chinese client documentation.
	- Introduced sections detailing automatic Apollo configuration synchronization into K8S ConfigMap in both English and Chinese guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->