### PR TITLE
docs: update release guide for skill-driven workflow

### DIFF
--- a/docs/zh/contribution/apollo-release-guide.md
+++ b/docs/zh/contribution/apollo-release-guide.md
@@ -1,138 +1,160 @@
-# 1. 升级版本
+# Apollo 发布指南（Skill 自动化版）
 
-在 Apollo 工程下全文替换版本号，例如 1.9.1-SNAPSHOT 升级到 1.9.1。替换过程中，一定要注意非版本号的地方替换。
+本文档面向在 Codex / Claude Code 中通过自然语言触发 Skill 的发布方式。
+目标是：减少手工步骤、统一发布质量，并在关键外部动作前保留人工确认。
 
-# 2. 撰写发布报告
+## 1. 适用范围与推荐顺序
 
-两个版本之间每一个 PR 都会记录在 [https://github.com/apolloconfig/apollo/blob/master/CHANGES.md](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md) 里，所以撰写发布报告只需要从 CHANGES.md 里提取即可。发布报告参考：[https://github.com/apolloconfig/apollo/releases/tag/v1.8.0](https://github.com/apolloconfig/apollo/releases/tag/v1.8.0)
+Apollo 发布流程由 3 个 Skill 覆盖：
 
-# 3. 版本验证
+1. `apollo-java-release`：发布 `apolloconfig/apollo-java`
+2. `apollo-release`：发布 `apolloconfig/apollo`
+3. `apollo-helm-chart-release`：发布 `apolloconfig/apollo-helm-chart`
 
-版本验证主要包含三方面的验证：
+推荐顺序：
 
-1. 新引入的代码变更验证，例如新功能、bugfix
-1. Apollo 核心主流程验证，包括：配置发布，动态推送，灰度推送等
-1. 升级过程验证，包括：经典部署模式、docker 模式、k8s 模式
+1. 先发布 `apollo-java-release`（不依赖其它发布流程）
+2. 再发布 `apollo-release`（通常依赖本次 Java SDK 版本）
+3. 最后发布 `apollo-helm-chart-release`
 
-# 4. 版本发布
+> 若本次发布不涉及某个仓库，可跳过对应子流程。
 
-## 4.1 打 tag
+## 2. 发布前准备
 
-1. 拉取 master 最新代码
-   1. git pull origin master  
-2. 打 tag
-   1. git tag ${new-version}
-3. push tag
-   1. git push origin tag ${new-version}
+### 2.1 权限与工具
 
-## 4.2 打包
+- GitHub 账号具备对应仓库的 PR、Release、Workflow、Discussion、Milestone 权限
+- 本地可用命令：`git`、`gh`、`python3`、`jq`
+- Helm Chart 发布额外需要：`helm`
 
-### 4.2.1 前置检查
+### 2.2 仓库与分支状态
 
-在打包之前检查本地环境, mvn -v 确保 java 版本是 1.8, 例如以下输出：
+- 在每个目标仓库执行前，确保工作区干净（无未提交变更）
+- 确认基线分支最新（`apollo` 默认 `master`，其余仓库按各自默认分支）
 
-> mvn -v
-> Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)Maven home: /usr/local/Cellar/maven/3.8.1/libexec
-> Java version: 1.8.0_301, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk1.8.0_301.jdk/Contents/Home/jre
-> Default locale: zh_CN, platform encoding: UTF-8
-> OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
+### 2.3 建议提前准备的发布输入
 
-### 4.2.2 打包
+- 发布版本号（如 `2.8.0`）
+- 下一开发版本（如 `2.9.0-SNAPSHOT`）
+- Highlights 对应 PR 列表（如 `PR_ID_1,PR_ID_2,PR_ID_3`）
 
-在 ${apollo_home}/scripts/ 目录下执行：
+### 2.4 安装发布 Skill（Codex / Claude Code）
 
-> ./build.sh
+在使用本文档后续流程前，请先安装这 3 个 Skill：
 
-如果报以下错误：
+- `apollo-java-release`
+- `apollo-release`
+- `apollo-helm-chart-release`
 
-> zsh: ./build.sh: bad interpreter: /bin/sh^M: no such file or directory
+推荐方式（自然语言）：
 
-则需要执行以下命令转换成 unix
+1. 在 Codex 会话中使用 `skill-installer`
+2. 安装来源指定为完整 GitHub 地址：`https://github.com/apolloconfig/apollo-skills`
+3. 安装上述 3 个 Skill
 
-> brew install dos2unix
-> dos2unix build.sh
+示例表达（自然语言）：
 
-### 4.2.3 计算构建包的 checksum
+- “请用 `skill-installer` 从 `https://github.com/apolloconfig/apollo-skills` 安装 `apollo-java-release`、`apollo-release`、`apollo-helm-chart-release`”
 
-计算 configservice checksum
+如需手动安装，也可以将这 3 个 Skill 目录放到本地 Skill 目录（通常为 `$CODEX_HOME/skills` 或 `~/.codex/skills`）后重启客户端。
 
->在 ${apollo_home}/apollo-configservice/target/ 目录下执行：
-> 
->shasum apollo-configservice-${new-version}-github.zip > apollo-configservice-${new-version}-github.zip.sha1
+## 3. 发布 Apollo Java（apollo-java-release）
 
-计算 adminservice checksum
+### 3.1 触发方式（自然语言）
 
->在 ${apollo_home}/apollo-adminservice/target/ 目录下执行：
->
->shasum apollo-adminservice-${new-version}-github.zip > apollo-adminservice-${new-version}-github.zip.sha1
+在 `apollo-java` 仓库会话中，直接发起类似请求：
 
-计算 portal checksum
+- “使用 `apollo-java-release` 发布 `X.Y.Z`，下一个版本 `A.B.C-SNAPSHOT`，highlights 用这些 PR：`...`”
 
->在 ${apollo_home}/apollo-portal/target/ 目录下执行：  
->
-> shasum apollo-portal-${new-version}-github.zip > apollo-portal-${new-version}-github.zip.sha1
+### 3.2 Skill 会自动完成
 
-## 4.3 创建 pre-release
+- 版本变更 PR（`revision` 从 SNAPSHOT 到正式版本）
+- pre-release 创建
+- 触发 `release.yml`，等待 Sonatype Central 发布完成
+- 发布公告讨论（Announcements）
+- 发布后回切到下一 SNAPSHOT，并创建 post-release PR
+- pre-release 转正式 release
 
-github 创建 pre-release
+### 3.3 checkpoint 交互方式
 
-![image.png](https://cdn.jsdelivr.net/gh/apolloconfig/apollo@master/doc/images/local-development/create-release.png)
+- Skill 在关键外部动作前会自动暂停，并由系统提示是否继续
+- 你只需在对话中选择继续，或要求先修改文案/参数
 
-填写 Release Note & 上传包
+## 4. 发布 Apollo Server（apollo-release）
 
-![image.png](https://cdn.jsdelivr.net/gh/apolloconfig/apollo@master/doc/images/local-development/fill-release-form.png)
+### 4.1 触发方式（自然语言）
 
-## 4.4 预发布 Apollo-Client Jar 包
+在 `apollo` 仓库会话中，直接发起类似请求：
 
-通过 github workflow 来发布。
+- “使用 `apollo-release` 发布 `X.Y.Z`，下一个版本 `A.B.C-SNAPSHOT`，highlights PR 是 `...`”
 
-[https://github.com/apolloconfig/apollo-java/actions/workflows/release.yml](https://github.com/apolloconfig/apollo-java/actions/workflows/release.yml)
+### 4.2 Skill 会自动完成
 
-![image.png](https://cdn.jsdelivr.net/gh/apolloconfig/apollo@master/doc/images/local-development/publish-sdk.png)
+- 版本 bump PR（`pom.xml` 的 `revision`）
+- 从 `CHANGES.md` 生成 Release Notes 与公告草稿
+- 创建 pre-release（`vX.Y.Z`）
+- 触发包构建与 checksum 上传（GitHub Action）
+- 触发 Docker 发布 workflow
+- pre-release 转正式 release
+- 发布 Announcements 讨论
+- 发布后回切 `next-snapshot`、归档 `CHANGES.md`、里程碑维护、创建 post-release PR
 
-> 注意：如果发布的是 SNAPSHOT 版本，使用默认值 snapshots 即可，如果发布的是正式版本（不带 SNAPSHOT），则需要修改为 releases 才可以正常发布。
+### 4.3 checkpoint 交互方式
 
-## 4.5 版本发布 PMC 投票
+与 `apollo-java-release` 一致：
 
-投票是为了让各个 PMC 成员协作验证版本的内容，防止发布有问题的版本。
-投票具体的形式为在 Discussions 发起一个帖子，可参考：[https://github.com/apolloconfig/apollo/discussions/3899](https://github.com/apolloconfig/apollo/discussions/3899)
+- 系统会在关键步骤提示你确认是否继续
+- 可在暂停点要求先调整 highlights、release note 或其它参数
 
-## 4.6 正式发布 Apollo-Client Jar 到仓库
+## 5. 发布 Helm Chart（apollo-helm-chart-release）
 
-## 4.7 发布 Docker 镜像
+### 5.1 触发方式（自然语言）
 
-### 4.7.1 本地构建镜像并测试
+在 `apollo-helm-chart` 仓库会话中，直接发起类似请求：
 
-在 4.2 步骤打完包的前提下，在 apollo 根目录下执行
+- “使用 `apollo-helm-chart-release` 发布当前 chart 版本变更”
 
-> mvn docker:build -pl apollo-configservice,apollo-adminservice,apollo-portal
+### 5.2 Skill 会自动完成
 
-注意：如果出现报错，可能需要重启一下本地 docker
+- chart 版本变更检测与一致性校验
+- `helm lint`、`helm package`、`helm repo index`
+- 变更白名单校验（防止误提交）
+- 生成分支与 commit 草案
+- 在 push / PR 前停下来等待你确认（默认不自动发布）
 
-### 4.7.2 Push 镜像到仓库
+## 6. 发布后统一验收
 
-通过 github workflow 来发布。
+建议至少检查：
 
-[https://github.com/apolloconfig/apollo/actions/workflows/docker-publish.yml](https://github.com/apolloconfig/apollo/actions/workflows/docker-publish.yml)
+1. Apollo Release 页面包含 3 个 zip + 3 个 sha1
+2. Docker 镜像 tag 可用
+3. Maven Central 上 apollo-java 对应版本可检索
+4. Helm 仓库 `docs/index.yaml` 已包含新 chart 版本
+5. 关键路径冒烟验证通过（配置发布、灰度发布、客户端拉取、Portal 核心操作）
 
-在文本框中填写发布的版本号即可
+## 7. 常见操作（Skill 使用视角）
 
-![image.png](https://cdn.jsdelivr.net/gh/apolloconfig/apollo@master/doc/images/local-development/publish-docker.jpg)
+### 7.1 中断后继续
 
-## 4.8 更新 helm chart
+直接在对话中要求继续即可，例如：
 
-### 4.8.1 更新 chart 内容
+- “继续刚才的发布流程”
+- “从下一个 checkpoint 继续执行”
 
-1. cd [apollo-helm-chart](https://github.com/apolloconfig/apollo-helm-chart)
-2. helm package apollo-portal && helm package apollo-service
-3. mv *.tgz docs
-4. cd docs
-5. helm repo index .
+Skill 会根据状态文件自动恢复，不会重复已完成步骤。
 
-### 4.8.2 分支合并到 main
+### 7.2 先演练再正式发布
 
-创建一个 pull request，把上述产物合并到 [main](https://github.com/apolloconfig/apollo-helm-chart) 分支。
+可先要求 dry-run，例如：
 
-# 5. 发布公告
+- “先用 dry-run 跑一遍 `apollo-release`，我先检查流程”
 
-参考：[https://github.com/apolloconfig/apollo/discussions/3740](https://github.com/apolloconfig/apollo/discussions/3740)
+确认输出后，再要求正式执行。
+
+### 7.3 调整 Highlights / 文案
+
+在 pre-release 创建前可直接提出调整，例如：
+
+- “把 highlights 改成这些 PR：`...`，然后重新生成 release notes”
+
+确认无误后再继续下一步。


### PR DESCRIPTION
## What's the purpose of this PR

Update `apollo-release-guide.md` (both Chinese and English versions) to match the current skill-driven release workflow used with Codex / Claude Code.

Key updates:

1. Align the recommended release order with current practice: `apollo-java-release` -> `apollo-release` -> `apollo-helm-chart-release`
2. Shift the guide from manual script execution to conversational skill triggering
3. Add a skill installation section, including the full GitHub source URL: `https://github.com/apolloconfig/apollo-skills`
4. Clarify checkpoint interaction as system-prompted confirmations in chat
5. Remove redundant “you don’t need to ...” wording and keep action-oriented guidance

## Which issue(s) this PR fixes:
N/A (documentation update)

## Brief changelog

- rewrite CN/EN release guides for the skill-driven workflow
- add skill installation instructions for Codex / Claude Code users
- align wording with the current release operation model

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code. (N/A, docs-only change)
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything. (N/A, docs-only change)
- [x] Run `mvn spotless:apply` to format your code. (N/A, docs-only change)
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md). (N/A, docs-only change)
