### PR TITLE
Provide a new configfiles API to return the raw content of configuration files directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Release Notes.
 Apollo 2.5.0
 
 ------------------
-* 
+* [Feature: Provide a new configfiles API to return the raw content of configuration files directly](https://github.com/apolloconfig/apollo/pull/5336)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/docs/en/client/other-language-client-user-guide.md
+++ b/docs/en/client/other-language-client-user-guide.md
@@ -34,7 +34,7 @@ Since the cache has a delay of at most one second, if you need to work with conf
 
 The Http interface returns JSON format, UTF-8 encoding, which contains all the configuration items in the corresponding namespace.
 
-Return content Sample is as follows.
+If the namespace is of type `properties`, the return content sample is as follows:
 
 ```json
 {
@@ -42,6 +42,15 @@ Return content Sample is as follows.
     "portal.elastic.cluster.name": "hermes-es-fws"
 }
 ```
+
+If the namespace is not of type `properties`, the return content sample is as follows:
+```json
+{
+    "content": "{\"portal.elastic.document.type\":\"biz\",\"portal.elastic.cluster.name\":\"hermes-es-fws\"}"
+}
+```
+
+> You can get the raw configuration content without escaping via `{config_server_url}/configfiles/raw/{appId}/{clusterName}/{namespaceName}?ip={clientIp}`.
 
 > The configuration in the form of properties can be obtained via `{config_server_url}/configfiles/{appId}/{clusterName}/{namespaceName}?ip={clientIp}`
 

--- a/docs/zh/client/other-language-client-user-guide.md
+++ b/docs/zh/client/other-language-client-user-guide.md
@@ -31,13 +31,22 @@
 ### 1.2.2 Http接口返回格式
 该Http接口返回的是JSON格式、UTF-8编码，包含了对应namespace中所有的配置项。
 
-返回内容Sample如下：
+若是properties类型的namespace，返回内容Sample如下：
 ```json
 {
     "portal.elastic.document.type":"biz",
     "portal.elastic.cluster.name":"hermes-es-fws"
 }
 ```
+
+若不是properties类型的namespace，返回内容Sample如下（content是namespace的内容）：
+```json
+{
+    "content": "{\"portal.elastic.document.type\":\"biz\",\"portal.elastic.cluster.name\":\"hermes-es-fws\"}"
+}
+```
+
+> 通过`{config_server_url}/configfiles/raw/{appId}/{clusterName}/{namespaceName}?ip={clientIp}`可以获取到原始的配置内容，不会进行转义。
 
 > 通过`{config_server_url}/configfiles/{appId}/{clusterName}/{namespaceName}?ip={clientIp}`可以获取到properties形式的配置
 


### PR DESCRIPTION
## What's the purpose of this PR

In some application scenarios, if Apollo can provide an API to directly return the raw content of configuration files, users can reference a ConfigService URL directly without the need for an additional proxy URL. See details at https://github.com/apolloconfig/apollo/issues/5327

## Which issue(s) this PR fixes:
Fixes #5327

## Brief changelog

Provide a new configfiles API to return the raw content of configuration files directly

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "configfiles API" for retrieving raw configuration content directly.
  - Enhanced response capabilities for different configuration formats.

- **Documentation**
  - Updated user guides to clarify response formats for different namespace types and how to access raw configuration content.

- **Tests**
  - Added tests for the new raw configuration retrieval functionality and refined existing mock behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->