### PR TITLE
fix: include super admin in hasAnyPermission semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
-* 
+* [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -375,7 +375,16 @@ public class DefaultRolePermissionService implements RolePermissionService {
     }
   }
 
+  @Override
   public boolean hasAnyPermission(String userId, List<Permission> permissions) {
+    if (CollectionUtils.isEmpty(permissions)) {
+      return false;
+    }
+
+    if (isSuperAdmin(userId)) {
+      return true;
+    }
+
     List<Permission> userPermissions = permissionRepository.findUserPermissions(userId);
 
     if (CollectionUtils.isEmpty(userPermissions)) {

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/component/UserPermissionValidatorTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/component/UserPermissionValidatorTest.java
@@ -17,10 +17,10 @@
 package com.ctrip.framework.apollo.portal.component;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
@@ -216,6 +216,13 @@ class UserPermissionValidatorTest {
     when(rolePermissionService.hasAnyPermission(USER_ID, requiredPerms)).thenReturn(false);
 
     assertThat(validator.hasPermissions(requiredPerms)).isFalse();
+  }
+
+  @Test
+  void hasReleaseNamespacePermission_match() {
+    when(rolePermissionService.hasAnyPermission(eq(USER_ID), anyList())).thenReturn(true);
+
+    assertThat(validator.hasReleaseNamespacePermission(APP_ID, ENV, CLUSTER, NAMESPACE)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## What's the purpose of this PR

Cherry-pick the super admin permission fix from `2.x` into `master`, so the behavior stays consistent across maintenance and mainline branches.

Without this fix, a super admin user can still see Edit/Publish actions in Portal UI, but the backend `hasAnyPermission` check may return false and cause `403` during edit/release when explicit namespace roles are missing.

## Which issue(s) this PR fixes:
Fixes #5567

## Brief changelog

- include super admin short-circuit in `DefaultRolePermissionService#hasAnyPermission`
- add `UserPermissionValidatorTest` and `RolePermissionServiceTest` coverage for super admin semantics
- add Portal UI E2E regression case for edit/release after namespace-role revoke
- update `CHANGES.md` for 3.0.0 with PR link
- cherry-pick source: #5566 (merged into `2.x`)

### Validation

- `./mvnw -pl apollo-portal -am -Dtest=UserPermissionValidatorTest,RolePermissionServiceTest -DfailIfNoTests=false test`
- `./mvnw spotless:apply`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed permission validation to properly recognize super administrator privileges. Super admins can now edit and release application namespaces without requiring explicit namespace-level role assignments.

* **Improvements**
  * Optimized permission lookup efficiency with enhanced containment checks.

* **Tests**
  * Added test coverage to verify super admin permissions work correctly and validated end-to-end namespace operations for super administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->