### PR TITLE
* Hide password when registering or modifying users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,5 +16,6 @@ Apollo 2.5.0
 * [Security: Prevent unauthorized access to other users' apps in /apps/by-owner endpoint](https://github.com/apolloconfig/apollo/pull/5396)
 * [Fix: Bump h2database and snakeyaml version](https://github.com/apolloconfig/apollo/pull/5406)
 * [Bugfix: Correct permission target format to appId+env+namespace/cluster](https://github.com/apolloconfig/apollo/pull/5407)
+* [Security: Hide password when registering or modifying users](https://github.com/apolloconfig/apollo/pull/5414)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -622,6 +622,8 @@
   "UserMange.UserName": "User Login Name",
   "UserMange.UserDisplayName": "User Display Name",
   "UserMange.Pwd": "Password",
+  "UserMange.ConfirmPwd": "Confirm Password",
+  "UserMange.PwdNotMatch": "Passwords do not match",
   "UserMange.Email": "Email",
   "UserMange.Created": "Create user successfully",
   "UserMange.CreateFailed": "Failed to create user",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -622,6 +622,8 @@
   "UserMange.UserName": "用户登录账户",
   "UserMange.UserDisplayName": "用户名称",
   "UserMange.Pwd": "密码",
+  "UserMange.ConfirmPwd": "确认密码",
+  "UserMange.PwdNotMatch": "密码不匹配",
   "UserMange.Email": "邮箱",
   "UserMange.Created": "创建用户成功",
   "UserMange.CreateFailed": "创建用户失败",

--- a/apollo-portal/src/main/resources/static/scripts/controller/UserController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/UserController.js
@@ -28,6 +28,7 @@ function UserController($scope, $window, $translate, toastr, AppUtil, UserServic
     $scope.changeStatus = changeStatus
     $scope.searchUsers = searchUsers
     $scope.resetSearchUser = resetSearchUser
+    $scope.validatePwdMatch = validatePwdMatch
 
     initPermission();
 
@@ -85,6 +86,13 @@ function UserController($scope, $window, $translate, toastr, AppUtil, UserServic
         searchUsers()
     }
 
+    function validatePwdMatch() {
+        $scope.pwdNotMatch = false;
+        if ($scope.user.password && $scope.user.password != $scope.user.confirmPassword) {
+            $scope.pwdNotMatch = true;
+        }
+    }
+
     $scope.changeUserEnabled = function (user) {
         var newUser={}
         if (user != null) {
@@ -104,6 +112,10 @@ function UserController($scope, $window, $translate, toastr, AppUtil, UserServic
     }
 
     $scope.createOrUpdateUser = function () {
+        validatePwdMatch();
+        if ($scope.pwdNotMatch) {
+            return;
+        }
         if ($scope.status === '2') {
             UserService.createOrUpdateUser(true, $scope.user).then(function (result) {
                 toastr.success($translate.instant('UserMange.Created'));

--- a/apollo-portal/src/main/resources/static/user-manage.html
+++ b/apollo-portal/src/main/resources/static/user-manage.html
@@ -131,7 +131,19 @@
                                 {{'UserMange.Pwd' | translate }}
                             </label>
                             <div class="col-sm-5">
-                                <input type="text" class="form-control" name="password" ng-model="user.password">
+                                <input type="password" class="form-control" name="password" ng-model="user.password">
+                                <div ng-show="pwdNotMatch" ng-model="pwdNotMatch" style="color:red">
+                                    {{'UserMange.PwdNotMatch' | translate }}
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group" valdr-form-group>
+                            <label class="col-sm-2 control-label">
+                                <apollorequiredfield></apollorequiredfield>
+                                {{'UserMange.ConfirmPwd' | translate }}
+                            </label>
+                            <div class="col-sm-5">
+                                <input type="password" class="form-control" name="confirmPassword" ng-model="user.confirmPassword" ng-blur="validatePwdMatch()">
                             </div>
                         </div>
                         <div class="form-group" valdr-form-group>
@@ -157,7 +169,7 @@
                             <div class="col-sm-offset-2 col-sm-9">
 
                                 <button type="submit" class="btn btn-primary"
-                                        ng-disabled="appForm.$invalid || submitBtnDisabled">{{status==='3' ? ('UserMange.Save' | translate) : ('Common.Submit' | translate) }}
+                                        ng-disabled="appForm.$invalid || submitBtnDisabled || pwdNotMatch">{{status==='3' ? ('UserMange.Save' | translate) : ('Common.Submit' | translate) }}
                                 </button>
                                 <button type="button" ng-click="changeStatus('1')" class="btn">{{status==='3' ? ('UserMange.Cancel' | translate) : ('UserMange.Back' | translate) }}</button>
                             </div>


### PR DESCRIPTION
## What's the purpose of this PR
Passwords displayed in plain text pose security risks

## Brief changelog
Follow this checklist to help us incorporate your contribution quickly and easily:

- [√] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [√] Write necessary unit tests to verify the code.
- [√] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [√] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added password confirmation field during user creation and editing, with real-time validation to ensure passwords match.
  - Password input is now masked for improved privacy.
  - Error message displayed if passwords do not match, and submission is disabled until resolved.

- **Localization**
  - Added English and Chinese translations for "Confirm Password" and "Passwords do not match" in the user management interface.

- **Documentation**
  - Updated changelog to note password masking for user registration and modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->