### PR TITLE
fix: avoid accidentally deleting new appNamespaceCache of same appid and name with old appNamesppace.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,5 +22,6 @@ Apollo 2.5.0
 * [optimize: Implement unified permission verification logic and Optimize the implementation of permission verification](https://github.com/apolloconfig/apollo/pull/5456)
 * [CI: Add code and header formatter by spotless plugin](https://github.com/apolloconfig/apollo/pull/5485)
 * [Fix: Operate the AccessKey multiple times within one second](https://github.com/apolloconfig/apollo/pull/5490)
+* [Bugfix: Prevent accidental cache deletion when recreating AppNamespace with the same name and appid](https://github.com/apolloconfig/apollo/issues/5502)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AppNamespaceServiceWithCache.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AppNamespaceServiceWithCache.java
@@ -37,10 +37,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -261,7 +258,13 @@ public class AppNamespaceServiceWithCache implements InitializingBean {
       if (deleted == null) {
         continue;
       }
-      appNamespaceCache.remove(assembleAppNamespaceKey(deleted));
+
+      String appNamespaceKey = assembleAppNamespaceKey(deleted);
+      AppNamespace appNamespace = appNamespaceCache.get(appNamespaceKey);
+      if (appNamespace != null && Objects.equals(appNamespace.getId(), deletedId)) {
+        appNamespaceCache.remove(appNamespaceKey);
+      }
+
       if (deleted.isPublic()) {
         AppNamespace publicAppNamespace = publicAppNamespaceCache.get(deleted.getName());
         // in case there is some dirty data, e.g. public namespace deleted in some app and now


### PR DESCRIPTION
## What's the purpose of this PR

This PR addresses a cache eviction bug in AppNamespaceServiceWithCache that occurs when an AppNamespace is deleted and immediately recreated.

The Problem: When an administrator deletes an AppNamespace and recreates it with the same name and appid within a short window (e.g. 1 minute), the scheduled cleanup task (running every 60s) for the old deleted namespace mistakenly removes the cache key associated with the new namespace. This happens because the cache key is derived from appId + namespaceName, leading to a collision.
<img width="2176" height="1626" alt="d972ce27cc2b7583554c938697e9355f" src="https://github.com/user-attachments/assets/f7874048-8544-4fe4-b19b-e0d4549afc6d" />


The Fix: Updated the cache cleanup logic to ensure that the cache is only evicted if it truly belongs to the deleted namespace, preventing accidental deletion of the new namespace's cache.

## Which issue(s) this PR fixes:

Fixes #5502 

## Brief changelog

Fix: Resolve an issue where the cache of a newly created AppNamespace could be accidentally deleted by the cleanup task of a deleted AppNamespace with the same name and appid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental cache deletion when recreating AppNamespace with the same name and appid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->