### PR TITLE
fix: enforce access key for raw /configfiles api

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtil.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtil.java
@@ -33,6 +33,7 @@ public class AccessKeyUtil {
   private static final String URL_SEPARATOR = "/";
   private static final String URL_CONFIGS_PREFIX = "/configs/";
   private static final String URL_CONFIGFILES_JSON_PREFIX = "/configfiles/json/";
+  private static final String URL_CONFIGFILES_RAW_PREFIX = "/configfiles/raw/";
   private static final String URL_CONFIGFILES_PREFIX = "/configfiles/";
   private static final String URL_NOTIFICATIONS_PREFIX = "/notifications/v2";
 
@@ -58,6 +59,8 @@ public class AccessKeyUtil {
       appId = StringUtils.substringBetween(servletPath, URL_CONFIGS_PREFIX, URL_SEPARATOR);
     } else if (StringUtils.startsWith(servletPath, URL_CONFIGFILES_JSON_PREFIX)) {
       appId = StringUtils.substringBetween(servletPath, URL_CONFIGFILES_JSON_PREFIX, URL_SEPARATOR);
+    } else if (StringUtils.startsWith(servletPath, URL_CONFIGFILES_RAW_PREFIX)) {
+      appId = StringUtils.substringBetween(servletPath, URL_CONFIGFILES_RAW_PREFIX, URL_SEPARATOR);
     } else if (StringUtils.startsWith(servletPath, URL_CONFIGFILES_PREFIX)) {
       appId = StringUtils.substringBetween(servletPath, URL_CONFIGFILES_PREFIX, URL_SEPARATOR);
     } else if (StringUtils.startsWith(servletPath, URL_NOTIFICATIONS_PREFIX)) {

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtilTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtilTest.java
@@ -90,6 +90,15 @@ public class AccessKeyUtilTest {
 
   @Test
   public void testExtractAppIdFromRequest4() {
+    when(request.getServletPath()).thenReturn("/configfiles/raw/someAppId/default/application");
+
+    String appId = accessKeyUtil.extractAppIdFromRequest(request);
+
+    assertThat(appId).isEqualTo("someAppId");
+  }
+
+  @Test
+  public void testExtractAppIdFromRequest5() {
     when(request.getServletPath()).thenReturn("/notifications/v2");
     when(request.getParameter("appId")).thenReturn("someAppId");
 


### PR DESCRIPTION
## Background
The raw `/configfiles` API was introduced in #5336. At that time, the access-key appId extraction logic was not updated for the new `/configfiles/raw/{appId}/...` route, so those requests could be checked against `raw` instead of the real application id.

## Summary
- extract the real appId for `/configfiles/raw/{appId}/...` access-key checks
- add regression coverage for raw config file URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app ID detection for an additional config file URL pattern, including “raw” config file requests.
  * Ensured requests under the new path format are parsed consistently with existing config endpoints.

* **Tests**
  * Added coverage for the new raw config file URL scenario to verify the extracted app ID is correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->