### PR TITLE
[codex] Migrate portal permission and AccessKey flows to OpenAPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Apollo 3.0.0
 * [Change: migrate Apollo Portal config item UI operations to OpenAPI](https://github.com/apolloconfig/apollo/pull/5610)
 * [Change: migrate Apollo Portal namespace core UI operations to OpenAPI](https://github.com/apolloconfig/apollo/pull/5612)
 * [Change: migrate Apollo Portal release, branch, and instance UI operations to OpenAPI](https://github.com/apolloconfig/apollo/pull/5616)
+* [Change: migrate Apollo Portal permission and AccessKey UI operations to OpenAPI](https://github.com/apolloconfig/apollo/pull/5617)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -27,7 +27,7 @@
 	<artifactId>apollo-portal</artifactId>
 	<name>Apollo Portal</name>
 	<properties>
-		<apollo.openapi.spec.url>https://raw.githubusercontent.com/apolloconfig/apollo-openapi/refs/tags/v0.3.2/apollo-openapi.yaml</apollo.openapi.spec.url>
+		<apollo.openapi.spec.url>https://raw.githubusercontent.com/apolloconfig/apollo-openapi/refs/tags/v0.3.3/apollo-openapi.yaml</apollo.openapi.spec.url>
 		<github.path>${project.artifactId}</github.path>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 	</properties>

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/AccessKeyOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/AccessKeyOpenApiService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import java.util.List;
+
+/**
+ * Server-side OpenAPI facade for access key management.
+ */
+public interface AccessKeyOpenApiService {
+
+  List<OpenAccessKeyDTO> findAccessKeys(String appId, String env);
+
+  OpenAccessKeyDTO createAccessKey(String appId, String env, String operator);
+
+  void deleteAccessKey(String appId, String env, Long accessKeyId, String operator);
+
+  void enableAccessKey(String appId, String env, Long accessKeyId, Integer mode, String operator);
+
+  void disableAccessKey(String appId, String env, Long accessKeyId, String operator);
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/PermissionOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/PermissionOpenApiService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.openapi.model.OpenAppRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenClusterNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPermissionConditionDTO;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Server-side OpenAPI facade for permission checks and role assignments.
+ */
+public interface PermissionOpenApiService {
+
+  void initAppPermission(String appId, String namespaceName, String operator);
+
+  void initClusterNamespacePermission(String appId, String env, String clusterName,
+      String operator);
+
+  OpenPermissionConditionDTO hasAppPermission(String appId, String permissionType, String userId);
+
+  OpenPermissionConditionDTO hasNamespacePermission(String appId, String namespaceName,
+      String permissionType, String userId);
+
+  OpenPermissionConditionDTO hasEnvNamespacePermission(String appId, String env,
+      String namespaceName, String permissionType, String userId);
+
+  OpenPermissionConditionDTO hasClusterNamespacePermission(String appId, String env,
+      String clusterName, String permissionType, String userId);
+
+  OpenPermissionConditionDTO hasRootPermission(String userId);
+
+  OpenEnvNamespaceRoleUserDTO getNamespaceEnvRoleUsers(String appId, String env,
+      String namespaceName);
+
+  void assignNamespaceEnvRoleToUser(String appId, String env, String namespaceName, String roleType,
+      String userId, String operator);
+
+  void removeNamespaceEnvRoleFromUser(String appId, String env, String namespaceName,
+      String roleType, String userId, String operator);
+
+  OpenClusterNamespaceRoleUserDTO getClusterNamespaceRoles(String appId, String env,
+      String clusterName);
+
+  void assignClusterNamespaceRoleToUser(String appId, String env, String clusterName,
+      String roleType, String userId, String operator);
+
+  void removeClusterNamespaceRoleFromUser(String appId, String env, String clusterName,
+      String roleType, String userId, String operator);
+
+  OpenNamespaceRoleUserDTO getNamespaceRoles(String appId, String namespaceName);
+
+  void assignNamespaceRoleToUser(String appId, String namespaceName, String roleType, String userId,
+      String operator);
+
+  void removeNamespaceRoleFromUser(String appId, String namespaceName, String roleType,
+      String userId, String operator);
+
+  OpenAppRoleUserDTO getAppRoles(String appId);
+
+  void assignAppRoleToUser(String appId, String roleType, String userId, String operator);
+
+  void removeAppRoleFromUser(String appId, String roleType, String userId, String operator);
+
+  Map<String, Boolean> hasCreateApplicationPermission(String userId);
+
+  void addCreateApplicationRoleToUsers(List<String> userIds, String operator);
+
+  void deleteCreateApplicationRoleFromUser(String userId, String operator);
+
+  List<String> getCreateApplicationRoleUsers();
+
+  void addManageAppMasterRoleToUser(String appId, String userId, String operator);
+
+  void removeManageAppMasterRoleFromUser(String appId, String userId, String operator);
+
+  Map<String, Boolean> isManageAppMasterPermissionEnabled();
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiService.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.openapi.server.service;
 import static com.ctrip.framework.apollo.common.constants.AccessKeyMode.FILTER;
 
 import com.ctrip.framework.apollo.common.dto.AccessKeyDTO;
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.common.utils.UniqueKeyGenerator;
 import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
 import com.ctrip.framework.apollo.openapi.util.OpenApiModelConverters;
@@ -42,7 +43,7 @@ public class ServerAccessKeyOpenApiService implements AccessKeyOpenApiService {
   @Override
   public List<OpenAccessKeyDTO> findAccessKeys(String appId, String env) {
     return OpenApiModelConverters
-        .fromAccessKeyDTOs(accessKeyService.findByAppId(Env.valueOf(env), appId));
+        .fromAccessKeyDTOs(accessKeyService.findByAppId(normalizeEnv(env), appId));
   }
 
   @Override
@@ -53,23 +54,31 @@ public class ServerAccessKeyOpenApiService implements AccessKeyOpenApiService {
     accessKey.setDataChangeCreatedBy(operator);
     accessKey.setDataChangeLastModifiedBy(operator);
     return OpenApiModelConverters
-        .fromAccessKeyDTO(accessKeyService.createAccessKey(Env.valueOf(env), accessKey));
+        .fromAccessKeyDTO(accessKeyService.createAccessKey(normalizeEnv(env), accessKey));
   }
 
   @Override
   public void deleteAccessKey(String appId, String env, Long accessKeyId, String operator) {
-    accessKeyService.deleteAccessKey(Env.valueOf(env), appId, accessKeyId, operator);
+    accessKeyService.deleteAccessKey(normalizeEnv(env), appId, accessKeyId, operator);
   }
 
   @Override
   public void enableAccessKey(String appId, String env, Long accessKeyId, Integer mode,
       String operator) {
     int resolvedMode = mode == null ? FILTER : mode;
-    accessKeyService.enable(Env.valueOf(env), appId, accessKeyId, resolvedMode, operator);
+    accessKeyService.enable(normalizeEnv(env), appId, accessKeyId, resolvedMode, operator);
   }
 
   @Override
   public void disableAccessKey(String appId, String env, Long accessKeyId, String operator) {
-    accessKeyService.disable(Env.valueOf(env), appId, accessKeyId, operator);
+    accessKeyService.disable(normalizeEnv(env), appId, accessKeyId, operator);
+  }
+
+  private Env normalizeEnv(String env) {
+    Env transformedEnv = Env.transformEnv(env);
+    if (Env.UNKNOWN == transformedEnv) {
+      throw BadRequestException.invalidEnvFormat(env);
+    }
+    return transformedEnv;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import static com.ctrip.framework.apollo.common.constants.AccessKeyMode.FILTER;
+
+import com.ctrip.framework.apollo.common.dto.AccessKeyDTO;
+import com.ctrip.framework.apollo.common.utils.UniqueKeyGenerator;
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import com.ctrip.framework.apollo.openapi.util.OpenApiModelConverters;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.service.AccessKeyService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default server-side OpenAPI implementation for access key management.
+ */
+@Service
+public class ServerAccessKeyOpenApiService implements AccessKeyOpenApiService {
+
+  private final AccessKeyService accessKeyService;
+
+  public ServerAccessKeyOpenApiService(AccessKeyService accessKeyService) {
+    this.accessKeyService = accessKeyService;
+  }
+
+  @Override
+  public List<OpenAccessKeyDTO> findAccessKeys(String appId, String env) {
+    return OpenApiModelConverters
+        .fromAccessKeyDTOs(accessKeyService.findByAppId(Env.valueOf(env), appId));
+  }
+
+  @Override
+  public OpenAccessKeyDTO createAccessKey(String appId, String env, String operator) {
+    AccessKeyDTO accessKey = new AccessKeyDTO();
+    accessKey.setAppId(appId);
+    accessKey.setSecret(UniqueKeyGenerator.generateId());
+    accessKey.setDataChangeCreatedBy(operator);
+    accessKey.setDataChangeLastModifiedBy(operator);
+    return OpenApiModelConverters
+        .fromAccessKeyDTO(accessKeyService.createAccessKey(Env.valueOf(env), accessKey));
+  }
+
+  @Override
+  public void deleteAccessKey(String appId, String env, Long accessKeyId, String operator) {
+    accessKeyService.deleteAccessKey(Env.valueOf(env), appId, accessKeyId, operator);
+  }
+
+  @Override
+  public void enableAccessKey(String appId, String env, Long accessKeyId, Integer mode,
+      String operator) {
+    int resolvedMode = mode == null ? FILTER : mode;
+    accessKeyService.enable(Env.valueOf(env), appId, accessKeyId, resolvedMode, operator);
+  }
+
+  @Override
+  public void disableAccessKey(String appId, String env, Long accessKeyId, String operator) {
+    accessKeyService.disable(Env.valueOf(env), appId, accessKeyId, operator);
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiService.java
@@ -238,7 +238,7 @@ public class ServerPermissionOpenApiService implements PermissionOpenApiService 
 
   @Override
   public void deleteCreateApplicationRoleFromUser(String userId, String operator) {
-    checkUserExists(userId);
+    RequestPrecondition.checkArgumentsNotEmpty(userId);
     rolePermissionService.removeRoleFromUsers(SystemRoleManagerService.CREATE_APPLICATION_ROLE_NAME,
         Sets.newHashSet(userId), operator);
   }
@@ -264,7 +264,7 @@ public class ServerPermissionOpenApiService implements PermissionOpenApiService 
 
   @Override
   public void removeManageAppMasterRoleFromUser(String appId, String userId, String operator) {
-    checkUserExists(userId);
+    RequestPrecondition.checkArgumentsNotEmpty(userId);
     roleInitializationService.initManageAppMasterRole(appId, operator);
     rolePermissionService.removeRoleFromUsers(
         RoleUtils.buildAppRoleName(appId, PermissionType.MANAGE_APP_MASTER),
@@ -284,7 +284,7 @@ public class ServerPermissionOpenApiService implements PermissionOpenApiService 
   }
 
   private void assignRole(String roleName, String roleType, String userId, String operator) {
-    validateRoleMutation(roleType, userId);
+    validateRoleAssignment(roleType, userId);
     Set<String> assignedUsers =
         rolePermissionService.assignRoleToUsers(roleName, Sets.newHashSet(userId), operator);
     if (CollectionUtils.isEmpty(assignedUsers)) {
@@ -293,13 +293,17 @@ public class ServerPermissionOpenApiService implements PermissionOpenApiService 
   }
 
   private void removeRole(String roleName, String roleType, String userId, String operator) {
-    validateRoleMutation(roleType, userId);
+    validateRoleRemoval(roleType, userId);
     rolePermissionService.removeRoleFromUsers(roleName, Sets.newHashSet(userId), operator);
   }
 
-  private void validateRoleMutation(String roleType, String userId) {
-    RequestPrecondition.checkArgumentsNotEmpty(userId);
+  private void validateRoleAssignment(String roleType, String userId) {
+    validateRoleRemoval(roleType, userId);
     checkUserExists(userId);
+  }
+
+  private void validateRoleRemoval(String roleType, String userId) {
+    RequestPrecondition.checkArgumentsNotEmpty(userId);
     if (!RoleType.isValidRoleType(roleType)) {
       throw BadRequestException.invalidRoleTypeFormat(roleType);
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiService.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.common.utils.RequestPrecondition;
+import com.ctrip.framework.apollo.openapi.model.OpenAppRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenClusterNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPermissionConditionDTO;
+import com.ctrip.framework.apollo.openapi.util.OpenApiModelConverters;
+import com.ctrip.framework.apollo.portal.constant.PermissionType;
+import com.ctrip.framework.apollo.portal.constant.RoleType;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.entity.vo.AppRolesAssignedUsers;
+import com.ctrip.framework.apollo.portal.entity.vo.ClusterNamespaceRolesAssignedUsers;
+import com.ctrip.framework.apollo.portal.entity.vo.NamespaceEnvRolesAssignedUsers;
+import com.ctrip.framework.apollo.portal.entity.vo.NamespaceRolesAssignedUsers;
+import com.ctrip.framework.apollo.portal.entity.vo.PermissionCondition;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import com.ctrip.framework.apollo.portal.service.RolePermissionService;
+import com.ctrip.framework.apollo.portal.service.SystemRoleManagerService;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import com.ctrip.framework.apollo.portal.util.RoleUtils;
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Default server-side OpenAPI implementation for permission and role management.
+ */
+@Service
+public class ServerPermissionOpenApiService implements PermissionOpenApiService {
+
+  private static final String HAS_CREATE_APPLICATION_PERMISSION = "hasCreateApplicationPermission";
+  private static final String IS_MANAGE_APP_MASTER_PERMISSION_ENABLED =
+      "isManageAppMasterPermissionEnabled";
+
+  private final RolePermissionService rolePermissionService;
+  private final UserService userService;
+  private final RoleInitializationService roleInitializationService;
+  private final SystemRoleManagerService systemRoleManagerService;
+
+  public ServerPermissionOpenApiService(RolePermissionService rolePermissionService,
+      UserService userService, RoleInitializationService roleInitializationService,
+      SystemRoleManagerService systemRoleManagerService) {
+    this.rolePermissionService = rolePermissionService;
+    this.userService = userService;
+    this.roleInitializationService = roleInitializationService;
+    this.systemRoleManagerService = systemRoleManagerService;
+  }
+
+  @Override
+  public void initAppPermission(String appId, String namespaceName, String operator) {
+    roleInitializationService.initNamespaceEnvRoles(appId, namespaceName, operator);
+  }
+
+  @Override
+  public void initClusterNamespacePermission(String appId, String env, String clusterName,
+      String operator) {
+    roleInitializationService.initClusterNamespaceRoles(appId, normalizeEnv(env), clusterName,
+        operator);
+  }
+
+  @Override
+  public OpenPermissionConditionDTO hasAppPermission(String appId, String permissionType,
+      String userId) {
+    return permission(rolePermissionService.userHasPermission(userId, permissionType, appId));
+  }
+
+  @Override
+  public OpenPermissionConditionDTO hasNamespacePermission(String appId, String namespaceName,
+      String permissionType, String userId) {
+    return permission(rolePermissionService.userHasPermission(userId, permissionType,
+        RoleUtils.buildNamespaceTargetId(appId, namespaceName)));
+  }
+
+  @Override
+  public OpenPermissionConditionDTO hasEnvNamespacePermission(String appId, String env,
+      String namespaceName, String permissionType, String userId) {
+    return permission(rolePermissionService.userHasPermission(userId, permissionType,
+        RoleUtils.buildNamespaceTargetId(appId, namespaceName, normalizeEnv(env))));
+  }
+
+  @Override
+  public OpenPermissionConditionDTO hasClusterNamespacePermission(String appId, String env,
+      String clusterName, String permissionType, String userId) {
+    String normalizedEnv = normalizeEnv(env);
+    return permission(rolePermissionService.userHasPermission(userId, permissionType,
+        RoleUtils.buildClusterTargetId(appId, normalizedEnv, clusterName)));
+  }
+
+  @Override
+  public OpenPermissionConditionDTO hasRootPermission(String userId) {
+    return permission(rolePermissionService.isSuperAdmin(userId));
+  }
+
+  @Override
+  public OpenEnvNamespaceRoleUserDTO getNamespaceEnvRoleUsers(String appId, String env,
+      String namespaceName) {
+    String normalizedEnv = normalizeEnv(env);
+    NamespaceEnvRolesAssignedUsers assignedUsers = new NamespaceEnvRolesAssignedUsers();
+    assignedUsers.setAppId(appId);
+    assignedUsers.setNamespaceName(namespaceName);
+    assignedUsers.setEnv(Env.valueOf(normalizedEnv));
+    assignedUsers.setReleaseRoleUsers(rolePermissionService.queryUsersWithRole(
+        RoleUtils.buildReleaseNamespaceRoleName(appId, namespaceName, normalizedEnv)));
+    assignedUsers.setModifyRoleUsers(rolePermissionService.queryUsersWithRole(
+        RoleUtils.buildModifyNamespaceRoleName(appId, namespaceName, normalizedEnv)));
+    return OpenApiModelConverters.fromNamespaceEnvRolesAssignedUsers(assignedUsers);
+  }
+
+  @Override
+  public void assignNamespaceEnvRoleToUser(String appId, String env, String namespaceName,
+      String roleType, String userId, String operator) {
+    assignRole(RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType, normalizeEnv(env)),
+        roleType, userId, operator);
+  }
+
+  @Override
+  public void removeNamespaceEnvRoleFromUser(String appId, String env, String namespaceName,
+      String roleType, String userId, String operator) {
+    removeRole(RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType, normalizeEnv(env)),
+        roleType, userId, operator);
+  }
+
+  @Override
+  public OpenClusterNamespaceRoleUserDTO getClusterNamespaceRoles(String appId, String env,
+      String clusterName) {
+    String normalizedEnv = normalizeEnv(env);
+    ClusterNamespaceRolesAssignedUsers assignedUsers = new ClusterNamespaceRolesAssignedUsers();
+    assignedUsers.setAppId(appId);
+    assignedUsers.setEnv(normalizedEnv);
+    assignedUsers.setCluster(clusterName);
+    assignedUsers.setReleaseRoleUsers(rolePermissionService.queryUsersWithRole(
+        RoleUtils.buildReleaseNamespacesInClusterRoleName(appId, normalizedEnv, clusterName)));
+    assignedUsers.setModifyRoleUsers(rolePermissionService.queryUsersWithRole(
+        RoleUtils.buildModifyNamespacesInClusterRoleName(appId, normalizedEnv, clusterName)));
+    return OpenApiModelConverters.fromClusterNamespaceRolesAssignedUsers(assignedUsers);
+  }
+
+  @Override
+  public void assignClusterNamespaceRoleToUser(String appId, String env, String clusterName,
+      String roleType, String userId, String operator) {
+    assignRole(RoleUtils.buildClusterRoleName(appId, normalizeEnv(env), clusterName, roleType),
+        roleType, userId, operator);
+  }
+
+  @Override
+  public void removeClusterNamespaceRoleFromUser(String appId, String env, String clusterName,
+      String roleType, String userId, String operator) {
+    removeRole(RoleUtils.buildClusterRoleName(appId, normalizeEnv(env), clusterName, roleType),
+        roleType, userId, operator);
+  }
+
+  @Override
+  public OpenNamespaceRoleUserDTO getNamespaceRoles(String appId, String namespaceName) {
+    NamespaceRolesAssignedUsers assignedUsers = new NamespaceRolesAssignedUsers();
+    assignedUsers.setAppId(appId);
+    assignedUsers.setNamespaceName(namespaceName);
+    assignedUsers.setReleaseRoleUsers(rolePermissionService
+        .queryUsersWithRole(RoleUtils.buildReleaseNamespaceRoleName(appId, namespaceName)));
+    assignedUsers.setModifyRoleUsers(rolePermissionService
+        .queryUsersWithRole(RoleUtils.buildModifyNamespaceRoleName(appId, namespaceName)));
+    return OpenApiModelConverters.fromNamespaceRolesAssignedUsers(assignedUsers);
+  }
+
+  @Override
+  public void assignNamespaceRoleToUser(String appId, String namespaceName, String roleType,
+      String userId, String operator) {
+    assignRole(RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType), roleType, userId,
+        operator);
+  }
+
+  @Override
+  public void removeNamespaceRoleFromUser(String appId, String namespaceName, String roleType,
+      String userId, String operator) {
+    removeRole(RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType), roleType, userId,
+        operator);
+  }
+
+  @Override
+  public OpenAppRoleUserDTO getAppRoles(String appId) {
+    AppRolesAssignedUsers assignedUsers = new AppRolesAssignedUsers();
+    assignedUsers.setAppId(appId);
+    assignedUsers.setMasterUsers(
+        rolePermissionService.queryUsersWithRole(RoleUtils.buildAppMasterRoleName(appId)));
+    return OpenApiModelConverters.fromAppRolesAssignedUsers(assignedUsers);
+  }
+
+  @Override
+  public void assignAppRoleToUser(String appId, String roleType, String userId, String operator) {
+    assignRole(RoleUtils.buildAppRoleName(appId, roleType), roleType, userId, operator);
+  }
+
+  @Override
+  public void removeAppRoleFromUser(String appId, String roleType, String userId, String operator) {
+    removeRole(RoleUtils.buildAppRoleName(appId, roleType), roleType, userId, operator);
+  }
+
+  @Override
+  public Map<String, Boolean> hasCreateApplicationPermission(String userId) {
+    return Collections.singletonMap(HAS_CREATE_APPLICATION_PERMISSION,
+        systemRoleManagerService.hasCreateApplicationPermission(userId));
+  }
+
+  @Override
+  public void addCreateApplicationRoleToUsers(List<String> userIds, String operator) {
+    if (CollectionUtils.isEmpty(userIds)) {
+      throw new BadRequestException("userIds should not be null or empty");
+    }
+    userIds.forEach(this::checkUserExists);
+    rolePermissionService.assignRoleToUsers(SystemRoleManagerService.CREATE_APPLICATION_ROLE_NAME,
+        new HashSet<>(userIds), operator);
+  }
+
+  @Override
+  public void deleteCreateApplicationRoleFromUser(String userId, String operator) {
+    checkUserExists(userId);
+    rolePermissionService.removeRoleFromUsers(SystemRoleManagerService.CREATE_APPLICATION_ROLE_NAME,
+        Sets.newHashSet(userId), operator);
+  }
+
+  @Override
+  public List<String> getCreateApplicationRoleUsers() {
+    Set<UserInfo> users = rolePermissionService
+        .queryUsersWithRole(SystemRoleManagerService.CREATE_APPLICATION_ROLE_NAME);
+    if (CollectionUtils.isEmpty(users)) {
+      return Collections.emptyList();
+    }
+    return users.stream().map(UserInfo::getUserId).sorted().collect(Collectors.toList());
+  }
+
+  @Override
+  public void addManageAppMasterRoleToUser(String appId, String userId, String operator) {
+    checkUserExists(userId);
+    roleInitializationService.initManageAppMasterRole(appId, operator);
+    rolePermissionService.assignRoleToUsers(
+        RoleUtils.buildAppRoleName(appId, PermissionType.MANAGE_APP_MASTER),
+        Sets.newHashSet(userId), operator);
+  }
+
+  @Override
+  public void removeManageAppMasterRoleFromUser(String appId, String userId, String operator) {
+    checkUserExists(userId);
+    roleInitializationService.initManageAppMasterRole(appId, operator);
+    rolePermissionService.removeRoleFromUsers(
+        RoleUtils.buildAppRoleName(appId, PermissionType.MANAGE_APP_MASTER),
+        Sets.newHashSet(userId), operator);
+  }
+
+  @Override
+  public Map<String, Boolean> isManageAppMasterPermissionEnabled() {
+    return Collections.singletonMap(IS_MANAGE_APP_MASTER_PERMISSION_ENABLED,
+        systemRoleManagerService.isManageAppMasterPermissionEnabled());
+  }
+
+  private OpenPermissionConditionDTO permission(boolean hasPermission) {
+    PermissionCondition permissionCondition = new PermissionCondition();
+    permissionCondition.setHasPermission(hasPermission);
+    return OpenApiModelConverters.fromPermissionCondition(permissionCondition);
+  }
+
+  private void assignRole(String roleName, String roleType, String userId, String operator) {
+    validateRoleMutation(roleType, userId);
+    Set<String> assignedUsers =
+        rolePermissionService.assignRoleToUsers(roleName, Sets.newHashSet(userId), operator);
+    if (CollectionUtils.isEmpty(assignedUsers)) {
+      throw BadRequestException.userAlreadyAuthorized(userId);
+    }
+  }
+
+  private void removeRole(String roleName, String roleType, String userId, String operator) {
+    validateRoleMutation(roleType, userId);
+    rolePermissionService.removeRoleFromUsers(roleName, Sets.newHashSet(userId), operator);
+  }
+
+  private void validateRoleMutation(String roleType, String userId) {
+    RequestPrecondition.checkArgumentsNotEmpty(userId);
+    checkUserExists(userId);
+    if (!RoleType.isValidRoleType(roleType)) {
+      throw BadRequestException.invalidRoleTypeFormat(roleType);
+    }
+  }
+
+  private void checkUserExists(String userId) {
+    if (userService.findByUserId(userId) == null) {
+      throw BadRequestException.userNotExists(userId);
+    }
+  }
+
+  private String normalizeEnv(String env) {
+    Env transformedEnv = Env.transformEnv(env);
+    if (Env.UNKNOWN == transformedEnv) {
+      throw BadRequestException.invalidEnvFormat(env);
+    }
+    return transformedEnv.getName();
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiModelConverters.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiModelConverters.java
@@ -17,6 +17,7 @@
 package com.ctrip.framework.apollo.openapi.util;
 
 import com.ctrip.framework.apollo.common.dto.ClusterDTO;
+import com.ctrip.framework.apollo.common.dto.AccessKeyDTO;
 import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleDTO;
 import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleItemDTO;
 import com.ctrip.framework.apollo.common.dto.InstanceDTO;
@@ -31,7 +32,11 @@ import com.ctrip.framework.apollo.common.entity.AppNamespace;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
 import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenAppNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenAppRoleUserDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenClusterDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenClusterNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvNamespaceRoleUserDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterInfo;
 import com.ctrip.framework.apollo.openapi.model.OpenGrayReleaseRuleDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenGrayReleaseRuleItemDTO;
@@ -45,21 +50,30 @@ import com.ctrip.framework.apollo.openapi.model.OpenNamespaceDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenNamespaceExtendDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenNamespaceIdentifier;
 import com.ctrip.framework.apollo.openapi.model.OpenNamespaceLockDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenNamespaceRoleUserDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenNamespaceTextModel;
 import com.ctrip.framework.apollo.openapi.model.OpenNamespaceUsageDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenOrganizationDto;
+import com.ctrip.framework.apollo.openapi.model.OpenPermissionConditionDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenReleaseChangeDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenReleaseDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenReleaseDiffDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenUserInfoDTO;
 import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
 import com.ctrip.framework.apollo.portal.entity.bo.KVEntity;
 import com.ctrip.framework.apollo.portal.entity.bo.NamespaceBO;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
 import com.ctrip.framework.apollo.portal.entity.model.NamespaceTextModel;
+import com.ctrip.framework.apollo.portal.entity.vo.AppRolesAssignedUsers;
+import com.ctrip.framework.apollo.portal.entity.vo.ClusterNamespaceRolesAssignedUsers;
 import com.ctrip.framework.apollo.portal.entity.vo.EnvClusterInfo;
 import com.ctrip.framework.apollo.portal.entity.vo.ItemDiffs;
+import com.ctrip.framework.apollo.portal.entity.vo.NamespaceEnvRolesAssignedUsers;
 import com.ctrip.framework.apollo.portal.entity.vo.NamespaceIdentifier;
+import com.ctrip.framework.apollo.portal.entity.vo.NamespaceRolesAssignedUsers;
 import com.ctrip.framework.apollo.portal.entity.vo.NamespaceUsage;
 import com.ctrip.framework.apollo.portal.entity.vo.Organization;
+import com.ctrip.framework.apollo.portal.entity.vo.PermissionCondition;
 import com.ctrip.framework.apollo.portal.entity.vo.ReleaseCompareResult;
 import com.ctrip.framework.apollo.portal.entity.vo.Change;
 import com.google.common.base.Preconditions;
@@ -68,6 +82,7 @@ import com.google.gson.Gson;
 import org.springframework.util.CollectionUtils;
 
 import java.lang.reflect.Type;
+import java.util.Comparator;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -515,6 +530,87 @@ public final class OpenApiModelConverters {
     }
     return clusters.stream().map(OpenApiModelConverters::fromClusterDTO)
         .collect(Collectors.toList());
+  }
+  // endregion
+
+  // region Permission and access key conversions
+  public static OpenAccessKeyDTO fromAccessKeyDTO(final AccessKeyDTO accessKey) {
+    Preconditions.checkArgument(accessKey != null);
+    return BeanUtils.transform(OpenAccessKeyDTO.class, accessKey);
+  }
+
+  public static List<OpenAccessKeyDTO> fromAccessKeyDTOs(final List<AccessKeyDTO> accessKeys) {
+    if (CollectionUtils.isEmpty(accessKeys)) {
+      return Collections.emptyList();
+    }
+    return accessKeys.stream().map(OpenApiModelConverters::fromAccessKeyDTO)
+        .collect(Collectors.toList());
+  }
+
+  public static OpenPermissionConditionDTO fromPermissionCondition(
+      final PermissionCondition condition) {
+    Preconditions.checkArgument(condition != null);
+    OpenPermissionConditionDTO result = new OpenPermissionConditionDTO();
+    result.setHasPermission(condition.hasPermission());
+    return result;
+  }
+
+  public static OpenUserInfoDTO fromUserInfo(final UserInfo userInfo) {
+    Preconditions.checkArgument(userInfo != null);
+    return BeanUtils.transform(OpenUserInfoDTO.class, userInfo);
+  }
+
+  public static List<OpenUserInfoDTO> fromUserInfos(final Set<UserInfo> userInfos) {
+    if (CollectionUtils.isEmpty(userInfos)) {
+      return Collections.emptyList();
+    }
+    return userInfos.stream()
+        .sorted(Comparator.comparing(UserInfo::getUserId, Comparator.nullsFirst(String::compareTo)))
+        .map(OpenApiModelConverters::fromUserInfo).collect(Collectors.toList());
+  }
+
+  public static OpenAppRoleUserDTO fromAppRolesAssignedUsers(
+      final AppRolesAssignedUsers assignedUsers) {
+    Preconditions.checkArgument(assignedUsers != null);
+    OpenAppRoleUserDTO result = new OpenAppRoleUserDTO();
+    result.setAppId(assignedUsers.getAppId());
+    result.setMasterUsers(fromUserInfos(assignedUsers.getMasterUsers()));
+    return result;
+  }
+
+  public static OpenNamespaceRoleUserDTO fromNamespaceRolesAssignedUsers(
+      final NamespaceRolesAssignedUsers assignedUsers) {
+    Preconditions.checkArgument(assignedUsers != null);
+    OpenNamespaceRoleUserDTO result = new OpenNamespaceRoleUserDTO();
+    result.setAppId(assignedUsers.getAppId());
+    result.setNamespaceName(assignedUsers.getNamespaceName());
+    result.setModifyRoleUsers(fromUserInfos(assignedUsers.getModifyRoleUsers()));
+    result.setReleaseRoleUsers(fromUserInfos(assignedUsers.getReleaseRoleUsers()));
+    return result;
+  }
+
+  public static OpenEnvNamespaceRoleUserDTO fromNamespaceEnvRolesAssignedUsers(
+      final NamespaceEnvRolesAssignedUsers assignedUsers) {
+    Preconditions.checkArgument(assignedUsers != null);
+    OpenEnvNamespaceRoleUserDTO result = new OpenEnvNamespaceRoleUserDTO();
+    result.setAppId(assignedUsers.getAppId());
+    result.setNamespaceName(assignedUsers.getNamespaceName());
+    result.setModifyRoleUsers(fromUserInfos(assignedUsers.getModifyRoleUsers()));
+    result.setReleaseRoleUsers(fromUserInfos(assignedUsers.getReleaseRoleUsers()));
+    result.setEnv(assignedUsers.getEnv().getName());
+    return result;
+  }
+
+  public static OpenClusterNamespaceRoleUserDTO fromClusterNamespaceRolesAssignedUsers(
+      final ClusterNamespaceRolesAssignedUsers assignedUsers) {
+    Preconditions.checkArgument(assignedUsers != null);
+    OpenClusterNamespaceRoleUserDTO result = new OpenClusterNamespaceRoleUserDTO();
+    result.setAppId(assignedUsers.getAppId());
+    result.setEnv(assignedUsers.getEnv());
+    result.setCluster(assignedUsers.getCluster());
+    result.setModifyRoleUsers(fromUserInfos(assignedUsers.getModifyRoleUsers()));
+    result.setReleaseRoleUsers(fromUserInfos(assignedUsers.getReleaseRoleUsers()));
+    return result;
   }
   // endregion
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyController.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.audit.annotation.ApolloAuditLog;
+import com.ctrip.framework.apollo.audit.annotation.OpType;
+import com.ctrip.framework.apollo.openapi.api.AccessKeyManagementApi;
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import com.ctrip.framework.apollo.openapi.server.service.AccessKeyOpenApiService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OpenAPI v1 controller for access key management.
+ */
+@RestController("openapiAccessKeyController")
+public class AccessKeyController implements AccessKeyManagementApi {
+
+  private final AccessKeyOpenApiService accessKeyOpenApiService;
+  private final OpenApiOperatorResolver operatorResolver;
+
+  public AccessKeyController(AccessKeyOpenApiService accessKeyOpenApiService,
+      OpenApiOperatorResolver operatorResolver) {
+    this.accessKeyOpenApiService = accessKeyOpenApiService;
+    this.operatorResolver = operatorResolver;
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.CREATE, name = "AccessKey.create")
+  public ResponseEntity<OpenAccessKeyDTO> createAccessKey(String appId, String env,
+      String operator) {
+    return ResponseEntity.ok(
+        accessKeyOpenApiService.createAccessKey(appId, env, operatorResolver.resolve(operator)));
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "AccessKey.delete")
+  public ResponseEntity<Void> deleteAccessKey(String appId, String env, Long accessKeyId,
+      String operator) {
+    accessKeyOpenApiService.deleteAccessKey(appId, env, accessKeyId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.UPDATE, name = "AccessKey.disable")
+  public ResponseEntity<Void> disableAccessKey(String appId, String env, Long accessKeyId,
+      String operator) {
+    accessKeyOpenApiService.disableAccessKey(appId, env, accessKeyId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.UPDATE, name = "AccessKey.enable")
+  public ResponseEntity<Void> enableAccessKey(String appId, String env, Long accessKeyId,
+      Integer mode, String operator) {
+    accessKeyOpenApiService.enableAccessKey(appId, env, accessKeyId, mode,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isAppAdmin(#appId)")
+  public ResponseEntity<List<OpenAccessKeyDTO>> findAccessKeys(String appId, String env) {
+    return ResponseEntity.ok(accessKeyOpenApiService.findAccessKeys(appId, env));
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OpenApiOperatorResolver.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/OpenApiOperatorResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.portal.component.UserIdentityContextHolder;
+import com.ctrip.framework.apollo.portal.constant.UserIdentityConstants;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves mutation operators for OpenAPI requests according to the current identity type.
+ */
+@Component
+public class OpenApiOperatorResolver {
+
+  private final UserInfoHolder userInfoHolder;
+  private final UserService userService;
+
+  public OpenApiOperatorResolver(UserInfoHolder userInfoHolder, UserService userService) {
+    this.userInfoHolder = userInfoHolder;
+    this.userService = userService;
+  }
+
+  public String resolve(String operator) {
+    if (UserIdentityConstants.USER.equals(UserIdentityContextHolder.getAuthType())) {
+      UserInfo loginUser = userInfoHolder.getUser();
+      if (loginUser == null || !StringUtils.hasText(loginUser.getUserId())) {
+        throw new BadRequestException("Current user not found");
+      }
+      return loginUser.getUserId();
+    }
+
+    if (UserIdentityConstants.CONSUMER.equals(UserIdentityContextHolder.getAuthType())) {
+      if (!StringUtils.hasText(operator)) {
+        throw new BadRequestException("operator should not be null or empty");
+      }
+      if (userService.findByUserId(operator) == null) {
+        throw BadRequestException.userNotExists(operator);
+      }
+      return operator;
+    }
+
+    throw new BadRequestException("Unsupported auth type: %s",
+        UserIdentityContextHolder.getAuthType());
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionController.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.audit.annotation.ApolloAuditLog;
+import com.ctrip.framework.apollo.audit.annotation.OpType;
+import com.ctrip.framework.apollo.openapi.api.PermissionManagementApi;
+import com.ctrip.framework.apollo.openapi.model.OpenAppRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenClusterNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenNamespaceRoleUserDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenPermissionConditionDTO;
+import com.ctrip.framework.apollo.openapi.server.service.PermissionOpenApiService;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OpenAPI v1 controller for permission checks and role management.
+ */
+@RestController("openapiPermissionController")
+public class PermissionController implements PermissionManagementApi {
+
+  private final PermissionOpenApiService permissionOpenApiService;
+  private final OpenApiOperatorResolver operatorResolver;
+
+  public PermissionController(PermissionOpenApiService permissionOpenApiService,
+      OpenApiOperatorResolver operatorResolver) {
+    this.permissionOpenApiService = permissionOpenApiService;
+    this.operatorResolver = operatorResolver;
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.addCreateApplicationRoleToUser")
+  public ResponseEntity<Void> addCreateApplicationRoleToUsers(String operator,
+      List<String> requestBody) {
+    permissionOpenApiService.addCreateApplicationRoleToUsers(requestBody,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.addManageAppMasterRoleToUser")
+  public ResponseEntity<Void> addManageAppMasterRoleToUser(String appId, String userId,
+      String operator) {
+    permissionOpenApiService.addManageAppMasterRoleToUser(appId, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasManageAppMasterPermission(#appId)")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.assignAppRoleToUser")
+  public ResponseEntity<Void> assignAppRoleToUser(String appId, String roleType, String userId,
+      String operator, String body) {
+    permissionOpenApiService.assignAppRoleToUser(appId, roleType, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  public ResponseEntity<Void> assignClusterNamespaceRoleToUser(String appId, String env,
+      String clusterName, String roleType, String userId, String operator) {
+    permissionOpenApiService.assignClusterNamespaceRoleToUser(appId, env, clusterName, roleType,
+        userId, operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.assignNamespaceEnvRoleToUser")
+  public ResponseEntity<Void> assignNamespaceEnvRoleToUser(String appId, String env,
+      String namespaceName, String roleType, String userId, String operator) {
+    permissionOpenApiService.assignNamespaceEnvRoleToUser(appId, env, namespaceName, roleType,
+        userId, operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.assignNamespaceRoleToUser")
+  public ResponseEntity<Void> assignNamespaceRoleToUser(String appId, String namespaceName,
+      String roleType, String userId, String operator) {
+    permissionOpenApiService.assignNamespaceRoleToUser(appId, namespaceName, roleType, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.deleteCreateApplicationRoleFromUser")
+  public ResponseEntity<Void> deleteCreateApplicationRoleFromUser(String userId, String operator) {
+    permissionOpenApiService.deleteCreateApplicationRoleFromUser(userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  public ResponseEntity<OpenAppRoleUserDTO> getAppRoles(String appId) {
+    return ResponseEntity.ok(permissionOpenApiService.getAppRoles(appId));
+  }
+
+  @Override
+  public ResponseEntity<OpenClusterNamespaceRoleUserDTO> getClusterNamespaceRoles(String appId,
+      String env, String clusterName) {
+    return ResponseEntity
+        .ok(permissionOpenApiService.getClusterNamespaceRoles(appId, env, clusterName));
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  public ResponseEntity<List<String>> getCreateApplicationRoleUsers() {
+    return ResponseEntity.ok(permissionOpenApiService.getCreateApplicationRoleUsers());
+  }
+
+  @Override
+  public ResponseEntity<OpenEnvNamespaceRoleUserDTO> getNamespaceEnvRoleUsers(String appId,
+      String env, String namespaceName) {
+    return ResponseEntity
+        .ok(permissionOpenApiService.getNamespaceEnvRoleUsers(appId, env, namespaceName));
+  }
+
+  @Override
+  public ResponseEntity<OpenNamespaceRoleUserDTO> getNamespaceRoles(String appId,
+      String namespaceName) {
+    return ResponseEntity.ok(permissionOpenApiService.getNamespaceRoles(appId, namespaceName));
+  }
+
+  @Override
+  public ResponseEntity<OpenPermissionConditionDTO> hasAppPermission(String appId,
+      String permissionType, String userId) {
+    return ResponseEntity
+        .ok(permissionOpenApiService.hasAppPermission(appId, permissionType, userId));
+  }
+
+  @Override
+  public ResponseEntity<OpenPermissionConditionDTO> hasClusterNamespacePermission(String appId,
+      String env, String clusterName, String permissionType, String userId) {
+    return ResponseEntity.ok(permissionOpenApiService.hasClusterNamespacePermission(appId, env,
+        clusterName, permissionType, userId));
+  }
+
+  @Override
+  public ResponseEntity<Map<String, Boolean>> hasCreateApplicationPermission(String userId) {
+    return ResponseEntity.ok(permissionOpenApiService.hasCreateApplicationPermission(userId));
+  }
+
+  @Override
+  public ResponseEntity<OpenPermissionConditionDTO> hasEnvNamespacePermission(String appId,
+      String env, String namespaceName, String permissionType, String userId) {
+    return ResponseEntity.ok(permissionOpenApiService.hasEnvNamespacePermission(appId, env,
+        namespaceName, permissionType, userId));
+  }
+
+  @Override
+  public ResponseEntity<OpenPermissionConditionDTO> hasNamespacePermission(String appId,
+      String namespaceName, String permissionType, String userId) {
+    return ResponseEntity.ok(permissionOpenApiService.hasNamespacePermission(appId, namespaceName,
+        permissionType, userId));
+  }
+
+  @Override
+  public ResponseEntity<OpenPermissionConditionDTO> hasRootPermission(String userId) {
+    return ResponseEntity.ok(permissionOpenApiService.hasRootPermission(userId));
+  }
+
+  @Override
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.initAppPermission")
+  public ResponseEntity<Void> initAppPermission(String appId, String namespaceName,
+      String operator) {
+    permissionOpenApiService.initAppPermission(appId, namespaceName,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.initClusterNamespacePermission")
+  public ResponseEntity<Void> initClusterNamespacePermission(String appId, String env,
+      String clusterName, String operator) {
+    permissionOpenApiService.initClusterNamespacePermission(appId, env, clusterName,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  public ResponseEntity<Map<String, Boolean>> isManageAppMasterPermissionEnabled() {
+    return ResponseEntity.ok(permissionOpenApiService.isManageAppMasterPermissionEnabled());
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasManageAppMasterPermission(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.removeAppRoleFromUser")
+  public ResponseEntity<Void> removeAppRoleFromUser(String appId, String roleType, String userId,
+      String operator) {
+    permissionOpenApiService.removeAppRoleFromUser(appId, roleType, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  public ResponseEntity<Void> removeClusterNamespaceRoleFromUser(String appId, String env,
+      String clusterName, String roleType, String userId, String operator) {
+    permissionOpenApiService.removeClusterNamespaceRoleFromUser(appId, env, clusterName, roleType,
+        userId, operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.isSuperAdmin()")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.forbidManageAppMaster")
+  public ResponseEntity<Void> removeManageAppMasterRoleFromUser(String appId, String userId,
+      String operator) {
+    permissionOpenApiService.removeManageAppMasterRoleFromUser(appId, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.removeNamespaceEnvRoleFromUser")
+  public ResponseEntity<Void> removeNamespaceEnvRoleFromUser(String appId, String env,
+      String namespaceName, String roleType, String userId, String operator) {
+    permissionOpenApiService.removeNamespaceEnvRoleFromUser(appId, env, namespaceName, roleType,
+        userId, operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.removeNamespaceRoleFromUser")
+  public ResponseEntity<Void> removeNamespaceRoleFromUser(String appId, String namespaceName,
+      String roleType, String userId, String operator) {
+    permissionOpenApiService.removeNamespaceRoleFromUser(appId, namespaceName, roleType, userId,
+        operatorResolver.resolve(operator));
+    return ResponseEntity.ok().build();
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionController.java
@@ -78,6 +78,7 @@ public class PermissionController implements PermissionManagementApi {
 
   @Override
   @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.CREATE, name = "Auth.assignClusterNamespaceRoleToUser")
   public ResponseEntity<Void> assignClusterNamespaceRoleToUser(String appId, String env,
       String clusterName, String roleType, String userId, String operator) {
     permissionOpenApiService.assignClusterNamespaceRoleToUser(appId, env, clusterName, roleType,
@@ -184,6 +185,7 @@ public class PermissionController implements PermissionManagementApi {
   }
 
   @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
   @ApolloAuditLog(type = OpType.CREATE, name = "Auth.initAppPermission")
   public ResponseEntity<Void> initAppPermission(String appId, String namespaceName,
       String operator) {
@@ -193,6 +195,7 @@ public class PermissionController implements PermissionManagementApi {
   }
 
   @Override
+  @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
   @ApolloAuditLog(type = OpType.CREATE, name = "Auth.initClusterNamespacePermission")
   public ResponseEntity<Void> initClusterNamespacePermission(String appId, String env,
       String clusterName, String operator) {
@@ -218,6 +221,7 @@ public class PermissionController implements PermissionManagementApi {
 
   @Override
   @PreAuthorize(value = "@unifiedPermissionValidator.hasAssignRolePermission(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "Auth.removeClusterNamespaceRoleFromUser")
   public ResponseEntity<Void> removeClusterNamespaceRoleFromUser(String appId, String env,
       String clusterName, String roleType, String userId, String operator) {
     permissionOpenApiService.removeClusterNamespaceRoleFromUser(appId, env, clusterName, roleType,

--- a/apollo-portal/src/main/resources/static/scripts/services/AccessKeyService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/AccessKeyService.js
@@ -14,30 +14,56 @@
  * limitations under the License.
  *
  */
-appService.service('AccessKeyService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
+appService.service('AccessKeyService', ['$resource', '$q', 'AppUtil', 'UserService', function ($resource, $q, AppUtil, UserService) {
     var access_key_resource = $resource('', {}, {
         load_access_keys: {
             method: 'GET',
             isArray: true,
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/accesskeys'
         },
         create_access_key: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/accesskeys'
         },
         remove_access_key: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/accesskeys/:id'
         },
         enable_access_key: {
             method: 'PUT',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id/enable?mode=:mode'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/accesskeys/:id/activation'
         },
         disable_access_key: {
             method: 'PUT',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id/disable'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/accesskeys/:id/deactivation'
         }
     });
+
+    var current_user_promise;
+
+    function loadCurrentUserId() {
+        if (!current_user_promise) {
+            current_user_promise = UserService.load_user().then(function (user) {
+                return user.userId;
+            }, function (result) {
+                current_user_promise = null;
+                return $q.reject(result);
+            });
+        }
+        return current_user_promise;
+    }
+
+    function resolveOperator(operator) {
+        if (operator) {
+            return $q.when(operator);
+        }
+        return loadCurrentUserId();
+    }
+
+    function withOperator(operator, callback) {
+        return resolveOperator(operator).then(callback);
+    }
+
     return {
         load_access_keys: function (appId, env) {
             var d = $q.defer();
@@ -54,58 +80,78 @@ appService.service('AccessKeyService', ['$resource', '$q', 'AppUtil', function (
         },
         create_access_key: function (appId, env, user) {
             var d = $q.defer();
-            access_key_resource.create_access_key({
+            withOperator(user, function (operator) {
+                access_key_resource.create_access_key({
                     appId: appId,
-                    env: env
-                }, { dataChangeCreatedBy: user },
-                function (result) {
-                    d.resolve(result);
-                }, function (result) {
-                    d.reject(result);
-                });
+                    env: env,
+                    operator: operator
+                }, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }).catch(function (result) {
+                d.reject(result);
+            });
             return d.promise;
         },
         remove_access_key: function (appId, env, id) {
             var d = $q.defer();
-            access_key_resource.remove_access_key({
+            withOperator(null, function (operator) {
+                access_key_resource.remove_access_key({
                     appId: appId,
                     env: env,
-                    id: id
+                    id: id,
+                    operator: operator
                 },
-                function (result) {
-                    d.resolve(result);
-                }, function (result) {
-                    d.reject(result);
-                });
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }).catch(function (result) {
+                d.reject(result);
+            });
             return d.promise;
         },
         enable_access_key: function (appId, env, id, mode) {
             var d = $q.defer();
-            access_key_resource.enable_access_key({
+            withOperator(null, function (operator) {
+                access_key_resource.enable_access_key({
                     appId: appId,
                     env: env,
                     id: id,
-                    mode: mode
+                    mode: mode,
+                    operator: operator
                 }, {},
-                function (result) {
-                    d.resolve(result);
-                }, function (result) {
-                    d.reject(result);
-                });
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }).catch(function (result) {
+                d.reject(result);
+            });
             return d.promise;
         },
         disable_access_key: function (appId, env, id) {
             var d = $q.defer();
-            access_key_resource.disable_access_key({
+            withOperator(null, function (operator) {
+                access_key_resource.disable_access_key({
                     appId: appId,
                     env: env,
-                    id: id
+                    id: id,
+                    operator: operator
                 }, {},
-                function (result) {
-                    d.resolve(result);
-                }, function (result) {
-                    d.reject(result);
-                });
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }).catch(function (result) {
+                d.reject(result);
+            });
             return d.promise;
         }
     }

--- a/apollo-portal/src/main/resources/static/scripts/services/AppService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/AppService.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-appService.service('AppService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
+appService.service('AppService', ['$resource', '$q', 'AppUtil', 'UserService', function ($resource, $q, AppUtil, UserService) {
     var app_resource = $resource(AppUtil.prefixPath() + '/apps/:appId', {}, {
         find_apps: {
             method: 'GET',
@@ -67,17 +67,31 @@ appService.service('AppService', ['$resource', '$q', 'AppUtil', function ($resou
         },
         allow_app_master_assign_role: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/system/master/:userId'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/roles/master'
         },
         delete_app_master_assign_role: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/system/master/:userId'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/roles/master'
         },
         has_create_application_role: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/system/role/createApplication/:userId'
+            url: AppUtil.prefixPath() + '/openapi/v1/system/roles/create-application'
         }
     });
+    var current_user_promise;
+
+    function loadCurrentUserId() {
+        if (!current_user_promise) {
+            current_user_promise = UserService.load_user().then(function (user) {
+                return user.userId;
+            }, function (result) {
+                current_user_promise = null;
+                return $q.reject(result);
+            });
+        }
+        return current_user_promise;
+    }
+
     function normalizeOpenApiStatusArray(result, bodyMapper) {
         var response = {
             entities: []
@@ -233,11 +247,16 @@ appService.service('AppService', ['$resource', '$q', 'AppUtil', function ($resou
         },
         allow_app_master_assign_role: function (appId, userId) {
             var d = $q.defer();
-            app_resource.allow_app_master_assign_role({
-                appId: appId,
-                userId: userId
-            }, null, function (result) {
-                d.resolve(result);
+            loadCurrentUserId().then(function (operator) {
+                app_resource.allow_app_master_assign_role({
+                    appId: appId,
+                    userId: userId,
+                    operator: operator
+                }, null, function (result) {
+                    d.resolve(result);
+                }, function (result) {
+                    d.reject(result);
+                });
             }, function (result) {
                 d.reject(result);
             });
@@ -245,11 +264,16 @@ appService.service('AppService', ['$resource', '$q', 'AppUtil', function ($resou
         },
         delete_app_master_assign_role: function (appId, userId) {
             var d = $q.defer();
-            app_resource.delete_app_master_assign_role({
-                appId: appId,
-                userId: userId
-            }, function (result) {
-                d.resolve(result);
+            loadCurrentUserId().then(function (operator) {
+                app_resource.delete_app_master_assign_role({
+                    appId: appId,
+                    userId: userId,
+                    operator: operator
+                }, function (result) {
+                    d.resolve(result);
+                }, function (result) {
+                    d.reject(result);
+                });
             }, function (result) {
                 d.reject(result);
             });

--- a/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
@@ -14,115 +14,131 @@
  * limitations under the License.
  *
  */
-appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
+appService.service('PermissionService', ['$resource', '$q', 'AppUtil', 'UserService', function ($resource, $q, AppUtil, UserService) {
     var permission_resource = $resource('', {}, {
         init_app_namespace_permission: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/initPermission',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/namespaces/:namespaceName/permission-init'
         },
         init_cluster_ns_permission: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/clusters/:clusterName/initNsPermission',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/clusters/:clusterName/namespaces/permission-init'
         },
         has_app_permission: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/permissions/:permissionType'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/permissions/:permissionType'
         },
         has_namespace_permission: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/namespaces/:namespaceName/permissions/:permissionType'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/namespaces/:namespaceName/permissions/:permissionType'
         },
         has_namespace_env_permission: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/namespaces/:namespaceName/permissions/:permissionType'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/namespaces/:namespaceName/permissions/:permissionType'
         },
         has_cluster_ns_permission: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/clusters/:clusterName/ns_permissions/:permissionType'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/clusters/:clusterName/namespaces/permissions/:permissionType'
         },
         has_root_permission:{
             method: 'GET',
-            url: AppUtil.prefixPath() + '/permissions/root'
+            url: AppUtil.prefixPath() + '/openapi/v1/permissions/root'
         },
         get_namespace_role_users: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/namespaces/:namespaceName/role_users'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/namespaces/:namespaceName/role-users'
         },
         get_namespace_env_role_users: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/namespaces/:namespaceName/role_users'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/namespaces/:namespaceName/role-users'
         },
         assign_namespace_role_to_user: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/namespaces/:namespaceName/roles/:roleType',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/namespaces/:namespaceName/roles/:roleType'
         },
         assign_namespace_env_role_to_user: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/namespaces/:namespaceName/roles/:roleType',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/namespaces/:namespaceName/roles/:roleType'
         },
         remove_namespace_role_from_user: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/namespaces/:namespaceName/roles/:roleType?user=:user'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/namespaces/:namespaceName/roles/:roleType'
         },
         remove_namespace_env_role_from_user: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/namespaces/:namespaceName/roles/:roleType?user=:user'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/namespaces/:namespaceName/roles/:roleType'
         },
         get_app_role_users: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/role_users'    
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/role-users'
         },
         assign_app_role_to_user: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/roles/:roleType',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/roles/:roleType'
         },
         remove_app_role_from_user: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/roles/:roleType?user=:user'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/roles/:roleType'
         },
         has_open_manage_app_master_role_limit: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/system/role/manageAppMaster'
+            url: AppUtil.prefixPath() + '/openapi/v1/system/role/manage-app-master'
         },
         get_cluster_ns_role_users: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/clusters/:clusterName/ns_role_users'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/clusters/:clusterName/namespaces/role-users'
         },
         assign_cluster_ns_role_to_user: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/clusters/:clusterName/ns_roles/:roleType',
-            headers: {
-                 'Content-Type': 'text/plain;charset=UTF-8'
-            }
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/clusters/:clusterName/roles/:roleType'
         },
         remove_cluster_ns_role_from_user: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/clusters/:clusterName/ns_roles/:roleType?user=:user'
+            url: AppUtil.prefixPath() + '/openapi/v1/apps/:appId/envs/:env/clusters/:clusterName/roles/:roleType'
         }
     });
 
+    var current_user_promise;
+
+    function loadCurrentUserId() {
+        if (!current_user_promise) {
+            current_user_promise = UserService.load_user().then(function (user) {
+                return user.userId;
+            }, function (result) {
+                current_user_promise = null;
+                return $q.reject(result);
+            });
+        }
+        return current_user_promise;
+    }
+
+    function attachCurrentUserId(params, callback, reject) {
+        loadCurrentUserId().then(function (userId) {
+            params.userId = userId;
+            callback(params);
+        }, reject);
+    }
+
+    function attachOperator(params, callback, reject) {
+        loadCurrentUserId().then(function (operator) {
+            params.operator = operator;
+            callback(params);
+        }, reject);
+    }
+
     function initAppNamespacePermission(appId, namespace) {
         var d = $q.defer();
-        permission_resource.init_app_namespace_permission({
-                appId: appId
-            }, namespace,
-            function (result) {
-                d.resolve(result);
+        attachOperator({
+                appId: appId,
+                namespaceName: namespace
+            },
+            function (params) {
+                permission_resource.init_app_namespace_permission(params, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -131,13 +147,18 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function initClusterNsPermission(appId, env, clusterName) {
         var d = $q.defer();
-        permission_resource.init_cluster_ns_permission({
+        attachOperator({
                 appId: appId,
                 env: env,
                 clusterName: clusterName
-            }, {},
-            function (result) {
-                d.resolve(result);
+            },
+            function (params) {
+                permission_resource.init_cluster_ns_permission(params, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -146,13 +167,18 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function hasAppPermission(appId, permissionType) {
         var d = $q.defer();
-        permission_resource.has_app_permission({
-                                                   appId: appId,
-                                                   permissionType: permissionType
-                                               },
-                                               function (result) {
-                                                   d.resolve(result);
-                                               }, function (result) {
+        attachCurrentUserId({
+                appId: appId,
+                permissionType: permissionType
+            },
+            function (params) {
+                permission_resource.has_app_permission(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }, function (result) {
                 d.reject(result);
             });
         return d.promise;
@@ -160,14 +186,19 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function hasNamespacePermission(appId, namespaceName, permissionType) {
         var d = $q.defer();
-        permission_resource.has_namespace_permission({
-                                                         appId: appId,
-                                                         namespaceName: namespaceName,
-                                                         permissionType: permissionType
-                                                     },
-                                                     function (result) {
-                                                         d.resolve(result);
-                                                     }, function (result) {
+        attachCurrentUserId({
+                appId: appId,
+                namespaceName: namespaceName,
+                permissionType: permissionType
+            },
+            function (params) {
+                permission_resource.has_namespace_permission(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }, function (result) {
                 d.reject(result);
             });
         return d.promise;
@@ -175,14 +206,19 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function hasNamespaceEnvPermission(appId, env, namespaceName, permissionType) {
         var d = $q.defer();
-        permission_resource.has_namespace_env_permission({
+        attachCurrentUserId({
                 appId: appId,
                 namespaceName: namespaceName,
                 permissionType: permissionType,
                 env: env
             },
-            function (result) {
-                d.resolve(result);
+            function (params) {
+                permission_resource.has_namespace_env_permission(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -191,14 +227,19 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function hasClusterNsPermission(appId, env, clusterName, permissionType) {
         var d = $q.defer();
-        permission_resource.has_cluster_ns_permission({
+        attachCurrentUserId({
                 appId: appId,
                 env: env,
                 clusterName: clusterName,
                 permissionType: permissionType
             },
-            function (result) {
-                d.resolve(result);
+            function (params) {
+                permission_resource.has_cluster_ns_permission(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -207,14 +248,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function assignNamespaceRoleToUser(appId, namespaceName, roleType, user) {
         var d = $q.defer();
-        permission_resource.assign_namespace_role_to_user({
-                                                              appId: appId,
-                                                              namespaceName: namespaceName,
-                                                              roleType: roleType
-                                                          }, user,
-                                                          function (result) {
-                                                              d.resolve(result);
-                                                          }, function (result) {
+        attachOperator({
+                appId: appId,
+                namespaceName: namespaceName,
+                roleType: roleType,
+                userId: user
+            },
+            function (params) {
+                permission_resource.assign_namespace_role_to_user(params, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }, function (result) {
                 d.reject(result);
             });
         return d.promise;
@@ -222,14 +269,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function assignNamespaceEnvRoleToUser(appId, env, namespaceName, roleType, user) {
         var d = $q.defer();
-        permission_resource.assign_namespace_env_role_to_user({
+        attachOperator({
                 appId: appId,
                 namespaceName: namespaceName,
                 roleType: roleType,
-                env: env
-            }, user,
-            function (result) {
-                d.resolve(result);
+                env: env,
+                userId: user
+            },
+            function (params) {
+                permission_resource.assign_namespace_env_role_to_user(params, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -238,15 +291,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function removeNamespaceRoleFromUser(appId, namespaceName, roleType, user) {
         var d = $q.defer();
-        permission_resource.remove_namespace_role_from_user({
-                                                                appId: appId,
-                                                                namespaceName: namespaceName,
-                                                                roleType: roleType,
-                                                                user: user
-                                                            },
-                                                            function (result) {
-                                                                d.resolve(result);
-                                                            }, function (result) {
+        attachOperator({
+                appId: appId,
+                namespaceName: namespaceName,
+                roleType: roleType,
+                userId: user
+            },
+            function (params) {
+                permission_resource.remove_namespace_role_from_user(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
+            }, function (result) {
                 d.reject(result);
             });
         return d.promise;
@@ -254,15 +312,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function removeNamespaceEnvRoleFromUser(appId, env, namespaceName, roleType, user) {
         var d = $q.defer();
-        permission_resource.remove_namespace_env_role_from_user({
+        attachOperator({
                 appId: appId,
                 namespaceName: namespaceName,
                 roleType: roleType,
-                user: user,
+                userId: user,
                 env: env
             },
-            function (result) {
-                d.resolve(result);
+            function (params) {
+                permission_resource.remove_namespace_env_role_from_user(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -271,14 +334,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function assignClusterNsRoleToUser(appId, env, clusterName, roleType, user) {
         var d = $q.defer();
-        permission_resource.assign_cluster_ns_role_to_user({
+        attachOperator({
                 appId: appId,
                 env: env,
                 clusterName: clusterName,
-                roleType: roleType
-            }, user,
-            function (result) {
-                d.resolve(result);
+                roleType: roleType,
+                userId: user
+            },
+            function (params) {
+                permission_resource.assign_cluster_ns_role_to_user(params, {},
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -287,15 +356,20 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
 
     function removeClusterNsRoleFromUser(appId, env, clusterName, roleType, user) {
         var d = $q.defer();
-        permission_resource.remove_cluster_ns_role_from_user({
+        attachOperator({
                 appId: appId,
                 env: env,
                 clusterName: clusterName,
                 roleType: roleType,
-                user: user
+                userId: user
             },
-            function (result) {
-                d.resolve(result);
+            function (params) {
+                permission_resource.remove_cluster_ns_role_from_user(params,
+                    function (result) {
+                        d.resolve(result);
+                    }, function (result) {
+                        d.reject(result);
+                    });
             }, function (result) {
                 d.reject(result);
             });
@@ -335,13 +409,18 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
         },
         has_root_permission: function () {
             var d = $q.defer();
-            permission_resource.has_root_permission({ },
-                                                         function (result) {
-                                                             d.resolve(result);
-                                                         }, function (result) {
+            attachCurrentUserId({},
+                function (params) {
+                    permission_resource.has_root_permission(params,
+                        function (result) {
+                            d.resolve(result);
+                        }, function (result) {
+                            d.reject(result);
+                        });
+                }, function (result) {
                     d.reject(result);
                 });
-            return d.promise;    
+            return d.promise;
             
         },
         assign_modify_namespace_role: function (appId, namespaceName, user) {
@@ -409,27 +488,38 @@ appService.service('PermissionService', ['$resource', '$q', 'AppUtil', function 
         },
         assign_master_role: function (appId, user) {
             var d = $q.defer();
-            permission_resource.assign_app_role_to_user({
-                                                            appId: appId,
-                                                            roleType: 'Master'
-                                                        }, user,
-                                                        function (result) {
-                                                            d.resolve(result);
-                                                        }, function (result) {
+            attachOperator({
+                    appId: appId,
+                    roleType: 'Master',
+                    userId: user
+                },
+                function (params) {
+                    permission_resource.assign_app_role_to_user(params, {},
+                        function (result) {
+                            d.resolve(result);
+                        }, function (result) {
+                            d.reject(result);
+                        });
+                }, function (result) {
                     d.reject(result);
                 });
             return d.promise;
         },
         remove_master_role: function (appId, user) {
             var d = $q.defer();
-            permission_resource.remove_app_role_from_user({
-                                                              appId: appId,
-                                                              roleType: 'Master',
-                                                              user: user
-                                                          },
-                                                          function (result) {
-                                                              d.resolve(result);
-                                                          }, function (result) {
+            attachOperator({
+                    appId: appId,
+                    roleType: 'Master',
+                    userId: user
+                },
+                function (params) {
+                    permission_resource.remove_app_role_from_user(params,
+                        function (result) {
+                            d.resolve(result);
+                        }, function (result) {
+                            d.reject(result);
+                        });
+                }, function (result) {
                     d.reject(result);
                 });
             return d.promise;

--- a/apollo-portal/src/main/resources/static/scripts/services/SystemRoleService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/SystemRoleService.js
@@ -14,57 +14,85 @@
  * limitations under the License.
  *
  */
-appService.service('SystemRoleService', ['$resource', '$q', 'AppUtil', function ($resource, $q,AppUtil) {
+appService.service('SystemRoleService', ['$resource', '$q', 'AppUtil', 'UserService', function ($resource, $q, AppUtil, UserService) {
     var system_role_service = $resource('', {}, {
         add_create_application_role: {
             method: 'POST',
-            url: AppUtil.prefixPath() + '/system/role/createApplication'
+            url: AppUtil.prefixPath() + '/openapi/v1/system/roles/create-application'
         },
         delete_create_application_role: {
             method: 'DELETE',
-            url: AppUtil.prefixPath() + '/system/role/createApplication/:userId'
+            url: AppUtil.prefixPath() + '/openapi/v1/system/roles/create-application'
         },
         get_create_application_role_users: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/system/role/createApplication',
+            url: AppUtil.prefixPath() + '/openapi/v1/system/roles/create-application/role-users',
             isArray: true
         },
         has_open_manage_app_master_role_limit: {
             method: 'GET',
-            url: AppUtil.prefixPath() + '/system/role/manageAppMaster'
+            url: AppUtil.prefixPath() + '/openapi/v1/system/role/manage-app-master'
         }
     });
+
+    var current_user_promise;
+
+    function loadCurrentUserId() {
+        if (!current_user_promise) {
+            current_user_promise = UserService.load_user().then(function (user) {
+                return user.userId;
+            }, function (result) {
+                current_user_promise = null;
+                return $q.reject(result);
+            });
+        }
+        return current_user_promise;
+    }
+
     return {
         add_create_application_role: function (userId) {
             var finished = false;
             var d = $q.defer();
-            system_role_service.add_create_application_role([
-                   userId
-                ],
-                function (result) {
-                    finished = true;
-                    d.resolve(result);
-                },
-                function (result) {
-                    finished = true;
-                    d.reject(result);
-                });
+            loadCurrentUserId().then(function (operator) {
+                system_role_service.add_create_application_role({
+                        operator: operator
+                    }, [
+                        userId
+                    ],
+                    function (result) {
+                        finished = true;
+                        d.resolve(result);
+                    },
+                    function (result) {
+                        finished = true;
+                        d.reject(result);
+                    });
+            }, function (result) {
+                finished = true;
+                d.reject(result);
+            });
             return d.promise;
         },
         delete_create_application_role: function (userId) {
             var finished = false;
             var d = $q.defer();
-            system_role_service.delete_create_application_role({
-                    "userId" : userId
-                },
-                function (result) {
-                    finished = true;
-                    d.resolve(result);
-                },
-                function (result) {
-                    finished = true;
-                    d.reject(result);
-                });
+            loadCurrentUserId().then(function (operator) {
+                system_role_service.delete_create_application_role({
+                        userId: userId,
+                        operator: operator
+                    },
+                    function (result) {
+                        finished = true;
+                        d.resolve(result);
+                    },
+                    function (result) {
+                        finished = true;
+                        d.reject(result);
+                    });
+            }, function (result) {
+                finished = true;
+                d.reject(result);
+            });
             return d.promise;
         },
         get_create_application_role_users: function () {

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/filter/ConsumerAuthenticationFilterTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/filter/ConsumerAuthenticationFilterTest.java
@@ -203,9 +203,11 @@ public class ConsumerAuthenticationFilterTest {
     executor.shutdown();
     try {
       if (!executor.awaitTermination(durationInSeconds + 5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
         throw new RuntimeException("Timed out waiting for rate limit tasks to finish");
       }
     } catch (InterruptedException e) {
+      executor.shutdownNow();
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/filter/ConsumerAuthenticationFilterTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/filter/ConsumerAuthenticationFilterTest.java
@@ -157,7 +157,7 @@ public class ConsumerAuthenticationFilterTest {
       }
     };
 
-    int realQps = qps + 3;
+    int realQps = qps * 3;
     executeWithQps(realQps, task, durationInSeconds);
 
     int leastTimes = qps * durationInSeconds;
@@ -201,6 +201,14 @@ public class ConsumerAuthenticationFilterTest {
     }
 
     executor.shutdown();
+    try {
+      if (!executor.awaitTermination(durationInSeconds + 5, TimeUnit.SECONDS)) {
+        throw new RuntimeException("Timed out waiting for rate limit tasks to finish");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
@@ -18,12 +18,14 @@ package com.ctrip.framework.apollo.openapi.server.service;
 
 import static com.ctrip.framework.apollo.common.constants.AccessKeyMode.FILTER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.common.dto.AccessKeyDTO;
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
 import com.ctrip.framework.apollo.portal.environment.Env;
 import com.ctrip.framework.apollo.portal.service.AccessKeyService;
@@ -77,5 +79,11 @@ class ServerAccessKeyOpenApiServiceTest {
     service.disableAccessKey("some-app", "DEV", 100L, "operator");
 
     verify(accessKeyService).disable(Env.DEV, "some-app", 100L, "operator");
+  }
+
+  @Test
+  void findAccessKeysShouldRejectInvalidEnv() {
+    assertThatThrownBy(() -> service.findAccessKeys("some-app", "invalid"))
+        .isInstanceOf(BadRequestException.class).hasMessageContaining("invalid env format:invalid");
   }
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
@@ -36,6 +36,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * Unit tests for {@link ServerAccessKeyOpenApiService}.
+ */
 @ExtendWith(MockitoExtension.class)
 class ServerAccessKeyOpenApiServiceTest {
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerAccessKeyOpenApiServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import static com.ctrip.framework.apollo.common.constants.AccessKeyMode.FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ctrip.framework.apollo.common.dto.AccessKeyDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.service.AccessKeyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServerAccessKeyOpenApiServiceTest {
+
+  @Mock
+  private AccessKeyService accessKeyService;
+
+  private ServerAccessKeyOpenApiService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ServerAccessKeyOpenApiService(accessKeyService);
+  }
+
+  @Test
+  void createAccessKeyShouldPopulateOperatorAndSecret() {
+    when(accessKeyService.createAccessKey(eq(Env.DEV), any(AccessKeyDTO.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+
+    OpenAccessKeyDTO result = service.createAccessKey("some-app", "DEV", "operator");
+
+    ArgumentCaptor<AccessKeyDTO> captor = ArgumentCaptor.forClass(AccessKeyDTO.class);
+    verify(accessKeyService).createAccessKey(eq(Env.DEV), captor.capture());
+    AccessKeyDTO request = captor.getValue();
+    assertThat(request.getAppId()).isEqualTo("some-app");
+    assertThat(request.getSecret()).isNotBlank();
+    assertThat(request.getDataChangeCreatedBy()).isEqualTo("operator");
+    assertThat(request.getDataChangeLastModifiedBy()).isEqualTo("operator");
+    assertThat(result.getAppId()).isEqualTo("some-app");
+    assertThat(result.getDataChangeCreatedBy()).isEqualTo("operator");
+  }
+
+  @Test
+  void enableAccessKeyShouldDefaultModeToFilter() {
+    service.enableAccessKey("some-app", "DEV", 100L, null, "operator");
+
+    verify(accessKeyService).enable(Env.DEV, "some-app", 100L, FILTER, "operator");
+  }
+
+  @Test
+  void disableAccessKeyShouldDelegateOperator() {
+    service.disableAccessKey("some-app", "DEV", 100L, "operator");
+
+    verify(accessKeyService).disable(Env.DEV, "some-app", 100L, "operator");
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
@@ -38,6 +38,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * Unit tests for {@link ServerPermissionOpenApiService}.
+ */
 @ExtendWith(MockitoExtension.class)
 class ServerPermissionOpenApiServiceTest {
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
@@ -92,16 +92,45 @@ class ServerPermissionOpenApiServiceTest {
   }
 
   @Test
-  void removeNamespaceRoleShouldRejectMissingTargetUser() {
+  void removeNamespaceRoleShouldAllowMissingTargetUserAndDelegateRoleName() {
+    String appId = "some-app";
+    String namespaceName = "application";
+    String roleType = PermissionType.MODIFY_NAMESPACE;
     String userId = "missing-user";
-    when(userService.findByUserId(userId)).thenReturn(null);
+    String operator = "operator";
+    String roleName = RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType);
 
-    assertThrows(BadRequestException.class, () -> service.removeNamespaceRoleFromUser("some-app",
-        "application", PermissionType.MODIFY_NAMESPACE, userId, "operator"));
+    service.removeNamespaceRoleFromUser(appId, namespaceName, roleType, userId, operator);
 
-    verify(rolePermissionService, never()).removeRoleFromUsers(RoleUtils
-        .buildNamespaceRoleName("some-app", "application", PermissionType.MODIFY_NAMESPACE),
-        Sets.newHashSet(userId), "operator");
+    verify(userService, never()).findByUserId(userId);
+    verify(rolePermissionService).removeRoleFromUsers(roleName, Sets.newHashSet(userId), operator);
+  }
+
+  @Test
+  void deleteCreateApplicationRoleShouldAllowMissingTargetUserAndDelegate() {
+    String userId = "missing-user";
+    String operator = "operator";
+
+    service.deleteCreateApplicationRoleFromUser(userId, operator);
+
+    verify(userService, never()).findByUserId(userId);
+    verify(rolePermissionService).removeRoleFromUsers(
+        SystemRoleManagerService.CREATE_APPLICATION_ROLE_NAME, Sets.newHashSet(userId), operator);
+  }
+
+  @Test
+  void removeManageAppMasterRoleShouldAllowMissingTargetUserAndDelegate() {
+    String appId = "some-app";
+    String userId = "missing-user";
+    String operator = "operator";
+
+    service.removeManageAppMasterRoleFromUser(appId, userId, operator);
+
+    verify(userService, never()).findByUserId(userId);
+    verify(roleInitializationService).initManageAppMasterRole(appId, operator);
+    verify(rolePermissionService).removeRoleFromUsers(
+        RoleUtils.buildAppRoleName(appId, PermissionType.MANAGE_APP_MASTER),
+        Sets.newHashSet(userId), operator);
   }
 
   @Test

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerPermissionOpenApiServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.portal.constant.PermissionType;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import com.ctrip.framework.apollo.portal.service.RolePermissionService;
+import com.ctrip.framework.apollo.portal.service.SystemRoleManagerService;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import com.ctrip.framework.apollo.portal.util.RoleUtils;
+import com.google.common.collect.Sets;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServerPermissionOpenApiServiceTest {
+
+  @Mock
+  private RolePermissionService rolePermissionService;
+  @Mock
+  private UserService userService;
+  @Mock
+  private RoleInitializationService roleInitializationService;
+  @Mock
+  private SystemRoleManagerService systemRoleManagerService;
+
+  private ServerPermissionOpenApiService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ServerPermissionOpenApiService(rolePermissionService, userService,
+        roleInitializationService, systemRoleManagerService);
+  }
+
+  @Test
+  void assignNamespaceRoleShouldValidateTargetUserAndDelegateRoleName() {
+    String appId = "some-app";
+    String namespaceName = "application";
+    String roleType = PermissionType.MODIFY_NAMESPACE;
+    String userId = "target-user";
+    String operator = "operator";
+    String roleName = RoleUtils.buildNamespaceRoleName(appId, namespaceName, roleType);
+    when(userService.findByUserId(userId)).thenReturn(new UserInfo(userId));
+    when(rolePermissionService.assignRoleToUsers(roleName, Sets.newHashSet(userId), operator))
+        .thenReturn(Sets.newHashSet(userId));
+
+    service.assignNamespaceRoleToUser(appId, namespaceName, roleType, userId, operator);
+
+    verify(rolePermissionService).assignRoleToUsers(roleName, Sets.newHashSet(userId), operator);
+  }
+
+  @Test
+  void assignNamespaceRoleShouldRejectMissingTargetUser() {
+    String userId = "missing-user";
+    when(userService.findByUserId(userId)).thenReturn(null);
+
+    assertThrows(BadRequestException.class, () -> service.assignNamespaceRoleToUser("some-app",
+        "application", PermissionType.MODIFY_NAMESPACE, userId, "operator"));
+
+    verify(rolePermissionService, never()).assignRoleToUsers(RoleUtils
+        .buildNamespaceRoleName("some-app", "application", PermissionType.MODIFY_NAMESPACE),
+        Sets.newHashSet(userId), "operator");
+  }
+
+  @Test
+  void removeNamespaceRoleShouldRejectMissingTargetUser() {
+    String userId = "missing-user";
+    when(userService.findByUserId(userId)).thenReturn(null);
+
+    assertThrows(BadRequestException.class, () -> service.removeNamespaceRoleFromUser("some-app",
+        "application", PermissionType.MODIFY_NAMESPACE, userId, "operator"));
+
+    verify(rolePermissionService, never()).removeRoleFromUsers(RoleUtils
+        .buildNamespaceRoleName("some-app", "application", PermissionType.MODIFY_NAMESPACE),
+        Sets.newHashSet(userId), "operator");
+  }
+
+  @Test
+  void hasCreateApplicationPermissionShouldUseUiCompatibleKey() {
+    when(systemRoleManagerService.hasCreateApplicationPermission("some-user")).thenReturn(true);
+
+    Map<String, Boolean> result = service.hasCreateApplicationPermission("some-user");
+
+    assertThat(result).containsEntry("hasCreateApplicationPermission", true);
+  }
+
+  @Test
+  void isManageAppMasterPermissionEnabledShouldUseUiCompatibleKey() {
+    when(systemRoleManagerService.isManageAppMasterPermissionEnabled()).thenReturn(true);
+
+    Map<String, Boolean> result = service.isManageAppMasterPermissionEnabled();
+
+    assertThat(result).containsEntry("isManageAppMasterPermissionEnabled", true);
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyControllerParamBindLowLevelTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ctrip.framework.apollo.openapi.model.OpenAccessKeyDTO;
+import com.ctrip.framework.apollo.openapi.server.service.AccessKeyOpenApiService;
+import com.ctrip.framework.apollo.portal.component.UnifiedPermissionValidator;
+import com.ctrip.framework.apollo.portal.component.UserIdentityContextHolder;
+import com.ctrip.framework.apollo.portal.constant.UserIdentityConstants;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class AccessKeyControllerParamBindLowLevelTest {
+
+  private static final String APP_ID = "app-1";
+  private static final String ENV = "DEV";
+  private static final Long ACCESS_KEY_ID = 100L;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean(name = "unifiedPermissionValidator")
+  private UnifiedPermissionValidator unifiedPermissionValidator;
+
+  @MockitoBean
+  private UserService userService;
+
+  @MockitoBean
+  private UserInfoHolder userInfoHolder;
+
+  @MockitoBean
+  private AccessKeyOpenApiService accessKeyOpenApiService;
+
+  private UserInfo user;
+
+  @BeforeEach
+  public void setUp() {
+    when(unifiedPermissionValidator.isAppAdmin(anyString())).thenReturn(true);
+    user = new UserInfo();
+    user.setUserId("portal-user");
+    when(userInfoHolder.getUser()).thenReturn(user);
+    when(userService.findByUserId("api-operator")).thenReturn(new UserInfo("api-operator"));
+
+    SecurityContextHolder.clearContext();
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken("portal-user", "N/A",
+            AuthorityUtils.NO_AUTHORITIES));
+    UserIdentityContextHolder.setAuthType(UserIdentityConstants.USER);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+    UserIdentityContextHolder.clear();
+  }
+
+  @Test
+  public void enableAccessKeyShouldUseCurrentPortalUserAndDefaultMode() throws Exception {
+    mockMvc.perform(put("/openapi/v1/apps/{appId}/envs/{env}/accesskeys/{accessKeyId}/activation",
+        APP_ID, ENV, ACCESS_KEY_ID)).andExpect(status().isOk());
+
+    verify(accessKeyOpenApiService).enableAccessKey(APP_ID, ENV, ACCESS_KEY_ID, 0, "portal-user");
+  }
+
+  @Test
+  public void disableAccessKeyShouldRejectBlankConsumerOperator() throws Exception {
+    UserIdentityContextHolder.setAuthType(UserIdentityConstants.CONSUMER);
+
+    mockMvc.perform(put("/openapi/v1/apps/{appId}/envs/{env}/accesskeys/{accessKeyId}/deactivation",
+        APP_ID, ENV, ACCESS_KEY_ID)).andExpect(status().isBadRequest());
+
+    verify(accessKeyOpenApiService, never()).disableAccessKey(APP_ID, ENV, ACCESS_KEY_ID, null);
+  }
+
+  @Test
+  public void createAccessKeyShouldUseConsumerOperatorQuery() throws Exception {
+    UserIdentityContextHolder.setAuthType(UserIdentityConstants.CONSUMER);
+    OpenAccessKeyDTO response = new OpenAccessKeyDTO();
+    response.setAppId(APP_ID);
+    when(accessKeyOpenApiService.createAccessKey(APP_ID, ENV, "api-operator")).thenReturn(response);
+
+    mockMvc.perform(post("/openapi/v1/apps/{appId}/envs/{env}/accesskeys", APP_ID, ENV)
+        .param("operator", "api-operator")).andExpect(status().isOk());
+
+    verify(accessKeyOpenApiService).createAccessKey(APP_ID, ENV, "api-operator");
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AccessKeyControllerParamBindLowLevelTest.java
@@ -16,7 +16,9 @@
  */
 package com.ctrip.framework.apollo.openapi.v1.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +48,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Low-level parameter binding tests for {@link AccessKeyController}.
+ */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -108,7 +113,8 @@ public class AccessKeyControllerParamBindLowLevelTest {
     mockMvc.perform(put("/openapi/v1/apps/{appId}/envs/{env}/accesskeys/{accessKeyId}/deactivation",
         APP_ID, ENV, ACCESS_KEY_ID)).andExpect(status().isBadRequest());
 
-    verify(accessKeyOpenApiService, never()).disableAccessKey(APP_ID, ENV, ACCESS_KEY_ID, null);
+    verify(accessKeyOpenApiService, never()).disableAccessKey(eq(APP_ID), eq(ENV),
+        eq(ACCESS_KEY_ID), any());
   }
 
   @Test

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionControllerParamBindLowLevelTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ctrip.framework.apollo.openapi.model.OpenPermissionConditionDTO;
+import com.ctrip.framework.apollo.openapi.server.service.PermissionOpenApiService;
+import com.ctrip.framework.apollo.portal.component.UnifiedPermissionValidator;
+import com.ctrip.framework.apollo.portal.component.UserIdentityContextHolder;
+import com.ctrip.framework.apollo.portal.constant.RoleType;
+import com.ctrip.framework.apollo.portal.constant.UserIdentityConstants;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class PermissionControllerParamBindLowLevelTest {
+
+  private static final String APP_ID = "app-1";
+  private static final String NAMESPACE = "application";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean(name = "unifiedPermissionValidator")
+  private UnifiedPermissionValidator unifiedPermissionValidator;
+
+  @MockitoBean
+  private UserService userService;
+
+  @MockitoBean
+  private UserInfoHolder userInfoHolder;
+
+  @MockitoBean
+  private PermissionOpenApiService permissionOpenApiService;
+
+  @BeforeEach
+  public void setUp() {
+    when(unifiedPermissionValidator.hasManageAppMasterPermission(anyString())).thenReturn(true);
+    when(unifiedPermissionValidator.hasAssignRolePermission(anyString())).thenReturn(true);
+    UserInfo user = new UserInfo("portal-user");
+    when(userInfoHolder.getUser()).thenReturn(user);
+    when(userService.findByUserId("api-operator")).thenReturn(new UserInfo("api-operator"));
+
+    SecurityContextHolder.clearContext();
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken("portal-user", "N/A",
+            AuthorityUtils.NO_AUTHORITIES));
+    UserIdentityContextHolder.setAuthType(UserIdentityConstants.CONSUMER);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+    UserIdentityContextHolder.clear();
+  }
+
+  @Test
+  public void hasAppPermissionShouldUseExplicitUserIdQuery() throws Exception {
+    OpenPermissionConditionDTO response = new OpenPermissionConditionDTO();
+    response.setHasPermission(true);
+    when(permissionOpenApiService.hasAppPermission(APP_ID, "AssignRole", "target-user"))
+        .thenReturn(response);
+
+    mockMvc
+        .perform(get("/openapi/v1/apps/{appId}/permissions/{permissionType}", APP_ID, "AssignRole")
+            .param("userId", "target-user"))
+        .andExpect(status().isOk());
+
+    verify(permissionOpenApiService).hasAppPermission(APP_ID, "AssignRole", "target-user");
+  }
+
+  @Test
+  public void assignNamespaceRoleShouldBindTargetUserAndResolvedOperator() throws Exception {
+    mockMvc.perform(post("/openapi/v1/apps/{appId}/namespaces/{namespaceName}/roles/{roleType}",
+        APP_ID, NAMESPACE, RoleType.MODIFY_NAMESPACE).param("userId", "target-user")
+        .param("operator", "api-operator")).andExpect(status().isOk());
+
+    verify(permissionOpenApiService).assignNamespaceRoleToUser(APP_ID, NAMESPACE,
+        RoleType.MODIFY_NAMESPACE, "target-user", "api-operator");
+  }
+
+  @Test
+  public void initAppPermissionShouldUseCurrentPortalUser() throws Exception {
+    UserIdentityContextHolder.setAuthType(UserIdentityConstants.USER);
+
+    mockMvc.perform(post("/openapi/v1/apps/{appId}/namespaces/{namespaceName}/permission-init",
+        APP_ID, NAMESPACE)).andExpect(status().isOk());
+
+    verify(permissionOpenApiService).initAppPermission(APP_ID, NAMESPACE, "portal-user");
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/PermissionControllerParamBindLowLevelTest.java
@@ -46,6 +46,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Low-level parameter binding tests for {@link PermissionController}.
+ */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)

--- a/e2e/portal-e2e/tests/helpers/portal-helpers.js
+++ b/e2e/portal-e2e/tests/helpers/portal-helpers.js
@@ -358,8 +358,8 @@ async function clearNamespaceRoleViaPortalApi(page, appId, namespaceName, option
   const envPath = env ? encodePathSegment(env) : '';
   const userQuery = encodePathSegment(userId);
   const path = env
-    ? `/apps/${appPath}/envs/${envPath}/namespaces/${namespacePath}/roles/${roleType}?user=${userQuery}`
-    : `/apps/${appPath}/namespaces/${namespacePath}/roles/${roleType}?user=${userQuery}`;
+    ? `/openapi/v1/apps/${appPath}/envs/${envPath}/namespaces/${namespacePath}/roles/${roleType}?userId=${userQuery}`
+    : `/openapi/v1/apps/${appPath}/namespaces/${namespacePath}/roles/${roleType}?userId=${userQuery}`;
   const response = await page.context().request.delete(path);
   expect([200, 204, 400, 404]).toContain(response.status());
 }
@@ -436,9 +436,10 @@ async function assignNamespaceRoleViaUi(page, appId, namespaceName, options = {}
     page,
     'POST',
     [
-      `/apps/${appId}/`,
+      `/openapi/v1/apps/${appId}/`,
       '/namespaces/',
       `/roles/${roleType}`,
+      `userId=${encodePathSegment(userId)}`,
       ...(targetEnv ? [`/envs/${targetEnv}/`] : []),
     ]
   );
@@ -516,9 +517,10 @@ async function assignNamespaceRoleViaUiBySearch(page, appId, namespaceName, opti
     page,
     'POST',
     [
-      `/apps/${appId}/`,
+      `/openapi/v1/apps/${appId}/`,
       '/namespaces/',
       `/roles/${roleType}`,
+      `userId=${encodePathSegment(selectedUserId)}`,
       ...(targetEnv ? [`/envs/${targetEnv}/`] : []),
     ]
   );
@@ -572,9 +574,10 @@ async function revokeNamespaceRoleViaUi(page, appId, namespaceName, options = {}
     page,
     'DELETE',
     [
-      `/apps/${appId}/`,
+      `/openapi/v1/apps/${appId}/`,
       '/namespaces/',
       `/roles/${roleType}`,
+      `userId=${encodePathSegment(userId)}`,
       ...(env ? [`/envs/${env}/`] : []),
     ],
     [200, 204, 400, 404]
@@ -586,6 +589,91 @@ async function revokeNamespaceRoleViaUi(page, appId, namespaceName, options = {}
   ]);
 
   await expect(page.locator('.toast-success').first()).toBeVisible({ timeout: 30000 });
+}
+
+async function clickWithAcceptedDialog(page, locator) {
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 30000 })
+    .then((dialog) => dialog.accept());
+  await locator.click();
+  await dialogPromise;
+}
+
+async function exerciseAccessKeyViaUi(page, appId, options = {}) {
+  const { env = DEFAULT_ENV } = options;
+  const encodedAppId = encodePathSegment(appId);
+  const encodedEnv = encodePathSegment(env);
+  await page.goto(`/app/access_key.html?#/appid=${encodedAppId}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.locator('.apollo-container[ng-controller="AccessKeyController"]').waitFor({
+    state: 'visible',
+    timeout: 60000,
+  });
+
+  const envSelect = page.locator('select[ng-model="addAccessKeySelectedEnv"]').first();
+  await envSelect.waitFor({ state: 'visible', timeout: 60000 });
+  await envSelect.selectOption(env);
+
+  const createResponse = waitForApiResponse(
+    page,
+    'POST',
+    `/openapi/v1/apps/${encodedAppId}/envs/${encodedEnv}/accesskeys`
+  );
+  await page.locator('form[ng-submit="create()"] button[type="submit"]').first().click();
+  const created = await createResponse;
+  const createdAccessKey = await created.json();
+  expect(createdAccessKey.id).toBeTruthy();
+  expect(createdAccessKey.secret).toBeTruthy();
+
+  const accessKeyRow = () => page.locator('tr[ng-repeat="accessKey in accessKeys[env]"]')
+    .filter({ hasText: createdAccessKey.secret })
+    .first();
+  await accessKeyRow().waitFor({ state: 'visible', timeout: 60000 });
+
+  const activationPath =
+    `/openapi/v1/apps/${encodedAppId}/envs/${encodedEnv}/accesskeys/${createdAccessKey.id}/activation`;
+  const enableResponse = waitForApiResponseByFragments(page, 'PUT', [
+    activationPath,
+    'mode=0',
+  ]);
+  await clickWithAcceptedDialog(
+    page,
+    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 0)"]').first()
+  );
+  await enableResponse;
+
+  const observeResponse = waitForApiResponseByFragments(page, 'PUT', [
+    activationPath,
+    'mode=1',
+  ]);
+  await clickWithAcceptedDialog(
+    page,
+    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 1)"]').first()
+  );
+  await observeResponse;
+
+  const disableResponse = waitForApiResponse(
+    page,
+    'PUT',
+    `/openapi/v1/apps/${encodedAppId}/envs/${encodedEnv}/accesskeys/${createdAccessKey.id}/deactivation`
+  );
+  await clickWithAcceptedDialog(
+    page,
+    accessKeyRow().locator('a[ng-click="disable(accessKey.id, env)"]').first()
+  );
+  await disableResponse;
+
+  const deleteResponse = waitForApiResponse(
+    page,
+    'DELETE',
+    `/openapi/v1/apps/${encodedAppId}/envs/${encodedEnv}/accesskeys/${createdAccessKey.id}`
+  );
+  await clickWithAcceptedDialog(
+    page,
+    accessKeyRow().locator('a[ng-click="remove(accessKey.id, env)"]').first()
+  );
+  await deleteResponse;
+  await expect(accessKeyRow()).toBeHidden({ timeout: 60000 });
 }
 
 async function openConfigPage(page, appId, options = {}) {
@@ -1510,6 +1598,7 @@ module.exports = {
   assignNamespaceRoleViaUi,
   assignNamespaceRoleViaUiBySearch,
   revokeNamespaceRoleViaUi,
+  exerciseAccessKeyViaUi,
   openConfigPage,
   switchNamespaceView,
   editNamespaceTextViaUi,

--- a/e2e/portal-e2e/tests/helpers/portal-helpers.js
+++ b/e2e/portal-e2e/tests/helpers/portal-helpers.js
@@ -591,12 +591,21 @@ async function revokeNamespaceRoleViaUi(page, appId, namespaceName, options = {}
   await expect(page.locator('.toast-success').first()).toBeVisible({ timeout: 30000 });
 }
 
-async function clickWithAcceptedDialog(page, locator) {
-  const dialogPromise = page.waitForEvent('dialog', { timeout: 1500 })
-    .then((dialog) => dialog.accept())
-    .catch(() => null);
-  await locator.click();
-  await dialogPromise;
+async function clickWithAcceptedDialog(page, locator, completionPromise) {
+  let dialogObserved = false;
+  const acceptDialog = (dialog) => {
+    dialogObserved = true;
+    return dialog.accept().catch(() => null);
+  };
+  page.once('dialog', acceptDialog);
+  try {
+    await locator.click();
+    await (completionPromise || page.waitForTimeout(1500));
+  } finally {
+    if (!dialogObserved) {
+      page.off('dialog', acceptDialog);
+    }
+  }
 }
 
 async function exerciseAccessKeyViaUi(page, appId, options = {}) {
@@ -639,7 +648,8 @@ async function exerciseAccessKeyViaUi(page, appId, options = {}) {
   ]);
   await clickWithAcceptedDialog(
     page,
-    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 0)"]').first()
+    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 0)"]').first(),
+    enableResponse
   );
   await enableResponse;
 
@@ -649,7 +659,8 @@ async function exerciseAccessKeyViaUi(page, appId, options = {}) {
   ]);
   await clickWithAcceptedDialog(
     page,
-    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 1)"]').first()
+    accessKeyRow().locator('a[ng-click="enable(accessKey.id, env, 1)"]').first(),
+    observeResponse
   );
   await observeResponse;
 
@@ -660,7 +671,8 @@ async function exerciseAccessKeyViaUi(page, appId, options = {}) {
   );
   await clickWithAcceptedDialog(
     page,
-    accessKeyRow().locator('a[ng-click="disable(accessKey.id, env)"]').first()
+    accessKeyRow().locator('a[ng-click="disable(accessKey.id, env)"]').first(),
+    disableResponse
   );
   await disableResponse;
 
@@ -671,7 +683,8 @@ async function exerciseAccessKeyViaUi(page, appId, options = {}) {
   );
   await clickWithAcceptedDialog(
     page,
-    accessKeyRow().locator('a[ng-click="remove(accessKey.id, env)"]').first()
+    accessKeyRow().locator('a[ng-click="remove(accessKey.id, env)"]').first(),
+    deleteResponse
   );
   await deleteResponse;
   await expect(accessKeyRow()).toBeHidden({ timeout: 60000 });

--- a/e2e/portal-e2e/tests/helpers/portal-helpers.js
+++ b/e2e/portal-e2e/tests/helpers/portal-helpers.js
@@ -592,8 +592,9 @@ async function revokeNamespaceRoleViaUi(page, appId, namespaceName, options = {}
 }
 
 async function clickWithAcceptedDialog(page, locator) {
-  const dialogPromise = page.waitForEvent('dialog', { timeout: 30000 })
-    .then((dialog) => dialog.accept());
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 1500 })
+    .then((dialog) => dialog.accept())
+    .catch(() => null);
   await locator.click();
   await dialogPromise;
 }

--- a/e2e/portal-e2e/tests/portal-priority.spec.js
+++ b/e2e/portal-e2e/tests/portal-priority.spec.js
@@ -24,6 +24,7 @@ const {
   clearNamespaceRoleViaPortalApi,
   assignNamespaceRoleViaUi,
   revokeNamespaceRoleViaUi,
+  exerciseAccessKeyViaUi,
   openConfigPage,
   createNamespaceItem,
   createBranchNamespaceItem,
@@ -119,6 +120,14 @@ test.describe.serial('@regression Apollo Portal high-priority user-guide scenari
       userId: USERNAME,
       env: modifyRoleEnv,
     });
+  });
+
+  test('access key page uses OpenAPI for lifecycle operations @regression', async ({ page }) => {
+    const appId = generateUniqueId('e2e-ak-');
+
+    await login(page);
+    await createAppViaUi(page, appId);
+    await exerciseAccessKeyViaUi(page, appId);
   });
 
   test('text mode edit and publish are readable from config service @regression', async ({ page, request }) => {


### PR DESCRIPTION
## What's the purpose of this PR

Migrate Apollo Portal permission, system-role, app-role, and AccessKey UI flows to the generated `/openapi/v1` contract while keeping the existing WebAPI controllers available for compatibility.

This PR also updates Portal to consume `apollo-openapi` `v0.3.3`, which adds the optional AccessKey activation/deactivation `operator` query parameter needed for consumer-token audit semantics.

## Which issue(s) this PR fixes:

N/A

## Brief changelog

- Add generated OpenAPI v1 controller implementations for AccessKey and permission management.
- Add server-side OpenAPI service adapters that reuse the existing Portal permission, system-role, user, and AccessKey services.
- Convert the Portal UI AccessKey, Permission, SystemRole, and permission-related AppService calls to `/openapi/v1` paths.
- Preserve UI response shapes for create-application and manage-app-master permission checks.
- Extend unit and e2e coverage for operator handling, permission checks, role mutation validation, and AccessKey OpenAPI request flow.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md). This will be added in a follow-up commit after the PR URL exists.

Additional validation:

- `mvn -B -pl apollo-portal -am -Dapollo.openapi.spec.url=/Users/jason/git/mine/apollo-openapi/apollo-openapi.yaml -Dtest=ServerPermissionOpenApiServiceTest,PermissionControllerParamBindLowLevelTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -pl apollo-assembly -am -DskipTests package`
- `PORTAL_USERNAME=apollo PORTAL_PASSWORD=admin ./e2e/portal-e2e/scripts/wait-for-ready.sh`
- `cd e2e/portal-e2e && npm ci && npx playwright install chromium && BASE_URL=http://127.0.0.1:8070 PLAYWRIGHT_WORKERS=2 npm run test:e2e:ci`
- `scripts/openapi/collect_portal_frontend_urls.py --language en`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access key and permission/role management migrated to standardized OpenAPI v1 endpoints; portal UI updated to call the new APIs and pass operator attribution.
  * New UI workflow to exercise access key lifecycle (create, enable/observe, disable, delete) via the portal.

* **Documentation**
  * Release notes updated to document the OpenAPI migration.

* **Tests**
  * New and updated unit, controller, parameter-binding, and end-to-end tests covering access keys and permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apolloconfig/apollo/pull/5617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->