### PR TITLE
feat: Provide a new open APl to return the organization list(#5349)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Apollo 2.5.0
 ------------------
 * [Refactor: align permission validator api between openapi and portal](https://github.com/apolloconfig/apollo/pull/5337)
 * [Feature: Provide a new configfiles API to return the raw content of configuration files directly](https://github.com/apolloconfig/apollo/pull/5336)
+* [Feature Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Apollo 2.5.0
 * [Refactor: align permission validator api between openapi and portal](https://github.com/apolloconfig/apollo/pull/5337)
 * [Feature: Provide a new configfiles API to return the raw content of configuration files directly](https://github.com/apolloconfig/apollo/pull/5336)
 * [Feature: Enhanced instance configuration auditing and caching](https://github.com/apolloconfig/apollo/pull/5361)
-* [Feature: Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
+* [Feature: Provide a new open API to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
+
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Apollo 2.5.0
 ------------------
 * [Refactor: align permission validator api between openapi and portal](https://github.com/apolloconfig/apollo/pull/5337)
 * [Feature: Provide a new configfiles API to return the raw content of configuration files directly](https://github.com/apolloconfig/apollo/pull/5336)
-* [Feature Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
 * [Feature: Enhanced instance configuration auditing and caching](https://github.com/apolloconfig/apollo/pull/5361)
+* [Feature: Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerOrganizationOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerOrganizationOpenApiService.java
@@ -22,6 +22,7 @@ import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
 import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
 import org.springframework.stereotype.Service;
 import java.util.List;
+
 @Service
 public class ServerOrganizationOpenApiService implements OrganizationOpenApiService {
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerOrganizationOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerOrganizationOpenApiService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.openapi.api.OrganizationOpenApiService;
+import com.ctrip.framework.apollo.openapi.dto.OpenOrganizationDto;
+import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
+import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
+import org.springframework.stereotype.Service;
+import java.util.List;
+@Service
+public class ServerOrganizationOpenApiService implements OrganizationOpenApiService {
+
+    private final PortalConfig portalConfig;
+
+    public ServerOrganizationOpenApiService(PortalConfig portalConfig) {
+        this.portalConfig = portalConfig;
+    }
+
+    @Override
+    public List<OpenOrganizationDto> getOrganizations() {
+        return OpenApiBeanUtils.transformFromOrganizations(portalConfig.organizations());
+    }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
@@ -191,6 +191,7 @@ public class OpenApiBeanUtils {
     Preconditions.checkArgument(openClusterDTO != null);
     return BeanUtils.transform(ClusterDTO.class, openClusterDTO);
   }
+
   public static OpenOrganizationDto transformFromOrganization(final Organization organization){
     Preconditions.checkArgument(organization != null);
     return BeanUtils.transform(OpenOrganizationDto.class, organization);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
@@ -23,6 +23,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenClusterDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleItemDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceLockDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenReleaseDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenOrganizationDto;
+import com.ctrip.framework.apollo.portal.entity.vo.Organization;
 import org.springframework.util.CollectionUtils;
 import com.ctrip.framework.apollo.common.dto.ClusterDTO;
 import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleDTO;
@@ -33,15 +45,6 @@ import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
 import com.ctrip.framework.apollo.common.entity.App;
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
-import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenClusterDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleItemDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceLockDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenReleaseDTO;
 import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
 import com.ctrip.framework.apollo.portal.entity.bo.NamespaceBO;
 import com.google.common.base.Preconditions;
@@ -187,5 +190,15 @@ public class OpenApiBeanUtils {
   public static ClusterDTO transformToClusterDTO(OpenClusterDTO openClusterDTO) {
     Preconditions.checkArgument(openClusterDTO != null);
     return BeanUtils.transform(ClusterDTO.class, openClusterDTO);
+  }
+  public static OpenOrganizationDto transformFromOrganization(final Organization organization){
+    Preconditions.checkArgument(organization != null);
+    return BeanUtils.transform(OpenOrganizationDto.class, organization);
+  }
+  public static List<OpenOrganizationDto> transformFromOrganizations(final List<Organization> organizations){
+    if (CollectionUtils.isEmpty(organizations)) {
+      return Collections.emptyList();
+    }
+    return organizations.stream().map(OpenApiBeanUtils::transformFromOrganization).collect(Collectors.toList());
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
@@ -195,6 +195,7 @@ public class OpenApiBeanUtils {
     Preconditions.checkArgument(organization != null);
     return BeanUtils.transform(OpenOrganizationDto.class, organization);
   }
+
   public static List<OpenOrganizationDto> transformFromOrganizations(final List<Organization> organizations){
     if (CollectionUtils.isEmpty(organizations)) {
       return Collections.emptyList();

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OrganizationController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OrganizationController.java
@@ -31,7 +31,6 @@ public class OrganizationController {
         this.organizationOpenApiService = organizationOpenApiService;
     }
 
-
     @RequestMapping("/organizations")
     public List<OpenOrganizationDto> getOrganization() {
         return organizationOpenApiService.getOrganizations();

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OrganizationController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OrganizationController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.openapi.api.OrganizationOpenApiService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.ctrip.framework.apollo.openapi.dto.OpenOrganizationDto;
+import java.util.List;
+
+@RestController("openapiOrganizationController")
+@RequestMapping("/openapi/v1")
+public class OrganizationController {
+    private final OrganizationOpenApiService organizationOpenApiService;
+
+    public OrganizationController(OrganizationOpenApiService organizationOpenApiService) {
+        this.organizationOpenApiService = organizationOpenApiService;
+    }
+
+
+    @RequestMapping("/organizations")
+    public List<OpenOrganizationDto> getOrganization() {
+        return organizationOpenApiService.getOrganizations();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<revision>2.5.0-SNAPSHOT</revision>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<apollo-java.version>2.4.0</apollo-java.version>
+		<apollo-java.version>2.5.0-SNAPSHOT</apollo-java.version>
 		<spring-boot.version>2.7.11</spring-boot.version>
 		<spring-cloud.version>2021.0.5</spring-cloud.version>
 		<!-- sort by alphabet -->


### PR DESCRIPTION
## What's the purpose of this PR

feat: Provide a new open APl to return the organization list([#5349](https://github.com/apolloconfig/apollo/issues/5349))

## Which issue(s) this PR fixes:
[#5349](https://github.com/apolloconfig/apollo/issues/5349)

## Brief changelog

After updating the project, we can use this method like this way： 
```java
       String portalUrl = "http://localhost:8070"; // portal url
        String token = "25e545146773469d1b9874339849487dc89f28e6d6e0dbd75a1664cca3bb1ada"; // 申请的token
        ApolloOpenApiClient client = ApolloOpenApiClient.newBuilder()
                .withPortalUrl(portalUrl)
                .withToken(token)
                .build();
        client.getOrganization().forEach(System.out::println);
```
![PixPin_2025-03-25_22-07-06](https://github.com/user-attachments/assets/ff597eb5-a951-4c97-9513-a7a61c2b19e6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new REST endpoint that enables retrieval of organization details.
  - Added new methods for transforming organization data into a more usable format.
  - Documented the addition of an API that returns the organization list.

- **Chores**
  - Upgraded the underlying platform dependency to a newer snapshot version for improved performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->