### PR TITLE
docs: remove QA bot embed and add OpenAPI workflow note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@
 - New Java classes should include a short Javadoc describing the class purpose.
 - Use standard Java naming: packages `lower.case`, classes `UpperCamelCase`, tests `*Test`.
 
+## OpenAPI Contract Workflow (apollo-portal)
+- Treat OpenAPI as contract-first: update spec in `apolloconfig/apollo-openapi` before (or together with) portal implementation changes.
+- `apollo-portal/pom.xml` uses `apollo.openapi.spec.url` + `openapi-generator-maven-plugin`; generated sources under `target/generated-sources/openapi/src/main/java` are added to compile path via `build-helper-maven-plugin`.
+- For new/changed OpenAPI endpoints, prefer implementing generated `*ManagementApi` interfaces and generated models; avoid introducing hand-written DTO/controller contracts that bypass the spec pipeline.
+- In PR review, verify contract alignment explicitly: endpoint path, request/response model, and permissions in `apollo` should match the spec in `apollo-openapi`.
+
 ## Testing Guidelines
 - JUnit 5 is the default, with Vintage enabled for legacy JUnit 4 tests.
 - Put new tests under the module’s `src/test/java` with `*Test` suffix.

--- a/docs/index.html
+++ b/docs/index.html
@@ -182,26 +182,6 @@
 
 </body>
 
-<!-- add qa bot -->
-<script>
-  (function() {
-    var link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = 'https://ai.apolloconfig.com/qa-bot.css';
-    document.head.appendChild(link);
-
-    var script = document.createElement('script');
-    script.src = 'https://ai.apolloconfig.com/qa-bot.js';
-    script.onload = function () {
-      QABot.initialize({
-        "serverUrl": "https://ai.apolloconfig.com/qa",
-        "documentSiteUrlPrefix": "https://www.apolloconfig.com/#"
-      });
-    };
-    document.body.appendChild(script);
-  })();
-</script>
-
 <!-- mermaid -->
 <script src="//unpkg.com/mermaid@8.14.0/dist/mermaid.min.js"></script>
 <script>


### PR DESCRIPTION
## What's the purpose of this PR

This PR makes two documentation-focused updates:

1. Remove the Apollo-QA-Bot frontend embed from the docs entry page, so the site no longer loads resources from `ai.apolloconfig.com`.
2. Add an `OpenAPI Contract Workflow (apollo-portal)` section to `AGENTS.md` to clarify contract-first implementation and review expectations.

## Which issue(s) this PR fixes:

N/A

## Brief changelog

- Remove QA Bot injection code from `docs/index.html` (`qa-bot.css`, `qa-bot.js`, and `QABot.initialize`).
- Add `OpenAPI Contract Workflow (apollo-portal)` guidance in `AGENTS.md`, including spec alignment checks for implementation/review.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Run `mvn spotless:apply` to format your code.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
