### PR TITLE
feat: add missing delete functionality for ServerConfig management (Issue #5596)

### DIFF
--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ServerConfigController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ServerConfigController.java
@@ -20,9 +20,11 @@ import com.ctrip.framework.apollo.biz.entity.ServerConfig;
 import com.ctrip.framework.apollo.biz.service.ServerConfigService;
 import java.util.List;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -45,5 +47,16 @@ public class ServerConfigController {
   @PostMapping("/server/config")
   public ServerConfig createOrUpdatePortalDBConfig(@Valid @RequestBody ServerConfig serverConfig) {
     return serverConfigService.createOrUpdateConfig(serverConfig);
+  }
+
+  /**
+   * Delete a server configuration by key
+   *
+   * @param key the configuration key to delete
+   * @param operator the operator who performs the deletion
+   */
+  @DeleteMapping("/server/config")
+  public void deleteConfig(@RequestParam String key, @RequestParam String operator) {
+    serverConfigService.deleteConfig(key, operator);
   }
 }

--- a/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ServerConfigControllerTest.java
+++ b/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ServerConfigControllerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.ctrip.framework.apollo.biz.entity.ServerConfig;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
@@ -74,4 +75,29 @@ class ServerConfigControllerTest extends AbstractControllerTest {
     assertEquals(2, serverConfigs.length);
 
   }
-}
+
+  /**
+   * Test DELETE operation for server configuration
+   * Verifies that deletion removes the config from the database
+   */
+  @Test
+  @Sql(scripts = "/controller/test-server-config.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/controller/cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  void deleteConfig() {
+    // Verify config exists before deletion
+    ServerConfig[] beforeDelete =
+        restTemplate.getForObject(url("/server/config/find-all-config"), ServerConfig[].class);
+    assertNotNull(beforeDelete);
+    assertEquals(1, beforeDelete.length);
+
+    // Execute delete
+    restTemplate.exchange(url("/server/config?key=name&operator=apollo"), HttpMethod.DELETE, null,
+        Void.class);
+
+    // Verify config is deleted
+    ServerConfig[] afterDelete =
+        restTemplate.getForObject(url("/server/config/find-all-config"), ServerConfig[].class);
+    assertNotNull(afterDelete);
+    assertEquals(0, afterDelete.length);
+  }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ServerConfigService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ServerConfigService.java
@@ -63,4 +63,22 @@ public class ServerConfigService {
     return serverConfigRepository.save(storedConfig);
   }
 
+  /**
+   * Delete a server configuration by key
+   * Uses soft-delete: marks as deleted via @SQLDelete annotation
+   *
+   * @param key the configuration key to delete
+   * @param operator the operator who performs the deletion
+   * @throws IllegalArgumentException if config not found
+   */
+  @Transactional
+  public void deleteConfig(String key, String operator) {
+    ServerConfig config = serverConfigRepository.findByKey(key);
+    if (Objects.isNull(config)) {
+      throw new IllegalArgumentException("ServerConfig not found: " + key);
+    }
+    config.setDataChangeLastModifiedBy(operator);
+    serverConfigRepository.deleteById(config.getId());
+  }
+
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/api/AdminServiceAPI.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/api/AdminServiceAPI.java
@@ -604,6 +604,24 @@ public class AdminServiceAPI {
     public ServerConfig createOrUpdateConfigDBConfig(Env env, ServerConfig serverConfig) {
       return restTemplate.post(env, "/server/config", serverConfig, ServerConfig.class);
     }
+
+    /**
+     * Delete a server configuration via admin service
+     *
+     * @param env the environment
+     * @param key the configuration key to delete
+     * @return true if deletion was successful
+     */
+    @ApolloAuditLog(type = OpType.RPC, name = "ServerConfig.deleteConfigDBConfigInRemote")
+    public boolean deleteConfigDBConfig(Env env, String key) {
+      try {
+        String operator = "apollo";
+        restTemplate.delete(env, "/server/config?key={key}&operator={operator}", key, operator);
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
+    }
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ServerConfigController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ServerConfigController.java
@@ -25,6 +25,7 @@ import com.ctrip.framework.apollo.portal.service.ServerConfigService;
 import java.util.List;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,6 +68,20 @@ public class ServerConfigController {
   @GetMapping("/server/envs/{env}/config-db/config/find-all-config")
   public List<ServerConfig> findAllConfigDBServerConfig(@PathVariable String env) {
     return serverConfigService.findAllConfigDBConfig(Env.transformEnv(env));
+  }
+
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @DeleteMapping("/server/portal-db/config/{key}")
+  @ApolloAuditLog(type = OpType.DELETE, name = "ServerConfig.deletePortalDBConfig")
+  public boolean deletePortalDBConfig(@PathVariable String key) {
+    return serverConfigService.deletePortalDBConfig(key);
+  }
+
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @DeleteMapping("/server/envs/{env}/config-db/config/{key}")
+  @ApolloAuditLog(type = OpType.DELETE, name = "ServerConfig.deleteConfigDBConfig")
+  public boolean deleteConfigDBConfig(@PathVariable String env, @PathVariable String key) {
+    return serverConfigService.deleteConfigDBConfig(Env.transformEnv(env), key);
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ServerConfigService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ServerConfigService.java
@@ -79,4 +79,32 @@ public class ServerConfigService {
     serverConfig.setDataChangeLastModifiedBy(modifiedBy);
     return serverConfigAPI.createOrUpdateConfigDBConfig(env, serverConfig);
   }
+
+  /**
+   * Delete ServerConfig from Portal DB by key
+   *
+   * @param key the configuration key to delete
+   * @return true if deletion was successful, false if key not found
+   */
+  @Transactional
+  public boolean deletePortalDBConfig(String key) {
+    ServerConfig storedConfig = serverConfigRepository.findByKey(key);
+    if (Objects.isNull(storedConfig)) {
+      return false;
+    }
+    serverConfigRepository.deleteById(storedConfig.getId());
+    return true;
+  }
+
+  /**
+   * Delete ServerConfig from Config DB by key and environment
+   *
+   * @param env the environment
+   * @param key the configuration key to delete
+   * @return true if deletion was successful, false if key not found
+   */
+  @Transactional
+  public boolean deleteConfigDBConfig(Env env, String key) {
+    return serverConfigAPI.deleteConfigDBConfig(env, key);
+  }
 }

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -534,6 +534,8 @@
   "ServiceConfig.Comment": "Comment",
   "ServiceConfig.Saved": "Save Successfully",
   "ServiceConfig.SaveFailed": "Failed to Save",
+  "ServiceConfig.Deleted": "Delete Successfully",
+  "ServiceConfig.DeleteFailed": "Failed to Delete",
   "ServiceConfig.PleaseEnterKey": "Please enter key",
   "ServiceConfig.KeyNotExistsAndCreateTip": "Key: '{{key}}' does not exist. Click Save to create the configuration item.",
   "ServiceConfig.KeyExistsAndSaveTip": "Key: '{{key}}' already exists. Click Save will override the configuration item.",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -534,6 +534,8 @@
   "ServiceConfig.Comment": "Comment",
   "ServiceConfig.Saved": "保存成功",
   "ServiceConfig.SaveFailed": "保存失败",
+  "ServiceConfig.Deleted": "删除成功",
+  "ServiceConfig.DeleteFailed": "删除失败",
   "ServiceConfig.PleaseEnterKey": "请输入 Key",
   "ServiceConfig.KeyNotExistsAndCreateTip": "Key: '{{key}}' 不存在，点击保存后会创建该配置项",
   "ServiceConfig.KeyExistsAndSaveTip": "Key: '{{key}}' 已存在，点击保存后会覆盖该配置项",

--- a/apollo-portal/src/main/resources/static/scripts/controller/ServerConfigController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/ServerConfigController.js
@@ -182,4 +182,41 @@ function ServerConfigController($scope, $window, $translate, toastr, AppUtil, Se
         $scope.configDBConfigSearchKey = '';
         configDBConfigFilter();
     }
+
+    /**
+     * Delete portal database configuration
+     * @param config the configuration object to delete
+     */
+    function deletePortalDBConfig(config) {
+        if (!$window.confirm('Are you sure you want to delete config: ' + config.key + '?')) {
+            return;
+        }
+        
+        ServerConfigService.deletePortalDBConfig(config.key).then(function (result) {
+            toastr.success($translate.instant('ServiceConfig.Deleted'));
+            getPortalDBConfig();
+        }, function (result) {
+            toastr.error(AppUtil.errorMsg(result), $translate.instant('ServiceConfig.DeleteFailed'));
+        });
+    }
+
+    /**
+     * Delete config database configuration
+     * @param config the configuration object to delete
+     */
+    function deleteConfigDBConfig(config) {
+        if (!$window.confirm('Are you sure you want to delete config: ' + config.key + '?')) {
+            return;
+        }
+        
+        ServerConfigService.deleteConfigDBConfig($scope.selectedEnv, config.key).then(function (result) {
+            toastr.success($translate.instant('ServiceConfig.Deleted'));
+            getConfigDBConfig();
+        }, function (result) {
+            toastr.error(AppUtil.errorMsg(result), $translate.instant('ServiceConfig.DeleteFailed'));
+        });
+    }
+
+    $scope.deletePortalDBConfig = deletePortalDBConfig;
+    $scope.deleteConfigDBConfig = deleteConfigDBConfig;
 }

--- a/apollo-portal/src/main/resources/static/scripts/services/ServerConfigService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/ServerConfigService.js
@@ -35,6 +35,14 @@ appService.service('ServerConfigService', ['$resource', '$q', 'AppUtil', functio
             isArray: true,
             url: AppUtil.prefixPath()
                 + '/server/envs/:env/config-db/config/find-all-config'
+        },
+        delete_portal_db_config: {
+            method: 'DELETE',
+            url: AppUtil.prefixPath() + '/server/portal-db/config/:key'
+        },
+        delete_config_db_config: {
+            method: 'DELETE',
+            url: AppUtil.prefixPath() + '/server/envs/:env/config-db/config/:key'
         }
     });
     return {
@@ -69,6 +77,35 @@ appService.service('ServerConfigService', ['$resource', '$q', 'AppUtil', functio
         findConfigDBConfig:function (env){
             let d = $q.defer();
             server_config_resource.find_config_db_config({env: env}, function (result) {
+                d.resolve(result);
+            }, function (result) {
+                d.reject(result);
+            });
+            return d.promise;
+        },
+        /**
+         * Delete portal database server configuration
+         * @param key configuration key to delete
+         * @returns promise
+         */
+        deletePortalDBConfig:function (key){
+            let d = $q.defer();
+            server_config_resource.delete_portal_db_config({key: key}, function (result) {
+                d.resolve(result);
+            }, function (result) {
+                d.reject(result);
+            });
+            return d.promise;
+        },
+        /**
+         * Delete config database server configuration
+         * @param env environment name
+         * @param key configuration key to delete
+         * @returns promise
+         */
+        deleteConfigDBConfig:function (env, key){
+            let d = $q.defer();
+            server_config_resource.delete_config_db_config({env: env, key: key}, function (result) {
                 d.resolve(result);
             }, function (result) {
                 d.reject(result);

--- a/apollo-portal/src/main/resources/static/server_config_manage.html
+++ b/apollo-portal/src/main/resources/static/server_config_manage.html
@@ -93,6 +93,9 @@
                                     <span class="btn btn-primary" ng-click="configEdit('edit', config)">
                                         {{'UserMange.Edit' | translate }}
                                     </span>
+                                    <span class="btn btn-danger" ng-click="deletePortalDBConfig(config)">
+                                        {{'Common.Delete' | translate }}
+                                    </span>
                                         </td>
                                     </tr>
                                 </table>
@@ -259,6 +262,9 @@
                                         <td>
                                     <span class="btn btn-primary" ng-click="configEdit('edit', config)">
                                         {{'UserMange.Edit' | translate }}
+                                    </span>
+                                    <span class="btn btn-danger" ng-click="deleteConfigDBConfig(config)">
+                                        {{'Common.Delete' | translate }}
                                     </span>
                                         </td>
                                     </tr>

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/controller/ServerConfigControllerTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/controller/ServerConfigControllerTest.java
@@ -98,4 +98,36 @@ public class ServerConfigControllerTest extends AbstractIntegrationTest {
     Assert.assertEquals(0, serverConfigList.size());
 
   }
+
+  /**
+   * Test DELETE operation for portal DB config
+   */
+  @Test
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testDeletePortalDBConfig() {
+    // Create config first
+    ServerConfig serverConfig = new ServerConfig();
+    serverConfig.setKey("deleteKey");
+    serverConfig.setValue("deleteValue");
+    restTemplate.postForEntity(url("/server/portal-db/config"), serverConfig, ServerConfig.class);
+
+    // Execute delete
+    restTemplate.delete(url("/server/portal-db/config/deleteKey"));
+
+    // Verify deletion
+    List<ServerConfig> configs = restTemplate.getForObject(
+        url("/server/portal-db/config/find-all-config"), List.class);
+    Assert.assertNotNull(configs);
+    Assert.assertEquals(0, configs.size());
+  }
+
+  /**
+   * Test DELETE operation for config DB config
+   */
+  @Test
+  public void testDeleteConfigDBConfig() {
+    when(serverConfigService.deleteConfigDBConfig(Env.DEV, "testKey")).thenReturn(true);
+    boolean result = serverConfigController.deleteConfigDBConfig(Env.DEV.getName(), "testKey");
+    Assert.assertTrue(result);
+  }
 }


### PR DESCRIPTION
## Summary

This PR addresses **issue #5596** by implementing the missing DELETE functionality for ServerConfig management.

## Problem

The ServerConfig management interface was missing delete operations, forcing admins to use database tools directly or workaround solutions to remove outdated server configurations.

## Solution

Added complete delete functionality with:
- Service layer methods for deleting Portal DB and Config DB configs
- REST API DELETE endpoints with proper security checks
- Audit logging integration
- Error handling with meaningful return values

## Changes

### Backend Service (ServerConfigService.java)

```java
// Delete from Portal DB
@Transactional
public boolean deletePortalDBConfig(String key)

// Delete from Config DB
@Transactional
public boolean deleteConfigDBConfig(Env env, String key)
```

### REST API Endpoints (ServerConfigController.java)

```
DELETE /server/portal-db/config/{key}
DELETE /server/envs/{env}/config-db/config/{key}
```

## Technical Details

- ✅ Both endpoints require super admin permission (@PreAuthorize)
- ✅ Integrated with Apollo audit logging (@ApolloAuditLog)
- ✅ Transactional operations ensure data consistency
- ✅ Validates key existence before deletion
- ✅ Returns boolean for success/failure indication
- ✅ Follows existing code patterns and conventions

## API Usage

### Delete from Portal DB
```bash
curl -X DELETE http://apollo:8070/server/portal-db/config/my.config.key   -H 'Authorization: Bearer <token>'
```

### Delete from Config DB
```bash
curl -X DELETE http://apollo:8070/server/envs/DEV/config-db/config/my.config.key   -H 'Authorization: Bearer <token>'
```

## Testing Recommendations

- [ ] Test delete with existing key (should return true)
- [ ] Test delete with non-existent key (should return false)
- [ ] Verify audit logs are created for delete operations
- [ ] Test permission checks (non-admin should get 403)
- [ ] Verify config is actually removed from database
- [ ] Test both portal and config DB delete endpoints

## Files Changed

- 
  - Added deletePortalDBConfig() method
  - Added deleteConfigDBConfig() method

- 
  - Added DeleteMapping import
  - Added deletePortalDBConfig() endpoint
  - Added deleteConfigDBConfig() endpoint

## Related

Fixes #5596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add server configuration deletion: UI shows Delete buttons with confirmation, success/error toasts, and list refresh for both Portal DB and Config DB entries.
  * Backend deletion endpoints added with role-restricted access and audit logging.

* **Documentation**
  * Added i18n messages for deletion success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->