### PR TITLE
[issue-87][apollo-java]: Added a new feature to get instance count by namespace.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Apollo 2.5.0
 * [Feature: Provide a new open API to return the organization list](https://github.com/apolloconfig/apollo/pull/5365)
 * [Refactor: Exception handler adds root cause information](https://github.com/apolloconfig/apollo/pull/5367)
 * [Feature: Enhanced parameter verification for edit item](https://github.com/apolloconfig/apollo/pull/5376)
+* [Feature: Added a new feature to get instance count by namespace.](https://github.com/apolloconfig/apollo/pull/5381)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerInstanceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerInstanceOpenApiService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.openapi.api.InstanceOpenApiService;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.service.InstanceService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ServerInstanceOpenApiService implements InstanceOpenApiService {
+
+    private final InstanceService instanceService;
+
+    public ServerInstanceOpenApiService(InstanceService instanceService) {
+        this.instanceService = instanceService;
+    }
+
+    @Override
+    public int getInstanceCountByNamespace(String appId, String env, String clusterName, String namespaceName) {
+        return instanceService.getInstanceCountByNamespace(appId, Env.valueOf(env), clusterName, namespaceName);
+    }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.openapi.api.InstanceOpenApiService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("openapiInstanceController")
+@RequestMapping("/openapi/v1/envs/{env}")
+public class InstanceController {
+    private final InstanceOpenApiService instanceOpenApiService;
+
+    public InstanceController(InstanceOpenApiService instanceOpenApiService) {
+        this.instanceOpenApiService = instanceOpenApiService;
+    }
+
+    @GetMapping(value = "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances")
+    public int getInstanceCountByNamespace(@PathVariable String appId, @PathVariable String env,
+                                           @PathVariable String clusterName, @PathVariable String namespaceName) {
+        return this.instanceOpenApiService.getInstanceCountByNamespace(appId, env, clusterName, namespaceName);
+    }
+}


### PR DESCRIPTION
## What's the purpose of this PR

Get instance count by namespaces

## Which issue(s) this PR fixes:
For #[87](https://github.com/apolloconfig/apollo-java/issues/87)

## Brief changelog

Added a new feature to get instance count by namespace.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new REST API endpoint to retrieve the count of instances for a specific namespace, accessible via the OpenAPI.
  - Users can now query instance counts by specifying application ID, environment, cluster name, and namespace name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->