### PR TITLE
fix the logical judgment for configuration addition, deletion, and modification.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,5 +17,6 @@ Apollo 2.5.0
 * [Fix: Bump h2database and snakeyaml version](https://github.com/apolloconfig/apollo/pull/5406)
 * [Bugfix: Correct permission target format to appId+env+namespace/cluster](https://github.com/apolloconfig/apollo/pull/5407)
 * [Security: Hide password when registering or modifying users](https://github.com/apolloconfig/apollo/pull/5414)
+* [Fix: the logical judgment for configuration addition, deletion, and modification.](https://github.com/apolloconfig/apollo/pull/5432)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/ItemBO.java
@@ -22,6 +22,7 @@ public class ItemBO {
     private ItemDTO item;
     private boolean isModified;
     private boolean isDeleted;
+    private boolean isNewlyAdded;
     private String oldValue;
     private String newValue;
 
@@ -65,5 +66,11 @@ public class ItemBO {
       this.newValue = newValue;
     }
 
+    public boolean isNewlyAdded() {
+        return isNewlyAdded;
+    }
 
-  }
+    public void setNewlyAdded(boolean newlyAdded) {
+        isNewlyAdded = newlyAdded;
+    }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/NamespaceService.java
@@ -422,6 +422,7 @@ public class NamespaceService {
     //new item or modified
     if (!StringUtils.isEmpty(key) && (!newValue.equals(oldValue))) {
       itemBO.setModified(true);
+      itemBO.setNewlyAdded(!releaseItems.containsKey(key));
       itemBO.setOldValue(oldValue == null ? "" : oldValue);
       itemBO.setNewValue(newValue);
     }

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -348,11 +348,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                    <span class="label label-success" ng-if="config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -480,11 +480,11 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.HaveGrayscale' | translate }}"
                                         ng-click="namespace.displayControl.currentOperateBranch=namespace.branchName;namespace.branch.viewType='table'">{{'Component.Namespace.Master.Items.Body.Grayscale' | translate }}</span>
-                                    <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                    <span class="label label-success" ng-if="config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -727,11 +727,11 @@
                                         ng-click="showText(config.item.key)">
                                         <span ng-bind="config.item.key | limitTo: 250"></span>
                                         <span ng-bind="config.item.key.length > 250 ? '...' :''"></span>
-                                        <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                        <span class="label label-success" ng-if="config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -352,7 +352,7 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
+                                        ng-if="config.isModified && !config.isDeleted && !config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -484,7 +484,7 @@
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                     <span class="label label-info"
-                                        ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
+                                        ng-if="config.isModified  && !config.isDeleted && !config.isNewlyAdded"
                                         data-tooltip="tooltip" data-placement="bottom"
                                         title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                     <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"
@@ -731,7 +731,7 @@
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.NewAddedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
+                                            ng-if="config.isModified  && !config.isDeleted && !config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Namespace.Master.Items.Body.ModifiedTips' | translate }}">{{'Component.Namespace.Master.Items.Body.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/release-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/release-modal.html
@@ -95,7 +95,7 @@
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.NewAddedTips' | translate }}">{{'Component.Publish.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isDeleted && !config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.ModifiedTips' | translate }}">{{'Component.Publish.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"

--- a/apollo-portal/src/main/resources/static/views/component/release-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/release-modal.html
@@ -91,11 +91,11 @@
                                     ng-if="config.item.key && config.isModified">
                                     <td width="20%" title="{{config.item.key}}">
                                         <span ng-bind="config.item.key"></span>
-                                        <span class="label label-success" ng-if="config.isModified && !config.oldValue"
+                                        <span class="label label-success" ng-if="config.isNewlyAdded"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.NewAddedTips' | translate }}">{{'Component.Publish.NewAdded' | translate }}</span>
                                         <span class="label label-info"
-                                            ng-if="config.isModified && config.oldValue && !config.isDeleted"
+                                            ng-if="config.isModified && !config.isNewlyAdded && !config.isDeleted"
                                             data-tooltip="tooltip" data-placement="bottom"
                                             title="{{'Component.Publish.ModifiedTips' | translate }}">{{'Component.Publish.Modified' | translate }}</span>
                                         <span class="label label-danger" ng-if="config.isDeleted" data-tooltip="tooltip"


### PR DESCRIPTION
## What's the purpose of this PR

您好，我在使用apollo的过程中，发现了一个问题，对于未发布的配置，增删改的判断有一些问题，做了下修复

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

一、复现步骤

1、原始数据如下：

<img width="1198" height="283" alt="image" src="https://github.com/user-attachments/assets/9cfbd275-8f29-496e-8dec-dec0036f9adf" />


2、修改第二条数据，value设为1; 删除第三条数据

<img width="1210" height="348" alt="image" src="https://github.com/user-attachments/assets/ac5eb129-76da-495c-aa87-8fa0438c7fd0" />


可以看到第二条和第三条数据的标识出现了错误，发布页面也有同样的问题

<img width="1206" height="358" alt="image" src="https://github.com/user-attachments/assets/3f5ebc93-2a6c-45cc-8a71-6a3ffa56c6bf" />


二、问题修复
1、对配置的增删改判断逻辑做下了修改，效果如下：

<img width="1212" height="301" alt="image" src="https://github.com/user-attachments/assets/249862d3-7c49-44e0-90a4-dab9ad3015c3" />


<img width="1200" height="363" alt="image" src="https://github.com/user-attachments/assets/938ed6cc-3b84-4265-a75a-1c510a923d7f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of status labels for configuration items, clearly distinguishing between newly added and modified items in the namespace panel and release modal.
  * Updated release notes to document the correction in logical judgment for configuration changes.

* **New Features**
  * Added explicit visual indication for newly added configuration items in relevant UI panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->