### PR TITLE
docs: remove outdated demo environment links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ The .Net SDK does not rely on any framework and can run in all .Net runtime envi
 
 For more details of the product introduction, please refer [Introduction to Apollo Configuration Center](https://www.apolloconfig.com/#/zh/design/apollo-introduction).
 
-For local demo purpose, please refer [Quick Start](https://www.apolloconfig.com/#/zh/deployment/quick-start).
-
-Demo Environment:
-- [http://81.68.181.139](http://81.68.181.139/)
-- User/Password: apollo/admin
+To try Apollo locally, please refer [Quick Start](https://www.apolloconfig.com/#/en/deployment/quick-start) or [Docker Quick Start](https://www.apolloconfig.com/#/en/deployment/quick-start-docker).
 
 # Screenshots
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -12,11 +12,7 @@ The .Net SDK does not rely on any framework and can run in all .Net runtime envi
 
 For more details of the product introduction, please refer [Introduction to Apollo Configuration Center](en/design/apollo-introduction).
 
-For local demo purpose, please refer [Quick Start](en/deployment/quick-start).
-
-Demo Environment:
-- [http://81.68.181.139](http://81.68.181.139/)
-- User/Password: apollo/admin
+To try Apollo locally, please refer [Quick Start](en/deployment/quick-start) or [Docker Quick Start](en/deployment/quick-start-docker).
 
 # Screenshots
 ![Screenshot](images/apollo-home-screenshot.jpg)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -12,12 +12,7 @@ Java客户端不依赖任何框架，能够运行于所有Java运行时环境，
 
 更多产品介绍参见[Apollo配置中心介绍](zh/design/apollo-introduction)
 
-本地快速部署请参见[Quick Start](zh/deployment/quick-start)
-
-演示环境（Demo）:
-
-- [http://81.68.181.139](http://81.68.181.139/)
-- 账号/密码:apollo/admin
+本地快速体验请参见[Quick Start](zh/deployment/quick-start)或[Docker方式部署Quick Start](zh/deployment/quick-start-docker)
 
 > 如访问GitHub速度缓慢，可以访问[Gitee镜像](https://gitee.com/apolloconfig/apollo)，不定期同步
 


### PR DESCRIPTION
## What's the purpose of this PR

Retire the outdated public demo environment references from the main README and localized docs landing pages. The public demo host has expired and is no longer planned as the recommended way to try Apollo.

## Which issue(s) this PR fixes:
Fixes #5605

## Brief changelog

- Remove the public demo URL from README.md, docs/en/README.md, and docs/zh/README.md.
- Remove the default demo credential from those docs.
- Point users to Quick Start and Docker Quick Start for local evaluation instead.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code. Not applicable: documentation-only change.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything. Not run: documentation-only change.
- [ ] Run `mvn spotless:apply` to format your code. Not run: Markdown-only change.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md). Not updated: documentation-only cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local setup instructions across all documentation versions to direct users to the Quick Start and Docker Quick Start guides for trying the product locally.
  * Simplified onboarding guidance for improved clarity and accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apolloconfig/apollo/pull/5606)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->