### PR TITLE
Fix user token rate limit responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Apollo 3.0.0
 * [Change: complete Apollo Portal UI management OpenAPI migration](https://github.com/apolloconfig/apollo/pull/5618)
 * [Feature: allow explicitly authorized consumer tokens to manage portal users](https://github.com/apolloconfig/apollo/pull/5623)
 * [Feature: add user access tokens for AI agents and automation](https://github.com/apolloconfig/apollo/pull/5632)
+* [Fix: return 429 instead of redirecting to sign-in for OpenAPI user token rate limits](https://github.com/apolloconfig/apollo/pull/5637)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
@@ -21,11 +21,13 @@ import com.ctrip.framework.apollo.portal.entity.po.UserToken;
 import com.ctrip.framework.apollo.portal.service.UserTokenService;
 import com.ctrip.framework.apollo.portal.util.UserTokenAuditUtil;
 import com.ctrip.framework.apollo.portal.util.UserTokenAuthUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.RateLimiter;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import jakarta.servlet.FilterChain;
@@ -35,6 +37,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -51,6 +54,7 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
   private static final String USER_ROLE = "ROLE_user";
   private static final int RATE_LIMITER_CACHE_MAX_SIZE = 20000;
   private static final int TOO_MANY_REQUESTS = 429;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final Cache<String, RateLimiter> LIMITER = CacheBuilder.newBuilder()
       .expireAfterAccess(1, TimeUnit.HOURS).maximumSize(RATE_LIMITER_CACHE_MAX_SIZE).build();
@@ -129,8 +133,8 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
   private void writeOpenApiError(HttpServletResponse response, int status, String message)
       throws IOException {
     response.setStatus(status);
-    response.setContentType("application/json;charset=UTF-8");
-    response.getWriter().write("{\"message\":\"" + message + "\"}");
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    OBJECT_MAPPER.writeValue(response.getWriter(), Map.of("message", message));
   }
 
   private RateLimiter getOrCreateRateLimiter(String key, Integer limitCount) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
@@ -96,8 +96,7 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
       try {
         RateLimiter rateLimiter = getOrCreateRateLimiter(userToken.getTokenPrefix(), rateLimit);
         if (!rateLimiter.tryAcquire()) {
-          writeOpenApiError(response, TOO_MANY_REQUESTS,
-              "Too Many Requests, the flow is limited");
+          writeOpenApiError(response, TOO_MANY_REQUESTS, "Too Many Requests, the flow is limited");
           return;
         }
       } catch (Exception e) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilter.java
@@ -87,7 +87,7 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
 
     UserToken userToken = userTokenService.authenticate(token, request);
     if (userToken == null) {
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized user token");
+      writeOpenApiError(response, HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized user token");
       return;
     }
 
@@ -96,12 +96,14 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
       try {
         RateLimiter rateLimiter = getOrCreateRateLimiter(userToken.getTokenPrefix(), rateLimit);
         if (!rateLimiter.tryAcquire()) {
-          response.sendError(TOO_MANY_REQUESTS, "Too Many Requests, the flow is limited");
+          writeOpenApiError(response, TOO_MANY_REQUESTS,
+              "Too Many Requests, the flow is limited");
           return;
         }
       } catch (Exception e) {
         logger.error("UserTokenAuthenticationFilter ratelimit error", e);
-        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Rate limiting failed");
+        writeOpenApiError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            "Rate limiting failed");
         return;
       }
     }
@@ -123,6 +125,13 @@ public class UserTokenAuthenticationFilter extends OncePerRequestFilter {
       return null;
     }
     return token;
+  }
+
+  private void writeOpenApiError(HttpServletResponse response, int status, String message)
+      throws IOException {
+    response.setStatus(status);
+    response.setContentType("application/json;charset=UTF-8");
+    response.getWriter().write("{\"message\":\"" + message + "\"}");
   }
 
   private RateLimiter getOrCreateRateLimiter(String key, Integer limitCount) {

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
@@ -16,8 +16,9 @@
  */
 package com.ctrip.framework.apollo.portal.filter;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,6 +107,37 @@ class UserTokenAuthenticationFilterTest {
     verify(filterChain, never()).doFilter(request, response);
     org.junit.jupiter.api.Assertions.assertEquals(HttpServletResponse.SC_UNAUTHORIZED,
         response.getStatus());
+  }
+
+  @Test
+  void rateLimitedUserTokenReturnsTooManyRequestsWithoutErrorDispatch() throws Exception {
+    String token = UserTokenService.TOKEN_PREFIX + "rate429_secret";
+    UserToken userToken = new UserToken();
+    userToken.setId(1L);
+    userToken.setUserId("apollo");
+    userToken.setTokenPrefix("rate429");
+    userToken.setRateLimit(1);
+    when(userTokenService.authenticate(org.mockito.ArgumentMatchers.eq(token),
+        org.mockito.ArgumentMatchers.any())).thenReturn(userToken);
+
+    MockHttpServletRequest firstRequest = new MockHttpServletRequest("GET", "/openapi/v1/apps");
+    MockHttpServletResponse firstResponse = new MockHttpServletResponse();
+    firstRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    filter.doFilter(firstRequest, firstResponse, filterChain);
+    SecurityContextHolder.clearContext();
+
+    MockHttpServletRequest limitedRequest =
+        new MockHttpServletRequest("GET", "/openapi/v1/apps");
+    MockHttpServletResponse limitedResponse = new MockHttpServletResponse();
+    limitedRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+    filter.doFilter(limitedRequest, limitedResponse, filterChain);
+
+    assertEquals(429, limitedResponse.getStatus());
+    assertNull(limitedResponse.getErrorMessage());
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+    verify(filterChain).doFilter(firstRequest, firstResponse);
+    verify(filterChain, never()).doFilter(limitedRequest, limitedResponse);
   }
 
   @Test

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
@@ -29,6 +29,7 @@ import com.ctrip.framework.apollo.portal.entity.po.UserToken;
 import com.ctrip.framework.apollo.portal.service.UserTokenService;
 import com.ctrip.framework.apollo.portal.util.UserTokenAuditUtil;
 import com.ctrip.framework.apollo.portal.util.UserTokenAuthUtil;
+import java.util.UUID;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -111,11 +113,12 @@ class UserTokenAuthenticationFilterTest {
 
   @Test
   void rateLimitedUserTokenReturnsTooManyRequestsWithoutErrorDispatch() throws Exception {
-    String token = UserTokenService.TOKEN_PREFIX + "rate429_secret";
+    String tokenPrefix = "rate429_" + UUID.randomUUID();
+    String token = UserTokenService.TOKEN_PREFIX + tokenPrefix + "_secret";
     UserToken userToken = new UserToken();
     userToken.setId(1L);
     userToken.setUserId("apollo");
-    userToken.setTokenPrefix("rate429");
+    userToken.setTokenPrefix(tokenPrefix);
     userToken.setRateLimit(1);
     when(userTokenService.authenticate(org.mockito.ArgumentMatchers.eq(token),
         org.mockito.ArgumentMatchers.any())).thenReturn(userToken);
@@ -134,6 +137,9 @@ class UserTokenAuthenticationFilterTest {
 
     assertEquals(429, limitedResponse.getStatus());
     assertNull(limitedResponse.getErrorMessage());
+    assertEquals(MediaType.APPLICATION_JSON_VALUE, limitedResponse.getContentType());
+    assertEquals("{\"message\":\"Too Many Requests, the flow is limited\"}",
+        limitedResponse.getContentAsString());
     assertNull(SecurityContextHolder.getContext().getAuthentication());
     verify(filterChain).doFilter(firstRequest, firstResponse);
     verify(filterChain, never()).doFilter(limitedRequest, limitedResponse);

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/filter/UserTokenAuthenticationFilterTest.java
@@ -126,8 +126,7 @@ class UserTokenAuthenticationFilterTest {
     filter.doFilter(firstRequest, firstResponse, filterChain);
     SecurityContextHolder.clearContext();
 
-    MockHttpServletRequest limitedRequest =
-        new MockHttpServletRequest("GET", "/openapi/v1/apps");
+    MockHttpServletRequest limitedRequest = new MockHttpServletRequest("GET", "/openapi/v1/apps");
     MockHttpServletResponse limitedResponse = new MockHttpServletResponse();
     limitedRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
 


### PR DESCRIPTION
## What is the purpose of this PR

OpenAPI requests authenticated with a user token should get API-style error responses from `UserTokenAuthenticationFilter`. When the user token is invalid, rate-limited, or the rate limiter throws, using `sendError` can enter the servlet error path and be handled by the portal login entry point, resulting in `302 /signin` for API clients.

This PR writes JSON error responses directly from the filter so rate-limited user-token requests return `429` instead of redirecting to sign-in.

## Which issue(s) this PR fixes:

N/A

## Brief changelog

- Write JSON error bodies directly for user-token authentication failure and rate-limit paths.
- Add regression coverage asserting rate-limited user-token requests return `429` without an error dispatch.
- Update `CHANGES.md` with this PR link.

## Tests

- [x] `./mvnw -pl apollo-portal -am -Dtest=UserTokenAuthenticationFilterTest,PortalOpenApiAuthenticationScenariosTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `./mvnw spotless:apply`
- [x] `git diff --check`
- [ ] `mvn clean test` (not run; covered by targeted portal auth tests)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request does not break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI token authentication failures now return JSON error responses with the appropriate HTTP status codes (no redirect).
  * Rate-limited token requests now return **429 Too Many Requests** with the expected JSON error message.
  * Authentication and rate-limit responses are now more consistent for API consumers.
* **Tests**
  * Added a unit test to verify rate-limited requests are blocked, return **429** with JSON content type, and do not proceed through the filter chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->