### PR TITLE
fix: Bump h2database and snakeyaml version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,6 @@ Apollo 2.5.0
 * [Feature: Added a new feature to get instance count by namespace.](https://github.com/apolloconfig/apollo/pull/5381)
 * [Bugfix: Remove cluster-related roles and permissions upon deletion](https://github.com/apolloconfig/apollo/pull/5395)
 * [Security: Prevent unauthorized access to other users' apps in /apps/by-owner endpoint](https://github.com/apolloconfig/apollo/pull/5396)
-
+* [Fix: Bump h2database and snakeyaml version](https://github.com/apolloconfig/apollo/pull/5406)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
@@ -268,8 +268,8 @@ public class ItemController {
     protected Yaml createYaml() {
       LoaderOptions loaderOptions = new LoaderOptions();
       loaderOptions.setAllowDuplicateKeys(false);
-      return new Yaml(new SafeConstructor(), new Representer(),
-          new DumperOptions(), loaderOptions);
+      DumperOptions dumperOptions = new DumperOptions();
+      return new Yaml(new SafeConstructor(loaderOptions), new Representer(dumperOptions), dumperOptions, loaderOptions);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,9 @@
 		<javax.mail.version>1.6.2</javax.mail.version>
 		<jaxb.version>2.3.1</jaxb.version>
 		<junit.version>5.9.2</junit.version>
+		<h2database.version>2.2.220</h2database.version>
 		<nacos-discovery-api.version>1.4.0</nacos-discovery-api.version>
+		<snakeyaml.version>2.3</snakeyaml.version>
 		<!-- database driver -->
 		<mysql-connector-j.version>8.2.0</mysql-connector-j.version>
 		<postgre.version>42.7.2</postgre.version>
@@ -199,6 +201,18 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>${common-lang3.version}</version>
+			</dependency>
+			<!-- to fix CVE-2022-45868 -->
+			<dependency>
+				<groupId>com.h2database</groupId>
+				<artifactId>h2</artifactId>
+				<version>${h2database.version}</version>
+			</dependency>
+			<!-- to fix CVE-2022-1471 -->
+			<dependency>
+				<groupId>org.yaml</groupId>
+				<artifactId>snakeyaml</artifactId>
+				<version>${snakeyaml.version}</version>
 			</dependency>
 			<!-- to fix CVE-2024-47072 -->
 			<dependency>


### PR DESCRIPTION
## What's the purpose of this PR
Fixes [CVE-2022-45868](https://github.com/advisories/GHSA-22wj-vf5f-wrvj)
Fixes [CVE-2022-1471](https://github.com/advisories/GHSA-mjmj-j48q-9wg2)

## Brief changelog
Resolves issue [#5386 ](https://github.com/apolloconfig/apollo/issues/5386)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [√] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [√] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [√] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated H2 database and SnakeYAML library versions to address known security vulnerabilities.
- **Documentation**
	- Added release note about dependency updates and security fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->