### PR TITLE
Add edge case tests for NamespaceService.loadNamespaceBO

### DIFF
--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -43,9 +43,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -310,7 +314,7 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
     when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, true);
 
     assertNotNull(namespaceBO);
     assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
@@ -332,7 +336,7 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
     when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, false);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, false);
 
     assertNotNull(namespaceBO);
     assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
@@ -451,7 +455,7 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     deletedItemDTO.setKey("deleted-key");
     when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList(deletedItemDTO));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, true);
 
     assertNotNull(namespaceBO);
     assertEquals(3, namespaceBO.getItemModifiedCnt());

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -300,43 +300,55 @@ public class NamespaceServiceTest extends AbstractUnitTest {
   @Test
   public void testLoadNamespaceBOWithDeletedItems() {
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
 
     List<ItemDTO> itemDTOList = createItems();
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(itemDTOList);
 
     List<ItemDTO> deletedItemDTOList = Lists.newArrayList();
     ItemDTO deletedItemDTO = new ItemDTO();
     deletedItemDTO.setKey("deleted-key");
     deletedItemDTOList.add(deletedItemDTO);
-    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(deletedItemDTOList);
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(deletedItemDTOList);
 
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
-    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName))
+        .thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, true);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName,
+        testNamespaceName, true, true);
 
     assertNotNull(namespaceBO);
     assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
     assertEquals(testClusterName, namespaceBO.getBaseInfo().getClusterName());
     assertEquals(testNamespaceName, namespaceBO.getBaseInfo().getNamespaceName());
     assertEquals(3, namespaceBO.getItems().size());
-    verify(itemService, times(1)).findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName);
+    verify(itemService, times(1)).findDeletedItems(testAppId, testEnv, testClusterName,
+        testNamespaceName);
     verify(additionalUserInfoEnrichService, times(1)).enrichAdditionalUserInfo(any(), any());
   }
 
   @Test
   public void testLoadNamespaceBOWithoutDeletedItems() {
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
 
     List<ItemDTO> itemDTOList = createItems();
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(itemDTOList);
 
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
-    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName))
+        .thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, false);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName,
+        testNamespaceName, true, false);
 
     assertNotNull(namespaceBO);
     assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
@@ -373,16 +385,22 @@ public class NamespaceServiceTest extends AbstractUnitTest {
   @Test
   public void testLoadNamespaceBONoItems() {
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList());
-    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(Lists.newArrayList());
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName))
+        .thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
     ItemDTO deletedItemDTO = new ItemDTO();
     deletedItemDTO.setKey("deleted-key");
-    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList(deletedItemDTO));
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(Lists.newArrayList(deletedItemDTO));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+    NamespaceBO namespaceBO =
+        namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
 
     assertNotNull(namespaceBO);
     assertEquals(3, namespaceBO.getItems().size());
@@ -393,15 +411,20 @@ public class NamespaceServiceTest extends AbstractUnitTest {
   @Test
   public void testLoadNamespaceBOWithPublicNamespace() {
     AppNamespace publicAppNamespace = createAppNamespace("public-app", testNamespaceName, true);
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
     when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(null);
-    when(appNamespaceService.findPublicAppNamespace(testNamespaceName)).thenReturn(publicAppNamespace);
+    when(appNamespaceService.findPublicAppNamespace(testNamespaceName))
+        .thenReturn(publicAppNamespace);
 
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createItems());
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+    NamespaceBO namespaceBO =
+        namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
 
     assertNotNull(namespaceBO);
     assertTrue(namespaceBO.isPublic());
@@ -412,14 +435,19 @@ public class NamespaceServiceTest extends AbstractUnitTest {
   @Test
   public void testLoadNamespaceBOWithPrivateNamespace() {
     AppNamespace privateAppNamespace = createAppNamespace(testAppId, testNamespaceName, false);
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
-    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(privateAppNamespace);
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName))
+        .thenReturn(privateAppNamespace);
 
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createItems());
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+    NamespaceBO namespaceBO =
+        namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
 
     assertNotNull(namespaceBO);
     assertEquals(testAppId, namespaceBO.getParentAppId());
@@ -444,18 +472,24 @@ public class NamespaceServiceTest extends AbstractUnitTest {
   @Test
   public void testLoadNamespaceBOItemModifiedCountCalculation() {
     ReleaseDTO releaseDTO = createReleaseDTO();
-    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
-    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
-    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(releaseDTO);
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName))
+        .thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
 
     List<ItemDTO> itemDTOList = createItems();
-    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(itemDTOList);
 
     ItemDTO deletedItemDTO = new ItemDTO();
     deletedItemDTO.setKey("deleted-key");
-    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList(deletedItemDTO));
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName))
+        .thenReturn(Lists.newArrayList(deletedItemDTO));
 
-    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true, true);
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName,
+        testNamespaceName, true, true);
 
     assertNotNull(namespaceBO);
     assertEquals(3, namespaceBO.getItemModifiedCnt());

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/NamespaceServiceTest.java
@@ -293,6 +293,171 @@ public class NamespaceServiceTest extends AbstractUnitTest {
     assertThat(namespaceKey2).isEqualTo(Arrays.asList("k1", "k2", "k3"));
   }
 
+  @Test
+  public void testLoadNamespaceBOWithDeletedItems() {
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+
+    List<ItemDTO> itemDTOList = createItems();
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+
+    List<ItemDTO> deletedItemDTOList = Lists.newArrayList();
+    ItemDTO deletedItemDTO = new ItemDTO();
+    deletedItemDTO.setKey("deleted-key");
+    deletedItemDTOList.add(deletedItemDTO);
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(deletedItemDTOList);
+
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true);
+
+    assertNotNull(namespaceBO);
+    assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
+    assertEquals(testClusterName, namespaceBO.getBaseInfo().getClusterName());
+    assertEquals(testNamespaceName, namespaceBO.getBaseInfo().getNamespaceName());
+    assertEquals(3, namespaceBO.getItems().size());
+    verify(itemService, times(1)).findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName);
+    verify(additionalUserInfoEnrichService, times(1)).enrichAdditionalUserInfo(any(), any());
+  }
+
+  @Test
+  public void testLoadNamespaceBOWithoutDeletedItems() {
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+
+    List<ItemDTO> itemDTOList = createItems();
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, false);
+
+    assertNotNull(namespaceBO);
+    assertEquals(testAppId, namespaceBO.getBaseInfo().getAppId());
+    assertEquals(testClusterName, namespaceBO.getBaseInfo().getClusterName());
+    assertEquals(testNamespaceName, namespaceBO.getBaseInfo().getNamespaceName());
+    assertEquals(2, namespaceBO.getItems().size());
+    verify(itemService, times(0)).findDeletedItems(any(), any(), any(), any());
+    verify(additionalUserInfoEnrichService, times(1)).enrichAdditionalUserInfo(any(), any());
+  }
+
+  @Test
+  public void testLoadNamespaceBONamespaceNotFound() {
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(null);
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName));
+  }
+
+  @Test
+  public void testLoadNamespaceBONoLatestRelease() {
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(null);
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+
+    assertNotNull(namespaceBO);
+    assertEquals(2, namespaceBO.getItems().size());
+    assertTrue(namespaceBO.getItems().get(0).isModified());
+    assertTrue(namespaceBO.getItems().get(1).isModified());
+  }
+
+  @Test
+  public void testLoadNamespaceBONoItems() {
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList());
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+
+    ItemDTO deletedItemDTO = new ItemDTO();
+    deletedItemDTO.setKey("deleted-key");
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList(deletedItemDTO));
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+
+    assertNotNull(namespaceBO);
+    assertEquals(3, namespaceBO.getItems().size());
+    assertTrue(namespaceBO.getItems().get(0).isDeleted());
+    assertEquals("k1", namespaceBO.getItems().get(0).getItem().getKey());
+  }
+
+  @Test
+  public void testLoadNamespaceBOWithPublicNamespace() {
+    AppNamespace publicAppNamespace = createAppNamespace("public-app", testNamespaceName, true);
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(null);
+    when(appNamespaceService.findPublicAppNamespace(testNamespaceName)).thenReturn(publicAppNamespace);
+
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+
+    assertNotNull(namespaceBO);
+    assertTrue(namespaceBO.isPublic());
+    assertEquals("public-app", namespaceBO.getParentAppId());
+    verify(appNamespaceService, times(1)).findPublicAppNamespace(testNamespaceName);
+  }
+
+  @Test
+  public void testLoadNamespaceBOWithPrivateNamespace() {
+    AppNamespace privateAppNamespace = createAppNamespace(testAppId, testNamespaceName, false);
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(privateAppNamespace);
+
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+
+    assertNotNull(namespaceBO);
+    assertEquals(testAppId, namespaceBO.getParentAppId());
+  }
+
+  @Test
+  public void testLoadNamespaceBOWithDirtyAppNamespace() {
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(null);
+    when(appNamespaceService.findPublicAppNamespace(testNamespaceName)).thenReturn(null);
+
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createItems());
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName);
+
+    assertNotNull(namespaceBO);
+    assertTrue(namespaceBO.isPublic());
+  }
+
+  @Test
+  public void testLoadNamespaceBOItemModifiedCountCalculation() {
+    ReleaseDTO releaseDTO = createReleaseDTO();
+    when(namespaceAPI.loadNamespace(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(createNamespace(testAppId, testClusterName, testNamespaceName));
+    when(releaseService.loadLatestRelease(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(releaseDTO);
+    when(appNamespaceService.findByAppIdAndName(testAppId, testNamespaceName)).thenReturn(createAppNamespace(testAppId, testNamespaceName, false));
+
+    List<ItemDTO> itemDTOList = createItems();
+    when(itemService.findItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(itemDTOList);
+
+    ItemDTO deletedItemDTO = new ItemDTO();
+    deletedItemDTO.setKey("deleted-key");
+    when(itemService.findDeletedItems(testAppId, testEnv, testClusterName, testNamespaceName)).thenReturn(Lists.newArrayList(deletedItemDTO));
+
+    NamespaceBO namespaceBO = namespaceService.loadNamespaceBO(testAppId, testEnv, testClusterName, testNamespaceName, true);
+
+    assertNotNull(namespaceBO);
+    assertEquals(3, namespaceBO.getItemModifiedCnt());
+  }
+
+
   private ReleaseDTO createReleaseDTO() {
     ReleaseDTO releaseDTO = new ReleaseDTO();
     releaseDTO.setConfigurations("{\"k1\":\"k1\",\"k2\":\"k2\", \"k3\":\"\"}");


### PR DESCRIPTION
Summary
Add comprehensive edge case tests for NamespaceService.loadNamespaceBO covering deleted items, namespace not found, missing release scenarios, and public/private namespace resolution.
Why
Current tests cover basic functionality but do not explicitly cover boundary cases such as:
- Handling of deleted items when the deletedItems parameter is true/false
- Namespace not found scenario throwing BadRequestException
- No latest release available (returning modified items)
- Empty items list with deleted items present
- Public vs private namespace resolution logic
- Dirty/missing AppNamespace edge cases
- Item modified count calculation with deleted items
These boundary cases are easy to regress (for example, through off-by-one in item counting or grouping changes), so explicit tests improve behavioral stability and prevent future regressions.
Verification
Ran mvn -Dtest=NamespaceServiceTest test
Result: all tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for namespace loading covering deleted-item handling and ordering, behavior with/without items or latest release, error when a namespace is missing, public vs. private namespace linkage and lookup, dirty app-namespace scenarios, item enrichment and deletion handling, validation of modified item count calculations, and additional error/validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->