### PR TITLE
Fix cluster role cleanup on app and cluster deletion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Apollo 2.5.0
 * [Refactor: Exception handler adds root cause information](https://github.com/apolloconfig/apollo/pull/5367)
 * [Feature: Enhanced parameter verification for edit item](https://github.com/apolloconfig/apollo/pull/5376)
 * [Feature: Added a new feature to get instance count by namespace.](https://github.com/apolloconfig/apollo/pull/5381)
+* [BugFix: Remove cluster roles when deleting apps or clusters](https://github.com/apolloconfig/apollo/issues/5392)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
@@ -47,6 +47,9 @@ public interface PermissionRepository extends PagingAndSortingRepository<Permiss
       + "OR p.targetId like CONCAT(?1, '+', ?2, '+%')")
   List<Long> findPermissionIdsByAppIdAndNamespace(String appId, String namespaceName);
 
+  @Query("SELECT p.id from Permission p where p.targetId = CONCAT(?1, '+', ?2, '+', ?3)")
+  List<Long> findPermissionIdsByAppIdAndCluster(String appId, String env, String clusterName);
+
   @Modifying
   @Query("UPDATE Permission SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and IsDeleted = false")
   Integer batchDelete(List<Long> permissionIds, String operator);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
@@ -35,6 +35,8 @@ public interface RoleRepository extends PagingAndSortingRepository<Role, Long> {
   @Query("SELECT r.id from Role r where r.roleName like CONCAT('Master+', ?1) "
       + "OR r.roleName like CONCAT('ModifyNamespace+', ?1, '+%') "
       + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+%')  "
+      + "OR r.roleName like CONCAT('ModifyNamespacesInCluster+', ?1, '+%') "
+      + "OR r.roleName like CONCAT('ReleaseNamespacesInCluster+', ?1, '+%') "
       + "OR r.roleName like CONCAT('ManageAppMaster+', ?1)")
   List<Long> findRoleIdsByAppId(String appId);
 
@@ -43,6 +45,10 @@ public interface RoleRepository extends PagingAndSortingRepository<Role, Long> {
       + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+', ?2) "
       + "OR r.roleName like CONCAT('ReleaseNamespace+', ?1, '+', ?2, '+%')")
   List<Long> findRoleIdsByAppIdAndNamespace(String appId, String namespaceName);
+
+  @Query("SELECT r.id from Role r where r.roleName = CONCAT('ModifyNamespacesInCluster+', ?1, '+', ?2, '+', ?3) "
+      + "OR r.roleName = CONCAT('ReleaseNamespacesInCluster+', ?1, '+', ?2, '+', ?3)")
+  List<Long> findRoleIdsByAppIdAndCluster(String appId, String env, String clusterName);
 
   @Modifying
   @Query("UPDATE Role SET IsDeleted = true, DeletedAt = ROUND(UNIX_TIMESTAMP(NOW(4))*1000), DataChange_LastModifiedBy = ?2 WHERE Id in ?1 and IsDeleted = false")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ClusterService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ClusterService.java
@@ -22,6 +22,8 @@ import com.ctrip.framework.apollo.portal.environment.Env;
 import com.ctrip.framework.apollo.portal.api.AdminServiceAPI;
 import com.ctrip.framework.apollo.portal.constant.TracerEventType;
 import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import com.ctrip.framework.apollo.portal.service.RolePermissionService;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import org.springframework.stereotype.Service;
 
@@ -33,12 +35,14 @@ public class ClusterService {
   private final UserInfoHolder userInfoHolder;
   private final AdminServiceAPI.ClusterAPI clusterAPI;
   private final RoleInitializationService roleInitializationService;
+  private final RolePermissionService rolePermissionService;
 
   public ClusterService(final UserInfoHolder userInfoHolder, final AdminServiceAPI.ClusterAPI clusterAPI,
-      RoleInitializationService roleInitializationService) {
+      RoleInitializationService roleInitializationService, final RolePermissionService rolePermissionService) {
     this.userInfoHolder = userInfoHolder;
     this.clusterAPI = clusterAPI;
     this.roleInitializationService = roleInitializationService;
+    this.rolePermissionService = rolePermissionService;
   }
 
   public List<ClusterDTO> findClusters(Env env, String appId) {
@@ -60,7 +64,9 @@ public class ClusterService {
   }
 
   public void deleteCluster(Env env, String appId, String clusterName){
-    clusterAPI.delete(env, appId, clusterName, userInfoHolder.getUser().getUserId());
+    String operator = userInfoHolder.getUser().getUserId();
+    rolePermissionService.deleteRolePermissionsByAppIdAndCluster(appId, env.getName(), clusterName, operator);
+    clusterAPI.delete(env, appId, clusterName, operator);
   }
 
   public ClusterDTO loadCluster(String appId, Env env, String clusterName){

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RolePermissionService.java
@@ -87,4 +87,9 @@ public interface RolePermissionService {
    * delete permissions when delete app namespace.
    */
   void deleteRolePermissionsByAppIdAndNamespace(String appId, String namespaceName, String operator);
+
+  /**
+   * delete permissions when delete cluster.
+   */
+  void deleteRolePermissionsByAppIdAndCluster(String appId, String env, String clusterName, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -348,4 +348,32 @@ public class DefaultRolePermissionService implements RolePermissionService {
             consumerRoleRepository.batchDeleteByRoleIds(roleIds, operator);
         }
     }
+
+    @Transactional
+    @Override
+    public void deleteRolePermissionsByAppIdAndCluster(String appId, String env, String clusterName, String operator) {
+        appId = EscapeCharacter.DEFAULT.escape(appId);
+        List<Long> permissionIds = permissionRepository.findPermissionIdsByAppIdAndCluster(appId, env, clusterName);
+
+        if (!permissionIds.isEmpty()) {
+            // 1. delete Permission
+            permissionRepository.batchDelete(permissionIds, operator);
+
+            // 2. delete Role Permission
+            rolePermissionRepository.batchDeleteByPermissionIds(permissionIds, operator);
+        }
+
+        List<Long> roleIds = roleRepository.findRoleIdsByAppIdAndCluster(appId, env, clusterName);
+
+        if (!roleIds.isEmpty()) {
+            // 3. delete Role
+            roleRepository.batchDelete(roleIds, operator);
+
+            // 4. delete User Role
+            userRoleRepository.batchDeleteByRoleIds(roleIds, operator);
+
+            // 5. delete Consumer Role
+            consumerRoleRepository.batchDeleteByRoleIds(roleIds, operator);
+        }
+    }
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ClusterServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ClusterServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ctrip.framework.apollo.portal.service;
 
 import com.ctrip.framework.apollo.portal.environment.Env;

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ClusterServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ClusterServiceTest.java
@@ -1,0 +1,48 @@
+package com.ctrip.framework.apollo.portal.service;
+
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.api.AdminServiceAPI;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import com.ctrip.framework.apollo.portal.service.RolePermissionService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+public class ClusterServiceTest extends com.ctrip.framework.apollo.portal.AbstractUnitTest {
+
+  @Mock
+  private AdminServiceAPI.ClusterAPI clusterAPI;
+  @Mock
+  private RoleInitializationService roleInitializationService;
+  @Mock
+  private RolePermissionService rolePermissionService;
+  @Mock
+  private UserInfoHolder userInfoHolder;
+
+  @InjectMocks
+  private ClusterService clusterService;
+
+  private String appId = "clusterApp";
+  private String clusterName = "default";
+  private Env env = Env.DEV;
+
+  @Before
+  public void setUp() {
+    UserInfo user = new UserInfo();
+    user.setUserId("operator");
+    when(userInfoHolder.getUser()).thenReturn(user);
+  }
+
+  @Test
+  public void testDeleteClusterShouldCleanupRoles() {
+    clusterService.deleteCluster(env, appId, clusterName);
+
+    verify(rolePermissionService).deleteRolePermissionsByAppIdAndCluster(appId, env.getName(), clusterName, "operator");
+    verify(clusterAPI).delete(env, appId, clusterName, "operator");
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/defaultImpl/RolePermissionServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/defaultImpl/RolePermissionServiceTest.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.portal.spi.defaultImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import com.ctrip.framework.apollo.common.entity.BaseEntity;
 import com.ctrip.framework.apollo.portal.AbstractIntegrationTest;

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/defaultImpl/RolePermissionServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/defaultImpl/RolePermissionServiceTest.java
@@ -32,6 +32,7 @@ import com.ctrip.framework.apollo.portal.repository.RolePermissionRepository;
 import com.ctrip.framework.apollo.portal.repository.RoleRepository;
 import com.ctrip.framework.apollo.portal.repository.UserRoleRepository;
 import com.ctrip.framework.apollo.portal.service.RolePermissionService;
+import com.ctrip.framework.apollo.portal.util.RoleUtils;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
@@ -318,6 +319,40 @@ public class RolePermissionServiceTest extends AbstractIntegrationTest {
     assertFalse(rolePermissionService.userHasPermission(someUserWithNoPermission, somePermissionType, someTargetId));
     assertFalse(rolePermissionService.userHasPermission(someUserWithNoPermission, anotherPermissionType, anotherTargetId));
 
+  }
+
+  @Test
+  @Sql(scripts = "/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testDeleteRolePermissionsByAppIdWithClusterRoles() {
+    String appId = "clusterApp";
+    String operator = "test";
+
+    rolePermissionService.deleteRolePermissionsByAppId(appId, operator);
+
+    String modifyRoleName = RoleUtils.buildModifyNamespacesInClusterRoleName(appId, "DEV", "default");
+    String releaseRoleName = RoleUtils.buildReleaseNamespacesInClusterRoleName(appId, "DEV", "default");
+
+    assertNull(roleRepository.findTopByRoleName(modifyRoleName));
+    assertNull(roleRepository.findTopByRoleName(releaseRoleName));
+  }
+
+  @Test
+  @Sql(scripts = "/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testDeleteRolePermissionsByCluster() {
+    String appId = "clusterApp";
+    String operator = "test";
+
+    rolePermissionService.deleteRolePermissionsByAppIdAndCluster(appId, "DEV", "default", operator);
+
+    String modifyRoleName = RoleUtils.buildModifyNamespacesInClusterRoleName(appId, "DEV", "default");
+    String releaseRoleName = RoleUtils.buildReleaseNamespacesInClusterRoleName(appId, "DEV", "default");
+
+    assertNull(roleRepository.findTopByRoleName(modifyRoleName));
+    assertNull(roleRepository.findTopByRoleName(releaseRoleName));
   }
 
   private Role assembleRole(String roleName) {

--- a/apollo-portal/src/test/resources/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql
+++ b/apollo-portal/src/test/resources/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql
@@ -1,0 +1,11 @@
+INSERT INTO "Permission" (`Id`, `PermissionType`, `TargetId`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES
+  (1500, 'ModifyNamespacesInCluster', 'clusterApp+DEV+default', 'someOperator', 'someOperator'),
+  (1501, 'ReleaseNamespacesInCluster', 'clusterApp+DEV+default', 'someOperator', 'someOperator');
+
+INSERT INTO "Role" (`Id`, `RoleName`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES
+  (1500, 'ModifyNamespacesInCluster+clusterApp+DEV+default', 'someOperator', 'someOperator'),
+  (1501, 'ReleaseNamespacesInCluster+clusterApp+DEV+default', 'someOperator', 'someOperator');
+
+INSERT INTO "RolePermission" (`Id`, `RoleId`, `PermissionId`) VALUES
+  (1500, 1500, 1500),
+  (1501, 1501, 1501);

--- a/apollo-portal/src/test/resources/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql
+++ b/apollo-portal/src/test/resources/sql/permission/RolePermissionServiceTest.deleteRolePermissionsByAppIdWithClusterRoles.sql
@@ -1,3 +1,18 @@
+--
+-- Copyright 2025 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 INSERT INTO "Permission" (`Id`, `PermissionType`, `TargetId`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES
   (1500, 'ModifyNamespacesInCluster', 'clusterApp+DEV+default', 'someOperator', 'someOperator'),
   (1501, 'ReleaseNamespacesInCluster', 'clusterApp+DEV+default', 'someOperator', 'someOperator');


### PR DESCRIPTION
## Summary
- ensure cluster roles are deleted when an app or cluster is removed
- document cluster role cleanup

## Testing
- `mvn clean test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f9cf932148330b2329b0247ac2856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where cluster roles were not properly removed when deleting applications or clusters.

- **New Features**
  - Enhanced role and permission management with precise queries for cluster-specific roles.
  - Added automatic cleanup of role permissions associated with clusters during cluster deletion.

- **Tests**
  - Added unit tests to ensure role permissions and roles are correctly deleted when clusters are removed.
  - Included test data setup for cluster role permission scenarios.

- **Documentation**
  - Updated release notes to document the bug fix related to cluster role removal during deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->