### PR TITLE
Fix: the logical judgment for configuration addition, deletion, and modification.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,5 +17,6 @@ Apollo 2.5.0
 * [Fix: Bump h2database and snakeyaml version](https://github.com/apolloconfig/apollo/pull/5406)
 * [Bugfix: Correct permission target format to appId+env+namespace/cluster](https://github.com/apolloconfig/apollo/pull/5407)
 * [Security: Hide password when registering or modifying users](https://github.com/apolloconfig/apollo/pull/5414)
+* [Fix: fix the logical judgment for configuration addition, deletion, and modification.](https://github.com/apolloconfig/apollo/pull/5430)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
@@ -22,7 +22,7 @@ public class ItemBO {
     private ItemDTO item;
     private boolean isModified;
     private boolean isDeleted;
-    private boolean isNewAdded;
+    private boolean isNewlyAdded;
     private String oldValue;
     private String newValue;
 
@@ -66,11 +66,11 @@ public class ItemBO {
       this.newValue = newValue;
     }
 
-    public boolean isNewAdded() {
-        return isNewAdded;
+    public boolean isNewlyAdded() {
+        return isNewlyAdded;
     }
 
-    public void setNewAdded(boolean newAdded) {
-        isNewAdded = newAdded;
+    public void setNewlyAdded(boolean newlyAdded) {
+        isNewlyAdded = newlyAdded;
     }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
@@ -22,6 +22,7 @@ public class ItemBO {
     private ItemDTO item;
     private boolean isModified;
     private boolean isDeleted;
+    private boolean isNewAdded;
     private String oldValue;
     private String newValue;
 
@@ -65,5 +66,11 @@ public class ItemBO {
       this.newValue = newValue;
     }
 
+    public boolean isNewAdded() {
+        return isNewAdded;
+    }
 
-  }
+    public void setNewAdded(boolean newAdded) {
+        isNewAdded = newAdded;
+    }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -422,6 +422,7 @@ public class NamespaceService {
     //new item or modified
     if (!StringUtils.isEmpty(key) && (!newValue.equals(oldValue))) {
       itemBO.setModified(true);
+      itemBO.setNewAdded(!releaseItems.containsKey(key));
       itemBO.setOldValue(oldValue == null ? "" : oldValue);
       itemBO.setNewValue(newValue);
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -422,7 +422,7 @@ public class NamespaceService {
     //new item or modified
     if (!StringUtils.isEmpty(key) && (!newValue.equals(oldValue))) {
       itemBO.setModified(true);
-      itemBO.setNewAdded(!releaseItems.containsKey(key));
+      itemBO.setNewlyAdded(!releaseItems.containsKey(key));
       itemBO.setOldValue(oldValue == null ? "" : oldValue);
       itemBO.setNewValue(newValue);
     }

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -348,11 +348,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isNewAdded"
+                                    <span class="label label-success" ng-if="config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -480,11 +480,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isNewAdded"
+                                    <span class="label label-success" ng-if="config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -727,11 +727,11 @@
                                         ng-click="showText(config.item.key)">
                                         <span ng-bind="config.item.key | limitTo: 250"></span>
                                         <span ng-bind="config.item.key.length > 250 ? '...' :''"></span>
-                                        <span class="label label-success" ng-if="config.isNewAdded"
+                                        <span class="label label-success" ng-if="config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -348,11 +348,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                    <span class="label label-success" ng-if="config.isNewAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -480,11 +480,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                    <span class="label label-success" ng-if="config.isNewAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -727,11 +727,11 @@
                                         ng-click="showText(config.item.key)">
                                         <span ng-bind="config.item.key | limitTo: 250"></span>
                                         <span ng-bind="config.item.key.length > 250 ? '...' :''"></span>
-                                        <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                        <span class="label label-success" ng-if="config.isNewAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/release-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/release-modal.html
@@ -91,11 +91,11 @@
                                     ng-if="config.item.key && config.isModified">
                                     <td width="20%" title="{{config.item.key}}">
                                         <span ng-bind="config.item.key"></span>
-                                        <span class="label label-success" ng-if="config.isNewAdded"
+                                        <span class="label label-success" ng-if="config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.NewAddedTips' | translate }}">{{'Component.Publish.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.ModifiedTips' | translate }}">{{'Component.Publish.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/release-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/release-modal.html
@@ -91,11 +91,11 @@
                                     ng-if="config.item.key && config.isModified">
                                     <td width="20%" title="{{config.item.key}}">
                                         <span ng-bind="config.item.key"></span>
-                                        <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                        <span class="label label-success" ng-if="config.isNewAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.NewAddedTips' | translate }}">{{'Component.Publish.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.ModifiedTips' | translate }}">{{'Component.Publish.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"


### PR DESCRIPTION
## What's the purpose of this PR

您好，我在使用apollo的过程中，发现了一个问题，对于未发布的配置，增删改的判断有一些问题，做了下修复

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog
一、复现步骤

1、原始数据如下：
<img width="1458" height="339" alt="image" src="https://github.com/user-attachments/assets/54900196-d113-402d-9c7f-afaa4af24866" />

2、修改第二条数据，value设为1;  删除第三条数据
<img width="1437" height="421" alt="image" src="https://github.com/user-attachments/assets/33edb2ce-98a2-4470-9317-b36547769182" />

可以看到第二条和第三条数据的标识出现了错误，发布页面也有同样的问题

<img width="1455" height="430" alt="image" src="https://github.com/user-attachments/assets/2a01d2ea-650b-44ee-82b1-aaebdb638ec2" />



二、问题修复
1、对配置的增删改判断逻辑做下了修改，效果如下：

<img width="1453" height="351" alt="image" src="https://github.com/user-attachments/assets/56148b28-e3ae-4755-a50a-1269803c323e" />

<img width="1453" height="427" alt="image" src="https://github.com/user-attachments/assets/b644892f-5f93-4d48-948d-5fa765f6a20f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced configuration item labels to clearly distinguish newly added items from modified ones in the namespace panel and release modal.

* **Bug Fixes**
  * Corrected logic for identifying newly added configuration items to improve accuracy in status labeling.

* **Style**
  * Updated label display logic for configuration changes to improve clarity for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->