### PR TITLE
fix: reduce notification v2 response serialization

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -302,7 +302,8 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
             }
           }
           logger.debug("Async notify {}", results.get(i));
-          results.get(i).setResult(configNotification, serializedNotificationResponse);
+          results.get(i).setResult(changedNamespace, configNotification,
+              serializedNotificationResponse);
         }
       });
       return;
@@ -311,7 +312,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     logger.debug("Notify {} clients for key {}", results.size(), content);
 
     for (DeferredResultWrapper result : results) {
-      result.setResult(configNotification, serializedNotificationResponse);
+      result.setResult(changedNamespace, configNotification, serializedNotificationResponse);
     }
     logger.debug("Notification completed");
   }

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -98,7 +98,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
   }
 
   @GetMapping
-  public DeferredResult<ResponseEntity<?>> pollNotification(
+  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> pollNotification(
       @RequestParam(value = "appId") String appId, @RequestParam(value = "cluster") String cluster,
       @RequestParam(value = "notifications") String notificationsAsString,
       @RequestParam(value = "dataCenter", required = false) String dataCenter,

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -99,7 +99,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
   }
 
   @GetMapping
-  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> pollNotification(
+  public DeferredResult<ResponseEntity<?>> pollNotification(
       @RequestParam(value = "appId") String appId, @RequestParam(value = "cluster") String cluster,
       @RequestParam(value = "notifications") String notificationsAsString,
       @RequestParam(value = "dataCenter", required = false) String dataCenter,

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -51,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -282,9 +283,9 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     ApolloConfigNotification configNotification =
         new ApolloConfigNotification(changedNamespace, message.getId());
     configNotification.addMessage(content, message.getId());
-    ResponseEntity<String> serializedNotificationResponse =
-        ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-            .body(gson.toJson(Lists.newArrayList(configNotification)));
+    ResponseEntity<String> serializedNotificationResponse = ResponseEntity.ok()
+        .contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+        .body(gson.toJson(Lists.newArrayList(configNotification)));
 
     // do async notification if too many clients
     if (results.size() > bizConfig.releaseMessageNotificationBatch()) {

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -41,6 +41,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -97,7 +98,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
   }
 
   @GetMapping
-  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> pollNotification(
+  public DeferredResult<ResponseEntity<?>> pollNotification(
       @RequestParam(value = "appId") String appId, @RequestParam(value = "cluster") String cluster,
       @RequestParam(value = "notifications") String notificationsAsString,
       @RequestParam(value = "dataCenter", required = false) String dataCenter,
@@ -281,6 +282,9 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     ApolloConfigNotification configNotification =
         new ApolloConfigNotification(changedNamespace, message.getId());
     configNotification.addMessage(content, message.getId());
+    ResponseEntity<String> serializedNotificationResponse = ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(gson.toJson(Lists.newArrayList(configNotification)));
 
     // do async notification if too many clients
     if (results.size() > bizConfig.releaseMessageNotificationBatch()) {
@@ -297,7 +301,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
             }
           }
           logger.debug("Async notify {}", results.get(i));
-          results.get(i).setResult(configNotification);
+          results.get(i).setResult(configNotification, serializedNotificationResponse);
         }
       });
       return;
@@ -306,7 +310,7 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     logger.debug("Notify {} clients for key {}", results.size(), content);
 
     for (DeferredResultWrapper result : results) {
-      result.setResult(configNotification);
+      result.setResult(configNotification, serializedNotificationResponse);
     }
     logger.debug("Notification completed");
   }

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -282,9 +282,9 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     ApolloConfigNotification configNotification =
         new ApolloConfigNotification(changedNamespace, message.getId());
     configNotification.addMessage(content, message.getId());
-    ResponseEntity<String> serializedNotificationResponse = ResponseEntity.ok()
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(gson.toJson(Lists.newArrayList(configNotification)));
+    ResponseEntity<String> serializedNotificationResponse =
+        ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+            .body(gson.toJson(Lists.newArrayList(configNotification)));
 
     // do async notification if too many clients
     if (results.size() > bizConfig.releaseMessageNotificationBatch()) {

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -74,6 +74,9 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
       result.setResult((ResponseEntity) serializedNotificationResponse);
       return;
     }
+    // The ApolloConfigNotification is shared across all deferred results for the same release
+    // message. Copy it before restoring the client-side namespace name to avoid mutating
+    // the shared notification and affecting other clients.
     setResult(copyApolloConfigNotification(notification));
   }
 

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -37,7 +37,7 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
       new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
 
   private Map<String, String> normalizedNamespaceNameToOriginalNamespaceName;
-  private DeferredResult<ResponseEntity<?>> result;
+  private DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> result;
 
 
   public DeferredResultWrapper(long timeoutInMilli) {
@@ -67,10 +67,11 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
     setResult(Lists.newArrayList(notification));
   }
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void setResult(ApolloConfigNotification notification,
       ResponseEntity<String> serializedNotificationResponse) {
     if (!shouldRestoreOriginalNamespaceName(notification.getNamespaceName())) {
-      result.setResult(serializedNotificationResponse);
+      result.setResult((ResponseEntity) serializedNotificationResponse);
       return;
     }
     setResult(copyApolloConfigNotification(notification));
@@ -92,7 +93,7 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
     result.setResult(new ResponseEntity<>(notifications, HttpStatus.OK));
   }
 
-  public DeferredResult<ResponseEntity<?>> getResult() {
+  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> getResult() {
     return result;
   }
 

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -68,16 +68,13 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public void setResult(ApolloConfigNotification notification,
+  public void setResult(String namespaceName, ApolloConfigNotification notification,
       ResponseEntity<String> serializedNotificationResponse) {
-    if (!shouldRestoreOriginalNamespaceName(notification.getNamespaceName())) {
+    if (!shouldRestoreOriginalNamespaceName(namespaceName)) {
       result.setResult((ResponseEntity) serializedNotificationResponse);
       return;
     }
-    // The ApolloConfigNotification is shared across all deferred results for the same release
-    // message. Copy it before restoring the client-side namespace name to avoid mutating
-    // the shared notification and affecting other clients.
-    setResult(copyApolloConfigNotification(notification));
+    setResult(notification);
   }
 
   /**
@@ -103,14 +100,6 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
   private boolean shouldRestoreOriginalNamespaceName(String namespaceName) {
     return normalizedNamespaceNameToOriginalNamespaceName != null
         && normalizedNamespaceNameToOriginalNamespaceName.containsKey(namespaceName);
-  }
-
-  private ApolloConfigNotification copyApolloConfigNotification(
-      ApolloConfigNotification notification) {
-    ApolloConfigNotification copiedNotification = new ApolloConfigNotification(
-        notification.getNamespaceName(), notification.getNotificationId());
-    notification.getMessages().getDetails().forEach(copiedNotification::addMessage);
-    return copiedNotification;
   }
 
   @Override

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -37,7 +37,7 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
       new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
 
   private Map<String, String> normalizedNamespaceNameToOriginalNamespaceName;
-  private DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> result;
+  private DeferredResult<ResponseEntity<?>> result;
 
 
   public DeferredResultWrapper(long timeoutInMilli) {
@@ -67,11 +67,10 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
     setResult(Lists.newArrayList(notification));
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public void setResult(String namespaceName, ApolloConfigNotification notification,
       ResponseEntity<String> serializedNotificationResponse) {
     if (!shouldRestoreOriginalNamespaceName(namespaceName)) {
-      result.setResult((ResponseEntity) serializedNotificationResponse);
+      result.setResult(serializedNotificationResponse);
       return;
     }
     setResult(notification);
@@ -83,23 +82,45 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
    */
   public void setResult(List<ApolloConfigNotification> notifications) {
     if (normalizedNamespaceNameToOriginalNamespaceName != null) {
-      notifications.stream()
-          .filter(notification -> normalizedNamespaceNameToOriginalNamespaceName
-              .containsKey(notification.getNamespaceName()))
-          .forEach(notification -> notification.setNamespaceName(
-              normalizedNamespaceNameToOriginalNamespaceName.get(notification.getNamespaceName())));
+      // Most responses can reuse the shared notification object. Copy only when
+      // this wrapper must restore a client-supplied namespace name, because that
+      // restoration mutates the DTO and must not affect other long-poll clients.
+      List<ApolloConfigNotification> notificationsToReturn = notifications;
+      for (int i = 0; i < notifications.size(); i++) {
+        ApolloConfigNotification notification = notifications.get(i);
+        if (!normalizedNamespaceNameToOriginalNamespaceName
+            .containsKey(notification.getNamespaceName())) {
+          continue;
+        }
+        if (notificationsToReturn == notifications) {
+          notificationsToReturn = Lists.newArrayList(notifications);
+        }
+        ApolloConfigNotification copiedNotification = copyApolloConfigNotification(notification);
+        copiedNotification.setNamespaceName(
+            normalizedNamespaceNameToOriginalNamespaceName.get(notification.getNamespaceName()));
+        notificationsToReturn.set(i, copiedNotification);
+      }
+      notifications = notificationsToReturn;
     }
 
     result.setResult(new ResponseEntity<>(notifications, HttpStatus.OK));
   }
 
-  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> getResult() {
+  public DeferredResult<ResponseEntity<?>> getResult() {
     return result;
   }
 
   private boolean shouldRestoreOriginalNamespaceName(String namespaceName) {
     return normalizedNamespaceNameToOriginalNamespaceName != null
         && normalizedNamespaceNameToOriginalNamespaceName.containsKey(namespaceName);
+  }
+
+  private ApolloConfigNotification copyApolloConfigNotification(
+      ApolloConfigNotification notification) {
+    ApolloConfigNotification copiedNotification = new ApolloConfigNotification(
+        notification.getNamespaceName(), notification.getNotificationId());
+    notification.getMessages().getDetails().forEach(copiedNotification::addMessage);
+    return copiedNotification;
   }
 
   @Override

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -37,7 +37,7 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
       new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
 
   private Map<String, String> normalizedNamespaceNameToOriginalNamespaceName;
-  private DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> result;
+  private DeferredResult<ResponseEntity<?>> result;
 
 
   public DeferredResultWrapper(long timeoutInMilli) {
@@ -67,8 +67,18 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
     setResult(Lists.newArrayList(notification));
   }
 
+  public void setResult(ApolloConfigNotification notification,
+      ResponseEntity<String> serializedNotificationResponse) {
+    if (!shouldRestoreOriginalNamespaceName(notification.getNamespaceName())) {
+      result.setResult(serializedNotificationResponse);
+      return;
+    }
+    setResult(copyApolloConfigNotification(notification));
+  }
+
   /**
-   * The namespace name is used as a key in client side, so we have to return the original one instead of the correct one
+   * The namespace name is used as a key in client side, so we have to return the original
+   * one instead of the correct one.
    */
   public void setResult(List<ApolloConfigNotification> notifications) {
     if (normalizedNamespaceNameToOriginalNamespaceName != null) {
@@ -82,8 +92,21 @@ public class DeferredResultWrapper implements Comparable<DeferredResultWrapper> 
     result.setResult(new ResponseEntity<>(notifications, HttpStatus.OK));
   }
 
-  public DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> getResult() {
+  public DeferredResult<ResponseEntity<?>> getResult() {
     return result;
+  }
+
+  private boolean shouldRestoreOriginalNamespaceName(String namespaceName) {
+    return normalizedNamespaceNameToOriginalNamespaceName != null
+        && normalizedNamespaceNameToOriginalNamespaceName.containsKey(namespaceName);
+  }
+
+  private ApolloConfigNotification copyApolloConfigNotification(
+      ApolloConfigNotification notification) {
+    ApolloConfigNotification copiedNotification = new ApolloConfigNotification(
+        notification.getNamespaceName(), notification.getNotificationId());
+    notification.getMessages().getDetails().forEach(copiedNotification::addMessage);
+    return copiedNotification;
   }
 
   @Override

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -46,8 +46,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.async.DeferredResult;
 
-import java.util.Collection;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -372,7 +373,8 @@ public class NotificationControllerV2Test {
     ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
 
     assertTrue(response.getBody() instanceof String);
-    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertEquals(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8),
+        response.getHeaders().getContentType());
 
     List<ApolloConfigNotification> notifications = getNotifications(response);
 

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -245,8 +245,7 @@ public class NotificationControllerV2Test {
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
-    ResponseEntity<?> result =
-        (ResponseEntity<?>) deferredResult.getResult();
+    ResponseEntity<?> result = (ResponseEntity<?>) deferredResult.getResult();
 
     List<ApolloConfigNotification> notifications = getNotifications(result);
 
@@ -291,8 +290,7 @@ public class NotificationControllerV2Test {
 
     controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
 
-    ResponseEntity<?> response =
-        (ResponseEntity<?>) deferredResult.getResult();
+    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
 
     List<ApolloConfigNotification> notifications = getNotifications(response);
 
@@ -418,8 +416,7 @@ public class NotificationControllerV2Test {
 
     assertTrue(deferredResult.hasResult());
 
-    ResponseEntity<?> response =
-        (ResponseEntity<?>) deferredResult.getResult();
+    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
 
     List<ApolloConfigNotification> notifications = getNotifications(response);
 

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -129,9 +129,8 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     assertEquals(watchKeysMap.size(), deferredResults.size());
 
@@ -155,9 +154,8 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     assertEquals(watchKeysMap.size(), deferredResults.size());
 
@@ -196,9 +194,8 @@ public class NotificationControllerV2Test {
         Sets.newHashSet(defaultNamespace, somePublicNamespace, somePublicNamespaceAsFile),
         someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     assertEquals(watchKeysMap.size(), deferredResults.size());
 
@@ -242,9 +239,8 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     ResponseEntity<?> result = (ResponseEntity<?>) deferredResult.getResult();
 
@@ -279,9 +275,8 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     assertEquals(watchKeysMap.size(), deferredResults.size());
 
@@ -325,12 +320,10 @@ public class NotificationControllerV2Test {
     when(bizConfig.releaseMessageNotificationBatch()).thenReturn(someBatch);
     when(bizConfig.releaseMessageNotificationBatchIntervalInMilli()).thenReturn(someBatchInterval);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> anotherDeferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
+    DeferredResult<ResponseEntity<?>> anotherDeferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     long someId = 1;
     ReleaseMessage someReleaseMessage = new ReleaseMessage(someWatchKey);
@@ -360,9 +353,8 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
-            someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster, notificationAsString, someDataCenter, someClientIp);
 
     long someId = 1;
     ReleaseMessage someReleaseMessage = new ReleaseMessage(someWatchKey);
@@ -406,9 +398,8 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(appIdWithIncorrectCase, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
-            someDataCenter, someClientIp);
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(
+        appIdWithIncorrectCase, someCluster, notificationAsString, someDataCenter, someClientIp);
 
     long someId = 1;
     ReleaseMessage someReleaseMessage = new ReleaseMessage(someMessage);
@@ -432,6 +423,53 @@ public class NotificationControllerV2Test {
     assertEquals(1, notificationMessages.getDetails().size());
     assertEquals(someId, notificationMessages.get(someMessage).longValue());
 
+  }
+
+  @Test
+  public void testPollNotificationWithMultipleIncorrectCaseClientsRestoresEachOriginalNamespace()
+      throws Exception {
+    String namespaceWithIncorrectCase = defaultNamespace.toUpperCase();
+    String anotherNamespaceWithIncorrectCase = "Application";
+    String someMessage = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR).join(someAppId,
+        someCluster, defaultNamespace);
+    String someWatchKey = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR).join(someAppId,
+        someCluster, defaultNamespace);
+
+    Multimap<String, String> watchKeysMap =
+        assembleMultiMap(defaultNamespace, Lists.newArrayList(someWatchKey));
+
+    when(namespaceUtil.filterNamespaceName(namespaceWithIncorrectCase))
+        .thenReturn(namespaceWithIncorrectCase);
+    when(namespaceUtil.filterNamespaceName(anotherNamespaceWithIncorrectCase))
+        .thenReturn(anotherNamespaceWithIncorrectCase);
+    when(namespaceUtil.normalizeNamespace(someAppId, namespaceWithIncorrectCase))
+        .thenReturn(defaultNamespace);
+    when(namespaceUtil.normalizeNamespace(someAppId, anotherNamespaceWithIncorrectCase))
+        .thenReturn(defaultNamespace);
+    when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
+        Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
+
+    DeferredResult<ResponseEntity<?>> deferredResult = controller.pollNotification(someAppId,
+        someCluster,
+        transformApolloConfigNotificationsToString(namespaceWithIncorrectCase, someNotificationId),
+        someDataCenter, someClientIp);
+    DeferredResult<ResponseEntity<?>> anotherDeferredResult = controller.pollNotification(someAppId,
+        someCluster, transformApolloConfigNotificationsToString(anotherNamespaceWithIncorrectCase,
+            someNotificationId),
+        someDataCenter, someClientIp);
+
+    long someId = 1;
+    ReleaseMessage someReleaseMessage = new ReleaseMessage(someMessage);
+    someReleaseMessage.setId(someId);
+
+    controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
+
+    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
+    ResponseEntity<?> anotherResponse = (ResponseEntity<?>) anotherDeferredResult.getResult();
+
+    assertEquals(namespaceWithIncorrectCase, getNotifications(response).get(0).getNamespaceName());
+    assertEquals(anotherNamespaceWithIncorrectCase,
+        getNotifications(anotherResponse).get(0).getNamespaceName());
   }
 
   private String transformApolloConfigNotificationsToString(String namespace, long notificationId) {

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -34,17 +34,20 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import java.util.Collection;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -125,7 +128,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -151,7 +154,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -192,7 +195,7 @@ public class NotificationControllerV2Test {
         Sets.newHashSet(defaultNamespace, somePublicNamespace, somePublicNamespaceAsFile),
         someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -238,19 +241,21 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
-    ResponseEntity<List<ApolloConfigNotification>> result =
-        (ResponseEntity<List<ApolloConfigNotification>>) deferredResult.getResult();
+    ResponseEntity<?> result =
+        (ResponseEntity<?>) deferredResult.getResult();
+
+    List<ApolloConfigNotification> notifications = getNotifications(result);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertEquals(1, result.getBody().size());
-    assertEquals(somePublicNamespace, result.getBody().get(0).getNamespaceName());
-    assertEquals(notificationId, result.getBody().get(0).getNotificationId());
+    assertEquals(1, notifications.size());
+    assertEquals(somePublicNamespace, notifications.get(0).getNamespaceName());
+    assertEquals(notificationId, notifications.get(0).getNotificationId());
 
-    ApolloNotificationMessages notificationMessages = result.getBody().get(0).getMessages();
+    ApolloNotificationMessages notificationMessages = notifications.get(0).getMessages();
     assertEquals(2, notificationMessages.getDetails().size());
     assertEquals(notificationId, notificationMessages.get(anotherWatchKey).longValue());
     assertEquals(yetAnotherNotificationId,
@@ -274,7 +279,7 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -286,16 +291,18 @@ public class NotificationControllerV2Test {
 
     controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
 
-    ResponseEntity<List<ApolloConfigNotification>> response =
-        (ResponseEntity<List<ApolloConfigNotification>>) deferredResult.getResult();
+    ResponseEntity<?> response =
+        (ResponseEntity<?>) deferredResult.getResult();
 
-    assertEquals(1, response.getBody().size());
-    ApolloConfigNotification notification = response.getBody().get(0);
+    List<ApolloConfigNotification> notifications = getNotifications(response);
+
+    assertEquals(1, notifications.size());
+    ApolloConfigNotification notification = notifications.get(0);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(somePublicNamespace, notification.getNamespaceName());
     assertEquals(someId, notification.getNotificationId());
 
-    ApolloNotificationMessages notificationMessages = response.getBody().get(0).getMessages();
+    ApolloNotificationMessages notificationMessages = notification.getMessages();
     assertEquals(1, notificationMessages.getDetails().size());
     assertEquals(someId, notificationMessages.get(anotherWatchKey).longValue());
   }
@@ -319,10 +326,10 @@ public class NotificationControllerV2Test {
     when(bizConfig.releaseMessageNotificationBatch()).thenReturn(someBatch);
     when(bizConfig.releaseMessageNotificationBatchIntervalInMilli()).thenReturn(someBatchInterval);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> anotherDeferredResult =
+    DeferredResult<ResponseEntity<?>> anotherDeferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -338,6 +345,43 @@ public class NotificationControllerV2Test {
     // now both of them should have result
     await().atMost(someBatchInterval * 500, TimeUnit.MILLISECONDS).untilAsserted(
         () -> assertTrue(deferredResult.hasResult() && anotherDeferredResult.hasResult()));
+  }
+
+  @Test
+  public void testPollNotificationWithHandleMessageUsesSerializedResponse() throws Exception {
+    String someWatchKey = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR).join(someAppId,
+        someCluster, defaultNamespace);
+
+    Multimap<String, String> watchKeysMap =
+        assembleMultiMap(defaultNamespace, Lists.newArrayList(someWatchKey));
+
+    String notificationAsString =
+        transformApolloConfigNotificationsToString(defaultNamespace, someNotificationId);
+
+    when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
+        Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
+
+    DeferredResult<ResponseEntity<?>> deferredResult =
+        controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
+            someClientIp);
+
+    long someId = 1;
+    ReleaseMessage someReleaseMessage = new ReleaseMessage(someWatchKey);
+    someReleaseMessage.setId(someId);
+
+    controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
+
+    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
+
+    assertTrue(response.getBody() instanceof String);
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+
+    List<ApolloConfigNotification> notifications = getNotifications(response);
+
+    assertEquals(1, notifications.size());
+    ApolloConfigNotification notification = notifications.get(0);
+    assertEquals(defaultNamespace, notification.getNamespaceName());
+    assertEquals(someId, notification.getNotificationId());
   }
 
   @Test
@@ -362,7 +406,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(appIdWithIncorrectCase, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+    DeferredResult<ResponseEntity<?>> deferredResult =
         controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
             someDataCenter, someClientIp);
 
@@ -374,11 +418,13 @@ public class NotificationControllerV2Test {
 
     assertTrue(deferredResult.hasResult());
 
-    ResponseEntity<List<ApolloConfigNotification>> response =
-        (ResponseEntity<List<ApolloConfigNotification>>) deferredResult.getResult();
+    ResponseEntity<?> response =
+        (ResponseEntity<?>) deferredResult.getResult();
 
-    assertEquals(1, response.getBody().size());
-    ApolloConfigNotification notification = response.getBody().get(0);
+    List<ApolloConfigNotification> notifications = getNotifications(response);
+
+    assertEquals(1, notifications.size());
+    ApolloConfigNotification notification = notifications.get(0);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(namespaceWithIncorrectCase, notification.getNamespaceName());
     assertEquals(someId, notification.getNotificationId());
@@ -422,6 +468,15 @@ public class NotificationControllerV2Test {
     Multimap<String, String> multimap = HashMultimap.create();
     multimap.putAll(key, values);
     return multimap;
+  }
+
+  private List<ApolloConfigNotification> getNotifications(ResponseEntity<?> response) {
+    Object body = response.getBody();
+    if (body instanceof String) {
+      Type notificationsType = new TypeToken<List<ApolloConfigNotification>>() {}.getType();
+      return gson.fromJson((String) body, notificationsType);
+    }
+    return (List<ApolloConfigNotification>) body;
   }
 
   private void assertWatchKeys(Multimap<String, String> watchKeysMap,

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -128,7 +128,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -154,7 +154,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -195,7 +195,7 @@ public class NotificationControllerV2Test {
         Sets.newHashSet(defaultNamespace, somePublicNamespace, somePublicNamespaceAsFile),
         someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -241,7 +241,7 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -279,7 +279,7 @@ public class NotificationControllerV2Test {
     String notificationAsString = transformApolloConfigNotificationsToString(defaultNamespace,
         someNotificationId, somePublicNamespace, someNotificationId);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -326,10 +326,10 @@ public class NotificationControllerV2Test {
     when(bizConfig.releaseMessageNotificationBatch()).thenReturn(someBatch);
     when(bizConfig.releaseMessageNotificationBatchIntervalInMilli()).thenReturn(someBatchInterval);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
-    DeferredResult<ResponseEntity<?>> anotherDeferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> anotherDeferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -361,7 +361,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(someAppId, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(someAppId, someCluster, notificationAsString, someDataCenter,
             someClientIp);
 
@@ -406,7 +406,7 @@ public class NotificationControllerV2Test {
     when(watchKeysUtil.assembleAllWatchKeys(appIdWithIncorrectCase, someCluster,
         Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
 
-    DeferredResult<ResponseEntity<?>> deferredResult =
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
         controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
             someDataCenter, someClientIp);
 

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -434,53 +434,6 @@ public class NotificationControllerV2Test {
 
   }
 
-  @Test
-  public void testPollNotificationWithIncorrectCaseDoesNotMutateSharedNotification()
-      throws Exception {
-    String appIdWithIncorrectCase = someAppId.toUpperCase();
-    String namespaceWithIncorrectCase = defaultNamespace.toUpperCase();
-    String someMessage = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR).join(someAppId,
-        someCluster, defaultNamespace);
-    String someWatchKey = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR)
-        .join(appIdWithIncorrectCase, someCluster, defaultNamespace);
-
-    Multimap<String, String> watchKeysMap =
-        assembleMultiMap(defaultNamespace, Lists.newArrayList(someWatchKey));
-
-    String notificationAsString =
-        transformApolloConfigNotificationsToString(namespaceWithIncorrectCase, someNotificationId);
-
-    when(namespaceUtil.filterNamespaceName(namespaceWithIncorrectCase))
-        .thenReturn(namespaceWithIncorrectCase);
-    when(namespaceUtil.normalizeNamespace(appIdWithIncorrectCase, namespaceWithIncorrectCase))
-        .thenReturn(defaultNamespace);
-    when(watchKeysUtil.assembleAllWatchKeys(appIdWithIncorrectCase, someCluster,
-        Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
-
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
-        controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
-            someDataCenter, someClientIp);
-    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> anotherDeferredResult =
-        controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
-            someDataCenter, someClientIp);
-
-    long someId = 1;
-    ReleaseMessage someReleaseMessage = new ReleaseMessage(someMessage);
-    someReleaseMessage.setId(someId);
-
-    controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
-
-    assertTrue(deferredResult.hasResult());
-    assertTrue(anotherDeferredResult.hasResult());
-
-    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
-    ResponseEntity<?> anotherResponse = (ResponseEntity<?>) anotherDeferredResult.getResult();
-
-    assertEquals(namespaceWithIncorrectCase, getNotifications(response).get(0).getNamespaceName());
-    assertEquals(namespaceWithIncorrectCase,
-        getNotifications(anotherResponse).get(0).getNamespaceName());
-  }
-
   private String transformApolloConfigNotificationsToString(String namespace, long notificationId) {
     List<ApolloConfigNotification> notifications =
         Lists.newArrayList(assembleApolloConfigNotification(namespace, notificationId));

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -434,6 +434,53 @@ public class NotificationControllerV2Test {
 
   }
 
+  @Test
+  public void testPollNotificationWithIncorrectCaseDoesNotMutateSharedNotification()
+      throws Exception {
+    String appIdWithIncorrectCase = someAppId.toUpperCase();
+    String namespaceWithIncorrectCase = defaultNamespace.toUpperCase();
+    String someMessage = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR).join(someAppId,
+        someCluster, defaultNamespace);
+    String someWatchKey = Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR)
+        .join(appIdWithIncorrectCase, someCluster, defaultNamespace);
+
+    Multimap<String, String> watchKeysMap =
+        assembleMultiMap(defaultNamespace, Lists.newArrayList(someWatchKey));
+
+    String notificationAsString =
+        transformApolloConfigNotificationsToString(namespaceWithIncorrectCase, someNotificationId);
+
+    when(namespaceUtil.filterNamespaceName(namespaceWithIncorrectCase))
+        .thenReturn(namespaceWithIncorrectCase);
+    when(namespaceUtil.normalizeNamespace(appIdWithIncorrectCase, namespaceWithIncorrectCase))
+        .thenReturn(defaultNamespace);
+    when(watchKeysUtil.assembleAllWatchKeys(appIdWithIncorrectCase, someCluster,
+        Sets.newHashSet(defaultNamespace), someDataCenter)).thenReturn(watchKeysMap);
+
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> deferredResult =
+        controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
+            someDataCenter, someClientIp);
+    DeferredResult<ResponseEntity<List<ApolloConfigNotification>>> anotherDeferredResult =
+        controller.pollNotification(appIdWithIncorrectCase, someCluster, notificationAsString,
+            someDataCenter, someClientIp);
+
+    long someId = 1;
+    ReleaseMessage someReleaseMessage = new ReleaseMessage(someMessage);
+    someReleaseMessage.setId(someId);
+
+    controller.handleMessage(someReleaseMessage, Topics.APOLLO_RELEASE_TOPIC);
+
+    assertTrue(deferredResult.hasResult());
+    assertTrue(anotherDeferredResult.hasResult());
+
+    ResponseEntity<?> response = (ResponseEntity<?>) deferredResult.getResult();
+    ResponseEntity<?> anotherResponse = (ResponseEntity<?>) anotherDeferredResult.getResult();
+
+    assertEquals(namespaceWithIncorrectCase, getNotifications(response).get(0).getNamespaceName());
+    assertEquals(namespaceWithIncorrectCase,
+        getNotifications(anotherResponse).get(0).getNamespaceName());
+  }
+
   private String transformApolloConfigNotificationsToString(String namespace, long notificationId) {
     List<ApolloConfigNotification> notifications =
         Lists.newArrayList(assembleApolloConfigNotification(namespace, notificationId));

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapperTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapperTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.configservice.wrapper;
+
+import static org.junit.Assert.assertSame;
+
+import com.ctrip.framework.apollo.core.dto.ApolloConfigNotification;
+import java.util.List;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+
+public class DeferredResultWrapperTest {
+
+  @Test
+  public void testSetResultReusesNotificationWhenNamespaceDoesNotNeedRestoration() {
+    DeferredResultWrapper wrapper = new DeferredResultWrapper(1000);
+    ApolloConfigNotification notification = new ApolloConfigNotification("application", 1);
+    notification.addMessage("someKey", 1);
+
+    wrapper.setResult(notification);
+
+    ResponseEntity<?> response = (ResponseEntity<?>) wrapper.getResult().getResult();
+    List<ApolloConfigNotification> notifications =
+        (List<ApolloConfigNotification>) response.getBody();
+    assertSame(notification, notifications.get(0));
+  }
+}


### PR DESCRIPTION
### Motivation

- Reduce CPU and memory churn when notifying many long-poll clients by avoiding repeated per-client JSON serialization for the same release message.
- Preserve existing behavior for clients that require the original (client-supplied) namespace name to be returned.

### Description

- Pre-serialize the long-poll notification payload once per `ReleaseMessage` in `NotificationControllerV2#handleMessage` and reuse the serialized JSON `ResponseEntity<String>` for clients that do not need namespace-name restoration.
- Add an overloaded `DeferredResultWrapper#setResult(ApolloConfigNotification, ResponseEntity<String>)` that either returns the pre-serialized response or falls back to a copied DTO (with namespace restoration) when needed.
- Broaden `pollNotification` / `DeferredResultWrapper.getResult()` signatures to return `ResponseEntity<?>` so the controller can return either the DTO list or a pre-serialized JSON string transparently.
- Update `NotificationControllerV2Test` to accept both serialized (String) and DTO responses, add helper `getNotifications` to parse either form, and add a test that verifies the optimized path returns a JSON string with `Content-Type: application/json`.

### Testing

- Ran the controller unit tests with `mvn -q -pl apollo-configservice -am -Dtest=NotificationControllerV2Test -Dsurefire.failIfNoSpecifiedTests=false test` and the `NotificationControllerV2Test` suite passed.
- Verified repository checks by running `git diff --check` locally (no code-check errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197250bbdc8330b48405fe6cd569fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Polling can now return a pre-serialized JSON response for single notifications (Content-Type: application/json; charset=UTF-8), improving response consistency and reducing runtime serialization; existing namespace-restoration behavior is preserved when needed.
* **Bug Fixes**
  * Prevented cross-request mutation so each response preserves its own namespace casing and contents.
* **Tests**
  * Tests updated to handle both serialized-JSON and typed-list responses; added coverage for serialized delivery and isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apolloconfig/apollo/pull/5620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->