### PR TITLE
Fix NPE in ConfigChangeContentBuilder.updateItem when the old value is null

### DIFF
--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/utils/ConfigChangeContentBuilder.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/utils/ConfigChangeContentBuilder.java
@@ -23,6 +23,7 @@ import com.google.gson.GsonBuilder;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.beans.BeanUtils;
 
 public class ConfigChangeContentBuilder {
@@ -41,7 +42,7 @@ public class ConfigChangeContentBuilder {
   }
 
   public ConfigChangeContentBuilder updateItem(Item oldItem, Item newItem) {
-    if (!oldItem.getValue().equals(newItem.getValue())) {
+    if (!Objects.equals(oldItem.getValue(), newItem.getValue())) {
       ItemPair itemPair = new ItemPair(cloneItem(oldItem), cloneItem(newItem));
       updateItems.add(itemPair);
     }

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/utils/ConfigChangeContentBuilderTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/utils/ConfigChangeContentBuilderTest.java
@@ -16,9 +16,10 @@
  */
 package com.ctrip.framework.apollo.biz.utils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +71,43 @@ public class ConfigChangeContentBuilderTest {
     configChangeContentBuilder.getUpdateItems().clear();
     configChangeContentBuilder.getDeleteItems().clear();
     assertFalse(configChangeContentBuilder.hasContent());
+  }
+
+  @Test
+  public void testUpdateItemWithNullOldValue() {
+    ConfigChangeContentBuilder builder = new ConfigChangeContentBuilder();
+
+    Item oldItem = new Item();
+    oldItem.setKey("someKey");
+    oldItem.setValue(null);
+
+    Item newItem = new Item();
+    newItem.setKey("someKey");
+    newItem.setValue("newValue");
+
+    // Should NOT throw NPE; should detect change from null to non-null
+    builder.updateItem(oldItem, newItem);
+
+    assertTrue("should detect change from null to non-null", builder.hasContent());
+    assertEquals("should have one update item", 1, builder.getUpdateItems().size());
+  }
+
+  @Test
+  public void testUpdateItemWithBothNullValues() {
+    ConfigChangeContentBuilder builder = new ConfigChangeContentBuilder();
+
+    Item oldItem = new Item();
+    oldItem.setKey("someKey");
+    oldItem.setValue(null);
+
+    Item newItem = new Item();
+    newItem.setKey("someKey");
+    newItem.setValue(null);
+
+    // Both values are null so no change should be recorded
+    builder.updateItem(oldItem, newItem);
+
+    assertFalse("no change when both values are null", builder.hasContent());
   }
 
   @Test


### PR DESCRIPTION
## Problem

`ConfigChangeContentBuilder.updateItem` compares the old and new item values with:

```java
if (!oldItem.getValue().equals(newItem.getValue())) {
```

When the old items value is `null` — e.g. a config item that previously had no value, or a null-valued item — this throws `NullPointerException`.

## Fix

Compare the values null-safely with `Objects.equals`.

## Test

Adds `testUpdateItemWithNullOldValue` and `testUpdateItemWithBothNullValues` to `ConfigChangeContentBuilderTest`. The null-old-value case throws `NullPointerException` before the change and passes after; the both-null case correctly records no change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection to handle `null` values safely when comparing item updates, preventing unexpected errors and more accurately recording changes.

* **Tests**
  * Added coverage for update scenarios with `null` and non-`null` values.
  * Verified that no change is recorded when both values are `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->