### PR TITLE
feat(openapi): instance domain service impl, controller migration and tests

### DIFF
--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -27,6 +27,7 @@
 	<artifactId>apollo-portal</artifactId>
 	<name>Apollo Portal</name>
 	<properties>
+		<apollo.openapi.spec.url>https://raw.githubusercontent.com/tacklequestions/apollo-openapi/main/apollo-openapi.yaml</apollo.openapi.spec.url>
 		<github.path>${project.artifactId}</github.path>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 	</properties>
@@ -43,6 +44,21 @@
 		<dependency>
 			<groupId>com.ctrip.framework.apollo</groupId>
 			<artifactId>apollo-openapi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.openapitools</groupId>
+			<artifactId>jackson-databind-nullable</artifactId>
+			<version>0.2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
+			<version>2.2.22</version>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-models-jakarta</artifactId>
+			<version>2.2.22</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ctrip.framework.apollo</groupId>
@@ -121,6 +137,40 @@
 
 	</dependencies>
 	<build>
+		<!-- 默认插件配置（公共部分） -->
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.openapitools</groupId>
+					<artifactId>openapi-generator-maven-plugin</artifactId>
+					<version>7.15.0</version>
+					<executions>
+						<execution>
+							<id>generate-openapi-sources</id>
+							<phase>generate-sources</phase>
+							<goals>
+								<goal>generate</goal>
+							</goals>
+							<configuration>
+								<inputSpec>${apollo.openapi.spec.url}</inputSpec>
+								<generatorName>spring</generatorName>
+								<output>${project.build.directory}/generated-sources/openapi</output>
+								<apiPackage>com.ctrip.framework.apollo.openapi.api</apiPackage>
+								<modelPackage>com.ctrip.framework.apollo.openapi.model</modelPackage>
+								<invokerPackage>com.ctrip.framework.apollo.openapi.invoker</invokerPackage>
+								<configOptions>
+									<interfaceOnly>true</interfaceOnly>
+									<useTags>true</useTags>
+									<dateLibrary>java8</dateLibrary>
+								</configOptions>
+								<skipValidateSpec>true</skipValidateSpec>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
@@ -198,6 +248,73 @@
 					</replacements>
 				</configuration>
 			</plugin>
+			<!-- OpenAPI 代码生成插件 -->
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+			</plugin>
+
+			<!-- 把生成目录标记为源码目录，让 IDE 直接参与编译 -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.4.0</version>
+				<executions>
+					<execution>
+						<id>add-openapi-sources</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<!-- 注意这层 src/main/java -->
+								<source>${project.build.directory}/generated-sources/openapi/src/main/java</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Java 8 环境 -->
+		<profile>
+			<id>java8</id>
+			<activation>
+				<jdk>[1.8,1.9)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.openapitools</groupId>
+							<artifactId>openapi-generator-maven-plugin</artifactId>
+							<version>6.6.0</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
+		<!-- Java 11 及以上环境 -->
+		<profile>
+			<id>java11plus</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.openapitools</groupId>
+							<artifactId>openapi-generator-maven-plugin</artifactId>
+							<version>7.15.0</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/InstanceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/InstanceOpenApiService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.common.dto.InstanceDTO;
+import com.ctrip.framework.apollo.common.dto.PageDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPageDTOOpenInstanceDTO;
+
+import java.util.List;
+import java.util.Set;
+
+public interface InstanceOpenApiService {
+
+    /**
+     * Return instance count by namespace
+     * @since 2.5.0
+     */
+    int getInstanceCountByNamespace(String appId, String env, String clusterName, String namespaceName);
+
+    OpenPageDTOOpenInstanceDTO getByRelease(String env, long releaseId, int page, int size);
+
+    OpenPageDTOOpenInstanceDTO getByNamespace(String env, String appId, String clusterName,
+                                            String namespaceName, String instanceAppId,
+                                            int page, int size);
+
+    List<OpenInstanceDTO> getByReleasesNotIn(String env, String appId, String clusterName,
+                                             String namespaceName, Set<Long> releaseIds);
+
+    OpenPageDTOOpenInstanceDTO transformToOpenPageDTO(PageDTO<InstanceDTO> pageDTO);
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerInstanceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerInstanceOpenApiService.java
@@ -21,7 +21,7 @@ import com.ctrip.framework.apollo.portal.environment.Env;
 import com.ctrip.framework.apollo.portal.service.InstanceService;
 import org.springframework.stereotype.Service;
 
-@Service
+@Service("ServerInstanceOpenApiServiceOld")
 public class ServerInstanceOpenApiService implements InstanceOpenApiService {
 
     private final InstanceService instanceService;

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/impl/ServerInstanceOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/impl/ServerInstanceOpenApiService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service.impl;
+
+import com.ctrip.framework.apollo.common.dto.InstanceDTO;
+import com.ctrip.framework.apollo.common.dto.PageDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPageDTOOpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.server.service.InstanceOpenApiService;
+import com.ctrip.framework.apollo.openapi.util.OpenApiModelConverters;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.service.InstanceService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Server端实现的Instance OpenAPI服务
+ * 通过封装调用InstanceService的方法来实现OpenAPI功能
+ */
+@Service
+public class ServerInstanceOpenApiService implements InstanceOpenApiService {
+
+    private final InstanceService instanceService;
+
+    public ServerInstanceOpenApiService(InstanceService instanceService) {
+        this.instanceService = instanceService;
+    }
+
+    @Override
+    public int getInstanceCountByNamespace(String appId, String env, String clusterName, String namespaceName) {
+        return instanceService.getInstanceCountByNamespace(appId, Env.valueOf(env), clusterName, namespaceName);
+    }
+
+    /**
+     * 根据发布版本查询实例（支持分页） - 返回OpenAPI DTO
+     */
+    @Override
+    public OpenPageDTOOpenInstanceDTO getByRelease(String env, long releaseId, int page, int size) {
+        PageDTO<InstanceDTO> portalPageDTO = instanceService.getByRelease(Env.valueOf(env), releaseId, page, size);
+
+        return transformToOpenPageDTO(portalPageDTO);
+    }
+
+    /**
+     * 根据命名空间查询实例（支持分页） - 返回OpenAPI DTO
+     */
+    @Override
+    public OpenPageDTOOpenInstanceDTO getByNamespace(String env, String appId, String clusterName,
+                                                   String namespaceName, String instanceAppId,
+                                                   int page, int size) {
+        PageDTO<InstanceDTO> portalPageDTO = instanceService.getByNamespace(Env.valueOf(env), appId, clusterName, namespaceName, instanceAppId, page, size);
+        return transformToOpenPageDTO(portalPageDTO);
+    }
+
+    /**
+     * 查询不在指定发布版本中的实例 - 返回OpenAPI DTO
+     */
+    @Override
+    public List<OpenInstanceDTO> getByReleasesNotIn(String env, String appId, String clusterName,
+                                                    String namespaceName, Set<Long> releaseIds) {
+        List<InstanceDTO> portalInstances = instanceService.getByReleasesNotIn(Env.valueOf(env), appId, clusterName, namespaceName, releaseIds);
+        return OpenApiModelConverters.fromInstanceDTOs(portalInstances);
+    }
+
+    /**
+     * 将PageDTO<InstanceDTO>转换为OpenPageDTOOpenInstanceDTO
+     */
+    @Override
+    public OpenPageDTOOpenInstanceDTO transformToOpenPageDTO(PageDTO<InstanceDTO> pageDTO) {
+        List<OpenInstanceDTO> openContent = OpenApiModelConverters.fromInstanceDTOs(pageDTO.getContent());
+        OpenPageDTOOpenInstanceDTO openPageDTOOpenInstanceDTO = new OpenPageDTOOpenInstanceDTO();
+        openPageDTOOpenInstanceDTO.setPage(pageDTO.getPage());
+        openPageDTOOpenInstanceDTO.setSize(pageDTO.getSize());
+        openPageDTOOpenInstanceDTO.setTotal(pageDTO.getTotal());
+        openPageDTOOpenInstanceDTO.setContent(openContent);
+
+        return openPageDTOOpenInstanceDTO;
+    }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiModelConverters.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiModelConverters.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ctrip.framework.apollo.openapi.util;
+
+import com.ctrip.framework.apollo.common.dto.*;
+import com.ctrip.framework.apollo.common.entity.App;
+import com.ctrip.framework.apollo.common.entity.AppNamespace;
+import com.ctrip.framework.apollo.common.utils.BeanUtils;
+import com.ctrip.framework.apollo.openapi.model.*;
+import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
+import com.ctrip.framework.apollo.portal.entity.bo.NamespaceBO;
+import com.ctrip.framework.apollo.portal.entity.bo.ReleaseBO;
+import com.ctrip.framework.apollo.portal.entity.model.NamespaceSyncModel;
+import com.ctrip.framework.apollo.portal.entity.model.NamespaceTextModel;
+import com.ctrip.framework.apollo.portal.entity.vo.EnvClusterInfo;
+import com.ctrip.framework.apollo.portal.entity.vo.ItemDiffs;
+import com.ctrip.framework.apollo.portal.entity.vo.NamespaceIdentifier;
+import com.ctrip.framework.apollo.portal.entity.vo.Organization;
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.springframework.util.CollectionUtils;
+
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Non-invasive converters for OpenAPI generated model classes.
+ * This class mirrors/OpenApiBeanUtils functions but targets com.ctrip.framework.apollo.openapi.model.* types.
+ */
+public final class OpenApiModelConverters {
+
+  private static final Gson GSON = new Gson();
+  private static final Type TYPE = new TypeToken<Map<String, String>>() {}.getType();
+
+  private OpenApiModelConverters() {}
+
+  // region Item conversions
+  public static OpenItemDTO fromItemDTO(ItemDTO item) {
+    Preconditions.checkArgument(item != null);
+    return BeanUtils.transform(OpenItemDTO.class, item);
+  }
+
+  public static ItemDTO toItemDTO(OpenItemDTO openItemDTO) {
+    Preconditions.checkArgument(openItemDTO != null);
+    return BeanUtils.transform(ItemDTO.class, openItemDTO);
+  }
+
+  public static List<ItemDTO> toItemDTOs(List<OpenItemDTO> openItemDTOs) {
+    if (CollectionUtils.isEmpty(openItemDTOs)) {
+      return Collections.emptyList();
+    }
+    return openItemDTOs.stream().map(OpenApiModelConverters::toItemDTO).collect(Collectors.toList());
+  }
+
+  public static List<OpenItemDTO> fromItemDTOs(List<ItemDTO> items) {
+    if (CollectionUtils.isEmpty(items)) {
+      return Collections.emptyList();
+    }
+    return items.stream().map(OpenApiModelConverters::fromItemDTO).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region App/AppNamespace conversions
+  public static OpenAppNamespaceDTO fromAppNamespace(AppNamespace appNamespace) {
+    Preconditions.checkArgument(appNamespace != null);
+    return BeanUtils.transform(OpenAppNamespaceDTO.class, appNamespace);
+  }
+
+  public static AppNamespace toAppNamespace(OpenAppNamespaceDTO openAppNamespaceDTO) {
+    Preconditions.checkArgument(openAppNamespaceDTO != null);
+    return BeanUtils.transform(AppNamespace.class, openAppNamespaceDTO);
+  }
+
+  public static List<OpenAppDTO> fromApps(final List<App> apps) {
+    if (CollectionUtils.isEmpty(apps)) {
+      return Collections.emptyList();
+    }
+    return apps.stream().map(OpenApiModelConverters::fromApp).collect(Collectors.toList());
+  }
+
+  public static OpenAppDTO fromApp(final App app) {
+    Preconditions.checkArgument(app != null);
+    return BeanUtils.transform(OpenAppDTO.class, app);
+  }
+  // endregion
+
+  // region Release conversions
+  public static OpenReleaseDTO fromReleaseDTO(ReleaseDTO release) {
+    Preconditions.checkArgument(release != null);
+    OpenReleaseDTO openReleaseDTO = BeanUtils.transform(OpenReleaseDTO.class, release);
+    Map<String, String> configs = GSON.fromJson(release.getConfigurations(), TYPE);
+    openReleaseDTO.setConfigurations(configs);
+    return openReleaseDTO;
+  }
+
+  public static OpenReleaseBO fromReleaseBO(final ReleaseBO releaseBO) {
+    Preconditions.checkArgument(releaseBO != null);
+    OpenReleaseBO openReleaseBO = new OpenReleaseBO();
+    openReleaseBO.setBaseInfo(fromReleaseDTO(releaseBO.getBaseInfo()));
+    Set<com.ctrip.framework.apollo.portal.entity.bo.KVEntity> items = releaseBO.getItems();
+    List<KVEntity> itemsList = new ArrayList<>();
+    if (!CollectionUtils.isEmpty(items)) {
+      for (com.ctrip.framework.apollo.portal.entity.bo.KVEntity item : items) {
+        KVEntity kvEntity = new KVEntity();
+        kvEntity.setKey(item.getKey());
+        kvEntity.setValue(item.getValue());
+        itemsList.add(kvEntity);
+      }
+    }
+    openReleaseBO.setItems(itemsList);
+    return openReleaseBO;
+  }
+
+  public static List<OpenReleaseBO> fromReleaseBOs(final List<ReleaseBO> releaseBOs) {
+    if (CollectionUtils.isEmpty(releaseBOs)) {
+      return Collections.emptyList();
+    }
+    return releaseBOs.stream().map(OpenApiModelConverters::fromReleaseBO).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Namespace conversions
+  public static OpenNamespaceDTO fromNamespaceBO(NamespaceBO namespaceBO) {
+    Preconditions.checkArgument(namespaceBO != null);
+    OpenNamespaceDTO openNamespaceDTO = BeanUtils.transform(OpenNamespaceDTO.class, namespaceBO.getBaseInfo());
+    openNamespaceDTO.setFormat(namespaceBO.getFormat());
+    openNamespaceDTO.setComment(namespaceBO.getComment());
+    openNamespaceDTO.setIsPublic(namespaceBO.isPublic());
+    List<OpenItemDTO> items = new LinkedList<>();
+    List<ItemBO> itemBOs = namespaceBO.getItems();
+    if (!CollectionUtils.isEmpty(itemBOs)) {
+      items.addAll(itemBOs.stream().map(itemBO -> fromItemDTO(itemBO.getItem())).collect(Collectors.toList()));
+    }
+    openNamespaceDTO.setItems(items);
+    return openNamespaceDTO;
+  }
+
+  public static List<OpenNamespaceDTO> fromNamespaceBOs(List<NamespaceBO> namespaceBOs) {
+    if (CollectionUtils.isEmpty(namespaceBOs)) {
+      return Collections.emptyList();
+    }
+    return namespaceBOs.stream().map(OpenApiModelConverters::fromNamespaceBO).collect(Collectors.toCollection(LinkedList::new));
+  }
+
+  public static OpenNamespaceLockDTO fromNamespaceLockDTO(String namespaceName, NamespaceLockDTO namespaceLock) {
+    OpenNamespaceLockDTO lock = new OpenNamespaceLockDTO();
+    lock.setNamespaceName(namespaceName);
+    if (namespaceLock == null) {
+      lock.setIsLocked(false);
+    } else {
+      lock.setIsLocked(true);
+      lock.setLockedBy(namespaceLock.getDataChangeCreatedBy());
+    }
+    return lock;
+  }
+
+  public static OpenNamespaceDTO fromNamespaceDTO(NamespaceDTO namespaceDTO) {
+    Preconditions.checkArgument(namespaceDTO != null);
+    return BeanUtils.transform(OpenNamespaceDTO.class, namespaceDTO);
+  }
+
+  public static NamespaceTextModel toNamespaceTextModel(final OpenNamespaceTextModel openNamespaceTextModel) {
+    Preconditions.checkArgument(openNamespaceTextModel != null);
+    return BeanUtils.transform(NamespaceTextModel.class, openNamespaceTextModel);
+  }
+
+  public static List<NamespaceTextModel> toNamespaceTextModels(final List<OpenNamespaceTextModel> openNamespaceTextModels) {
+    if (CollectionUtils.isEmpty(openNamespaceTextModels)) {
+      return Collections.emptyList();
+    }
+    return openNamespaceTextModels.stream().map(OpenApiModelConverters::toNamespaceTextModel).collect(Collectors.toList());
+  }
+
+  public static NamespaceIdentifier toNamespaceIdentifier(final OpenNamespaceIdentifier openNamespaceIdentifier) {
+    Preconditions.checkArgument(openNamespaceIdentifier != null);
+    NamespaceIdentifier namespaceIdentifier = new NamespaceIdentifier();
+    namespaceIdentifier.setAppId(openNamespaceIdentifier.getAppId());
+    namespaceIdentifier.setEnv(openNamespaceIdentifier.getEnv());
+    namespaceIdentifier.setClusterName(openNamespaceIdentifier.getClusterName());
+    namespaceIdentifier.setNamespaceName(openNamespaceIdentifier.getNamespaceName());
+    return namespaceIdentifier;
+  }
+
+  public static List<NamespaceIdentifier> toNamespaceIdentifiers(final List<OpenNamespaceIdentifier> openNamespaceIdentifiers) {
+    if (CollectionUtils.isEmpty(openNamespaceIdentifiers)) {
+      return Collections.emptyList();
+    }
+    return openNamespaceIdentifiers.stream().map(OpenApiModelConverters::toNamespaceIdentifier).collect(Collectors.toList());
+  }
+
+  public static OpenNamespaceIdentifier fromNamespaceIdentifier(final NamespaceIdentifier namespaceIdentifier) {
+    Preconditions.checkArgument(namespaceIdentifier != null);
+    OpenNamespaceIdentifier openNamespaceIdentifier = new OpenNamespaceIdentifier();
+    openNamespaceIdentifier.setAppId(namespaceIdentifier.getAppId());
+    openNamespaceIdentifier.setEnv(namespaceIdentifier.getEnv().toString());
+    openNamespaceIdentifier.setClusterName(namespaceIdentifier.getClusterName());
+    openNamespaceIdentifier.setNamespaceName(namespaceIdentifier.getNamespaceName());
+    return openNamespaceIdentifier;
+  }
+
+  public static NamespaceSyncModel toNamespaceSyncModel(final OpenNamespaceSyncModel openNamespaceSyncModel) {
+    Preconditions.checkArgument(openNamespaceSyncModel != null);
+    NamespaceSyncModel model = BeanUtils.transform(NamespaceSyncModel.class, openNamespaceSyncModel);
+    if (openNamespaceSyncModel.getSyncToNamespaces() != null) {
+      model.setSyncToNamespaces(toNamespaceIdentifiers(openNamespaceSyncModel.getSyncToNamespaces()));
+    }
+    if (openNamespaceSyncModel.getSyncItems() != null) {
+      model.setSyncItems(toItemDTOs(openNamespaceSyncModel.getSyncItems()));
+    }
+    return model;
+  }
+
+  public static List<NamespaceSyncModel> toNamespaceSyncModels(final List<OpenNamespaceSyncModel> openNamespaceSyncModels) {
+    if (CollectionUtils.isEmpty(openNamespaceSyncModels)) {
+      return Collections.emptyList();
+    }
+    return openNamespaceSyncModels.stream().map(OpenApiModelConverters::toNamespaceSyncModel).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Gray release rule conversions
+  public static OpenGrayReleaseRuleDTO fromGrayReleaseRuleDTO(GrayReleaseRuleDTO grayReleaseRuleDTO) {
+    Preconditions.checkArgument(grayReleaseRuleDTO != null);
+    return BeanUtils.transform(OpenGrayReleaseRuleDTO.class, grayReleaseRuleDTO);
+  }
+
+  public static GrayReleaseRuleDTO toGrayReleaseRuleDTO(OpenGrayReleaseRuleDTO openGrayReleaseRuleDTO) {
+    Preconditions.checkArgument(openGrayReleaseRuleDTO != null);
+    String appId = openGrayReleaseRuleDTO.getAppId();
+    String branchName = openGrayReleaseRuleDTO.getBranchName();
+    String clusterName = openGrayReleaseRuleDTO.getClusterName();
+    String namespaceName = openGrayReleaseRuleDTO.getNamespaceName();
+    GrayReleaseRuleDTO grayReleaseRuleDTO = new GrayReleaseRuleDTO(appId, clusterName, namespaceName, branchName);
+    Set<OpenGrayReleaseRuleItemDTO> openGrayReleaseRuleItemDTOSet = new HashSet<>(openGrayReleaseRuleDTO.getRuleItems());
+    openGrayReleaseRuleItemDTOSet.forEach(openGrayReleaseRuleItemDTO -> {
+      String clientAppId = openGrayReleaseRuleItemDTO.getClientAppId();
+      Set<String> clientIpList = new HashSet<>(openGrayReleaseRuleItemDTO.getClientIpList());
+      Set<String> clientLabelList = new HashSet<>(openGrayReleaseRuleItemDTO.getClientLabelList());
+      GrayReleaseRuleItemDTO ruleItem = new GrayReleaseRuleItemDTO(clientAppId, clientIpList, clientLabelList);
+      grayReleaseRuleDTO.addRuleItem(ruleItem);
+    });
+    return grayReleaseRuleDTO;
+  }
+  // endregion
+
+  // region Cluster conversions
+  public static OpenClusterDTO fromClusterDTO(ClusterDTO cluster) {
+    Preconditions.checkArgument(cluster != null);
+    return BeanUtils.transform(OpenClusterDTO.class, cluster);
+  }
+
+  public static ClusterDTO toClusterDTO(OpenClusterDTO openClusterDTO) {
+    Preconditions.checkArgument(openClusterDTO != null);
+    return BeanUtils.transform(ClusterDTO.class, openClusterDTO);
+  }
+  // endregion
+
+  // region Organization conversions
+  public static OpenOrganizationDto fromOrganization(final Organization organization) {
+    Preconditions.checkArgument(organization != null);
+    return BeanUtils.transform(OpenOrganizationDto.class, organization);
+  }
+
+  public static List<OpenOrganizationDto> fromOrganizations(final List<Organization> organizations) {
+    if (CollectionUtils.isEmpty(organizations)) {
+      return Collections.emptyList();
+    }
+    return organizations.stream().map(OpenApiModelConverters::fromOrganization).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Instance conversions
+  public static OpenInstanceDTO fromInstanceDTO(final InstanceDTO instanceDTO) {
+    Preconditions.checkArgument(instanceDTO != null);
+    return BeanUtils.transform(OpenInstanceDTO.class, instanceDTO);
+  }
+
+  public static List<OpenInstanceDTO> fromInstanceDTOs(final List<InstanceDTO> instanceDTOs) {
+    if (CollectionUtils.isEmpty(instanceDTOs)) {
+      return Collections.emptyList();
+    }
+    return instanceDTOs.stream().map(OpenApiModelConverters::fromInstanceDTO).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Env/Cluster info conversions
+  public static OpenEnvClusterInfo fromEnvClusterInfo(final EnvClusterInfo envClusterInfo) {
+    Preconditions.checkArgument(envClusterInfo != null);
+    return BeanUtils.transform(OpenEnvClusterInfo.class, envClusterInfo);
+  }
+
+  public static List<OpenEnvClusterInfo> fromEnvClusterInfos(final List<EnvClusterInfo> envClusterInfos) {
+    if (CollectionUtils.isEmpty(envClusterInfos)) {
+      return Collections.emptyList();
+    }
+    return envClusterInfos.stream().map(OpenApiModelConverters::fromEnvClusterInfo).collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Item diffs/change sets
+  public static OpenItemChangeSets fromItemChangeSets(final ItemChangeSets itemChangeSets) {
+    Preconditions.checkArgument(itemChangeSets != null);
+    OpenItemChangeSets openItemChangeSets = new OpenItemChangeSets();
+    if (itemChangeSets.getCreateItems() != null) {
+      openItemChangeSets.setCreateItems(fromItemDTOs(itemChangeSets.getCreateItems()));
+    }
+    if (itemChangeSets.getUpdateItems() != null) {
+      openItemChangeSets.setUpdateItems(fromItemDTOs(itemChangeSets.getUpdateItems()));
+    }
+    if (itemChangeSets.getDeleteItems() != null) {
+      openItemChangeSets.setDeleteItems(fromItemDTOs(itemChangeSets.getDeleteItems()));
+    }
+    return openItemChangeSets;
+  }
+
+  public static OpenItemDiffs fromItemDiffs(final ItemDiffs itemDiffs) {
+    Preconditions.checkArgument(itemDiffs != null);
+    OpenItemDiffs openItemDiffs = new OpenItemDiffs();
+    if (itemDiffs.getNamespace() != null) {
+      openItemDiffs.setNamespace(fromNamespaceIdentifier(itemDiffs.getNamespace()));
+    }
+    if (itemDiffs.getDiffs() != null) {
+      openItemDiffs.setDiffs(fromItemChangeSets(itemDiffs.getDiffs()));
+    }
+    openItemDiffs.setExtInfo(itemDiffs.getExtInfo());
+    return openItemDiffs;
+  }
+
+  public static List<OpenItemDiffs> fromItemDiffsList(final List<ItemDiffs> itemDiffsList) {
+    if (CollectionUtils.isEmpty(itemDiffsList)) {
+      return Collections.emptyList();
+    }
+    return itemDiffsList.stream().map(OpenApiModelConverters::fromItemDiffs).collect(Collectors.toList());
+  }
+  // endregion
+}
+

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceController.java
@@ -16,21 +16,90 @@
  */
 package com.ctrip.framework.apollo.openapi.v1.controller;
 
-import com.ctrip.framework.apollo.openapi.api.InstanceOpenApiService;
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.openapi.model.OpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPageDTOOpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.server.service.InstanceOpenApiService;
+import com.google.common.base.Splitter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RestController("openapiInstanceController")
 @RequestMapping("/openapi/v1/envs/{env}")
 public class InstanceController {
+    
+    private static final Splitter RELEASES_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
+    
     private final InstanceOpenApiService instanceOpenApiService;
 
     public InstanceController(InstanceOpenApiService instanceOpenApiService) {
         this.instanceOpenApiService = instanceOpenApiService;
     }
 
+    /**
+     * 获取命名空间下的实例数量
+     * GET /openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances
+     */
     @GetMapping(value = "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances")
     public int getInstanceCountByNamespace(@PathVariable String appId, @PathVariable String env,
                                            @PathVariable String clusterName, @PathVariable String namespaceName) {
         return this.instanceOpenApiService.getInstanceCountByNamespace(appId, env, clusterName, namespaceName);
+    }
+
+    /**
+     * 根据发布版本查询实例（支持分页）
+     * GET /openapi/v1/envs/{env}/releases/{releaseId}/instances
+     */
+    @GetMapping(value = "/releases/{releaseId}/instances")
+    public ResponseEntity<OpenPageDTOOpenInstanceDTO> getInstancesByRelease(@PathVariable String env,
+                                                                          @PathVariable Long releaseId,
+                                                                          @RequestParam(defaultValue = "0") int page,
+                                                                          @RequestParam(defaultValue = "20") int size) {
+        OpenPageDTOOpenInstanceDTO instances = instanceOpenApiService.getByRelease(env, releaseId, page, size);
+        return ResponseEntity.ok(instances);
+    }
+
+    /**
+     * 根据命名空间查询实例（支持分页）
+     * GET /openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances_search
+     */
+    @GetMapping(value = "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances_search")
+    public ResponseEntity<OpenPageDTOOpenInstanceDTO> getInstancesByNamespace(@PathVariable String env,
+                                                                         @PathVariable String appId,
+                                                                         @PathVariable String clusterName,
+                                                                         @PathVariable String namespaceName,
+                                                                         @RequestParam(required = false) String instanceAppId,
+                                                                         @RequestParam(defaultValue = "0") int page,
+                                                                         @RequestParam(defaultValue = "20") int size) {
+        OpenPageDTOOpenInstanceDTO instances = instanceOpenApiService.getByNamespace(env, appId, clusterName, namespaceName, instanceAppId, page, size);
+        return ResponseEntity.ok(instances);
+    }
+
+    /**
+     * 查询不在指定发布版本中的实例
+     * GET /openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances_not_in?excludeReleases=1,2,3
+     */
+    @GetMapping(value = "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/instances_not_in",
+                params = "excludeReleases")
+    public ResponseEntity<List<OpenInstanceDTO>> getInstancesExcludingReleases(@PathVariable String env, 
+                                                                               @PathVariable String appId,
+                                                                               @PathVariable String clusterName, 
+                                                                               @PathVariable String namespaceName,
+                                                                               @RequestParam("excludeReleases") String releaseIds) {
+        Set<Long> releaseIdSet = RELEASES_SPLITTER.splitToList(releaseIds).stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+
+        if (CollectionUtils.isEmpty(releaseIdSet)) {
+            throw new BadRequestException("excludeReleases parameter cannot be empty");
+        }
+
+        List<OpenInstanceDTO> instances = instanceOpenApiService.getByReleasesNotIn(env, appId, clusterName, namespaceName, releaseIdSet);
+        return ResponseEntity.ok(instances);
     }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/springsecurity/SpringSecurityUserInfoHolder.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/springsecurity/SpringSecurityUserInfoHolder.java
@@ -16,34 +16,98 @@
  */
 package com.ctrip.framework.apollo.portal.spi.springsecurity;
 
+import com.ctrip.framework.apollo.openapi.entity.Consumer;
+import com.ctrip.framework.apollo.openapi.service.ConsumerService;
 import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
 import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
 import com.ctrip.framework.apollo.portal.spi.UserService;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 
 public class SpringSecurityUserInfoHolder implements UserInfoHolder {
 
-  private final UserService userService;
 
-  public SpringSecurityUserInfoHolder(UserService userService) {
+  private final UserService userService;
+  private final ConsumerService consumerService;
+
+  public SpringSecurityUserInfoHolder(UserService userService,
+                               @Lazy ConsumerService consumerService) {
     this.userService = userService;
+    this.consumerService = consumerService;
   }
 
   @Override
   public UserInfo getUser() {
-    String userId = this.getCurrentUsername();
-    UserInfo userInfoFound = this.userService.findByUserId(userId);
+    // 首先尝试从OpenAPI Consumer上下文获取用户信息
+    UserInfo consumerUserInfo = getConsumerUserInfo();
+    if (consumerUserInfo != null) {
+      return consumerUserInfo;
+    }
+
+    // 回退到Spring Security上下文
+    String userId = getCurrentUsername();
+    UserInfo userInfoFound = userService.findByUserId(userId);
     if (userInfoFound != null) {
       return userInfoFound;
     }
+
     UserInfo userInfo = new UserInfo();
     userInfo.setUserId(userId);
     return userInfo;
   }
 
+  /**
+   * 从OpenAPI Consumer上下文获取用户信息
+   */
+  private UserInfo getConsumerUserInfo() {
+    try {
+      ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+      if (attributes == null) {
+        return null;
+      }
+
+      HttpServletRequest request = attributes.getRequest();
+      String requestURI = request.getRequestURI();
+
+      // 只对OpenAPI请求处理Consumer用户信息
+      if (!requestURI.startsWith("/openapi/")) {
+        return null;
+      }
+
+      // 获取Consumer ID
+      Object consumerIdObj = request.getAttribute("Authorization");
+      if (consumerIdObj == null) {
+        return null;
+      }
+
+      long consumerId = Long.parseLong(consumerIdObj.toString());
+      Consumer consumer = consumerService.getConsumerByConsumerId(consumerId);
+      if (consumer == null) {
+        return null;
+      }
+
+      // 构建基于Consumer的用户信息
+      UserInfo userInfo = new UserInfo();
+      userInfo.setUserId(consumer.getOwnerName());
+      userInfo.setName(consumer.getName());
+      userInfo.setEmail(consumer.getOwnerEmail());
+
+      return userInfo;
+    } catch (Exception e) {
+      // 如果获取Consumer信息失败，返回null，让系统回退到默认方式
+      return null;
+    }
+  }
+
+  /**
+   * 从Spring Security上下文获取用户名
+   */
   private String getCurrentUsername() {
     Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     if (principal instanceof UserDetails) {
@@ -54,5 +118,4 @@ public class SpringSecurityUserInfoHolder implements UserInfoHolder {
     }
     return String.valueOf(principal);
   }
-
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceControllerTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceControllerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.openapi.auth.ConsumerPermissionValidator;
+import com.ctrip.framework.apollo.openapi.model.OpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPageDTOOpenInstanceDTO;
+import com.ctrip.framework.apollo.openapi.server.service.InstanceOpenApiService;
+import com.ctrip.framework.apollo.openapi.util.ConsumerAuthUtil;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = InstanceController.class)
+public class InstanceControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private ConsumerAuthUtil consumerAuthUtil;
+
+  @MockBean
+  private InstanceOpenApiService instanceOpenApiService;
+
+  @MockBean(name = "consumerPermissionValidator")
+  private ConsumerPermissionValidator consumerPermissionValidator;
+
+  @Test
+  public void testGetInstanceCountByNamespace() throws Exception {
+    final String appId = "app-id-test";
+    final String env = "DEV";
+    final String clusterName = "default";
+    final String namespaceName = "application";
+    final int mockInstanceCount = 10;
+
+    when(this.instanceOpenApiService.getInstanceCountByNamespace(appId, env, clusterName, namespaceName))
+        .thenReturn(mockInstanceCount);
+
+    this.mockMvc.perform(MockMvcRequestBuilders.get(
+            String.format("/openapi/v1/envs/%s/apps/%s/clusters/%s/namespaces/%s/instances",
+                env, appId, clusterName, namespaceName)))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(String.valueOf(mockInstanceCount)));
+  }
+
+  @Test
+  public void testGetInstancesByRelease() throws Exception {
+    final String env = "DEV";
+    final long releaseId = 100L;
+    final int page = 0;
+    final int size = 10;
+
+    OpenPageDTOOpenInstanceDTO mockPage = new OpenPageDTOOpenInstanceDTO();
+    mockPage.setPage(page);
+    mockPage.setSize(size);
+    mockPage.setTotal(1L);
+    mockPage.setContent(Arrays.asList(new OpenInstanceDTO()));
+
+    when(this.instanceOpenApiService.getByRelease(env, releaseId, page, size))
+        .thenReturn(mockPage);
+
+    this.mockMvc.perform(MockMvcRequestBuilders.get(
+            String.format("/openapi/v1/envs/%s/releases/%s/instances", env, releaseId))
+            .param("page", String.valueOf(page))
+            .param("size", String.valueOf(size)))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)));
+  }
+
+  @Test
+  public void testGetInstancesByNamespace() throws Exception {
+    final String env = "PRO";
+    final String appId = "some-app";
+    final String clusterName = "default";
+    final String namespaceName = "application";
+    final String instanceAppId = "instance-app-id";
+    final int page = 0;
+    final int size = 20;
+
+    OpenPageDTOOpenInstanceDTO mockPage = new OpenPageDTOOpenInstanceDTO();
+    mockPage.setPage(page);
+    mockPage.setSize(size);
+    mockPage.setTotal(2L);
+    mockPage.setContent(Arrays.asList(new OpenInstanceDTO(), new OpenInstanceDTO()));
+
+    when(this.instanceOpenApiService.getByNamespace(env, appId, clusterName, namespaceName, instanceAppId, page, size))
+        .thenReturn(mockPage);
+
+    this.mockMvc.perform(MockMvcRequestBuilders.get(
+            String.format("/openapi/v1/envs/%s/apps/%s/clusters/%s/namespaces/%s/instances_search",
+                env, appId, clusterName, namespaceName))
+            .param("instanceAppId", instanceAppId)
+            .param("page", String.valueOf(page))
+            .param("size", String.valueOf(size)))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(2)));
+  }
+
+  @Test
+  public void testGetInstancesExcludingReleases() throws Exception {
+    final String env = "UAT";
+    final String appId = "another-app";
+    final String clusterName = "default";
+    final String namespaceName = "application";
+    final String releaseIds = "1,2,3";
+
+    when(this.instanceOpenApiService.getByReleasesNotIn(env, appId, clusterName, namespaceName, ImmutableSet.of(1L, 2L, 3L)))
+        .thenReturn(Arrays.asList(new OpenInstanceDTO()));
+
+    this.mockMvc.perform(MockMvcRequestBuilders.get(
+            String.format("/openapi/v1/envs/%s/apps/%s/clusters/%s/namespaces/%s/instances_not_in",
+                env, appId, clusterName, namespaceName))
+            .param("excludeReleases", releaseIds))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)));
+  }
+
+  @Test
+  public void testGetInstancesExcludingReleasesWithEmptyParam() throws Exception {
+    final String env = "UAT";
+    final String appId = "another-app";
+    final String clusterName = "default";
+    final String namespaceName = "application";
+
+    this.mockMvc.perform(MockMvcRequestBuilders.get(
+            String.format("/openapi/v1/envs/%s/apps/%s/clusters/%s/namespaces/%s/instances_not_in",
+                env, appId, clusterName, namespaceName))
+            .param("excludeReleases", ""))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
  ## What's the purpose of this PR

  Refactor the Instance domain end-to-end on top of generated OpenAPI models: add a server-side OpenAPI service interface and implementation for Instance,
  migrate the OpenAPI InstanceController to use it, and add/update tests. Keep the legacy service bean (named) to avoid Java 8 bean conflicts. Uses the
  non-invasive converters from PR03.

  ## Which issue(s) this PR fixes:

  Fixes #5462 

  ## Brief changelog

  - Add server-side interface: apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/InstanceOpenApiService.java
  - Add implementation: apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/impl/ServerInstanceOpenApiService.java
      - Use OpenApiModelConverters for DTO conversions
      - Implement queries: count by namespace, list by release (paged), list by namespace (paged), and list not in releases
  - Migrate controller: apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceController.java
  - Add tests: apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/InstanceControllerTest.java
  - Retain legacy service: apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerInstanceOpenApiService.java with
  @Service("ServerInstanceOpenApiServiceOld") to ensure Java 8 build compatibility
  - No changes to OpenApiBeanUtils; scope limited to Instance domain; base on PR03 (converters)