### PR TITLE
fix: physically delete retained release histories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Apollo 3.0.0
 * [Feature: allow explicitly authorized consumer tokens to manage portal users](https://github.com/apolloconfig/apollo/pull/5623)
 * [Feature: add user access tokens for AI agents and automation](https://github.com/apolloconfig/apollo/pull/5632)
 * [Fix: return 429 instead of redirecting to sign-in for OpenAPI user token rate limits](https://github.com/apolloconfig/apollo/pull/5637)
-* [Fix: physically delete retained release history and release rows](https://github.com/apolloconfig/apollo/pull/5641)
+* [Fix: physically delete retained release history and unreferenced release rows](https://github.com/apolloconfig/apollo/pull/5641)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Apollo 3.0.0
 * [Feature: allow explicitly authorized consumer tokens to manage portal users](https://github.com/apolloconfig/apollo/pull/5623)
 * [Feature: add user access tokens for AI agents and automation](https://github.com/apolloconfig/apollo/pull/5632)
 * [Fix: return 429 instead of redirecting to sign-in for OpenAPI user token rate limits](https://github.com/apolloconfig/apollo/pull/5637)
+* [Fix: physically delete retained release history and release rows](https://github.com/apolloconfig/apollo/pull/5641)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRepository.java
@@ -17,13 +17,15 @@
 package com.ctrip.framework.apollo.biz.repository;
 
 import com.ctrip.framework.apollo.biz.entity.ReleaseHistory;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -53,5 +55,9 @@ public interface ReleaseHistoryRepository extends JpaRepository<ReleaseHistory, 
 
   List<ReleaseHistory> findFirst100ByAppIdAndClusterNameAndNamespaceNameAndBranchNameAndIdLessThanEqualOrderByIdAsc(
       String appId, String clusterName, String namespaceName, String branchName, long maxId);
+
+  @Modifying
+  @Query(value = "DELETE FROM `ReleaseHistory` WHERE `Id` IN (:ids)", nativeQuery = true)
+  int deletePhysicallyByIdIn(@Param("ids") Collection<Long> ids);
 
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
@@ -67,7 +67,8 @@ public interface ReleaseRepository extends JpaRepository<Release, Long> {
       + "AND NOT EXISTS (SELECT 1 FROM `ReleaseHistory` h "
       + "WHERE h.`PreviousReleaseId` = `Release`.`Id`) "
       + "AND NOT EXISTS (SELECT 1 FROM `GrayReleaseRule` g "
-      + "WHERE g.`IsDeleted` = false AND g.`ReleaseId` = `Release`.`Id`)", nativeQuery = true)
+      + "WHERE g.`IsDeleted` = false AND g.`BranchStatus` = 1 "
+      + "AND g.`ReleaseId` = `Release`.`Id`)", nativeQuery = true)
   int deletePhysicallyIfUnreferencedByIdIn(@Param("ids") Collection<Long> ids);
 
   // For release history conversion program, need to delete after conversion it done

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
@@ -18,14 +18,14 @@ package com.ctrip.framework.apollo.biz.repository;
 
 import com.ctrip.framework.apollo.biz.entity.Release;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
-
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -59,6 +59,10 @@ public interface ReleaseRepository extends JpaRepository<Release, Long> {
       + "dataChangeLastModifiedBy = ?4 where appId=?1 and clusterName=?2 "
       + "and namespaceName = ?3 and isDeleted = false")
   int batchDelete(String appId, String clusterName, String namespaceName, String operator);
+
+  @Modifying
+  @Query(value = "DELETE FROM `Release` WHERE `Id` IN (:ids)", nativeQuery = true)
+  int deletePhysicallyByIdIn(@Param("ids") Collection<Long> ids);
 
   // For release history conversion program, need to delete after conversion it done
   List<Release> findByAppIdAndClusterNameAndNamespaceNameOrderByIdAsc(String appId,

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ReleaseRepository.java
@@ -61,8 +61,14 @@ public interface ReleaseRepository extends JpaRepository<Release, Long> {
   int batchDelete(String appId, String clusterName, String namespaceName, String operator);
 
   @Modifying
-  @Query(value = "DELETE FROM `Release` WHERE `Id` IN (:ids)", nativeQuery = true)
-  int deletePhysicallyByIdIn(@Param("ids") Collection<Long> ids);
+  @Query(value = "DELETE FROM `Release` WHERE `Id` IN (:ids) "
+      + "AND NOT EXISTS (SELECT 1 FROM `ReleaseHistory` h "
+      + "WHERE h.`ReleaseId` = `Release`.`Id`) "
+      + "AND NOT EXISTS (SELECT 1 FROM `ReleaseHistory` h "
+      + "WHERE h.`PreviousReleaseId` = `Release`.`Id`) "
+      + "AND NOT EXISTS (SELECT 1 FROM `GrayReleaseRule` g "
+      + "WHERE g.`IsDeleted` = false AND g.`ReleaseId` = `Release`.`Id`)", nativeQuery = true)
+  int deletePhysicallyIfUnreferencedByIdIn(@Param("ids") Collection<Long> ids);
 
   // For release history conversion program, need to delete after conversion it done
   List<Release> findByAppIdAndClusterNameAndNamespaceNameOrderByIdAsc(String appId,

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryService.java
@@ -201,14 +201,19 @@ public class ReleaseHistoryService {
       List<ReleaseHistory> cleanReleaseHistoryList = releaseHistoryRepository
           .findFirst100ByAppIdAndClusterNameAndNamespaceNameAndBranchNameAndIdLessThanEqualOrderByIdAsc(
               appId, clusterName, namespaceName, branchName, maxId.get());
+      if (cleanReleaseHistoryList.isEmpty()) {
+        break;
+      }
+      List<Long> releaseHistoryIds =
+          cleanReleaseHistoryList.stream().map(ReleaseHistory::getId).collect(Collectors.toList());
       Set<Long> releaseIds = cleanReleaseHistoryList.stream().map(ReleaseHistory::getReleaseId)
           .collect(Collectors.toSet());
 
       transactionManager.execute(new TransactionCallbackWithoutResult() {
         @Override
         protected void doInTransactionWithoutResult(TransactionStatus status) {
-          releaseHistoryRepository.deleteAll(cleanReleaseHistoryList);
-          releaseRepository.deleteAllById(releaseIds);
+          releaseHistoryRepository.deletePhysicallyByIdIn(releaseHistoryIds);
+          releaseRepository.deletePhysicallyByIdIn(releaseIds);
         }
       });
       hasMore = cleanReleaseHistoryList.size() == 100;

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryService.java
@@ -27,6 +27,7 @@ import com.ctrip.framework.apollo.core.utils.ApolloThreadFactory;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import com.google.common.collect.Queues;
 import com.google.gson.Gson;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
@@ -206,14 +207,23 @@ public class ReleaseHistoryService {
       }
       List<Long> releaseHistoryIds =
           cleanReleaseHistoryList.stream().map(ReleaseHistory::getId).collect(Collectors.toList());
-      Set<Long> releaseIds = cleanReleaseHistoryList.stream().map(ReleaseHistory::getReleaseId)
-          .collect(Collectors.toSet());
+      Set<Long> releaseIds = new HashSet<>();
+      for (ReleaseHistory releaseHistory : cleanReleaseHistoryList) {
+        if (releaseHistory.getReleaseId() > 0) {
+          releaseIds.add(releaseHistory.getReleaseId());
+        }
+        if (releaseHistory.getPreviousReleaseId() > 0) {
+          releaseIds.add(releaseHistory.getPreviousReleaseId());
+        }
+      }
 
       transactionManager.execute(new TransactionCallbackWithoutResult() {
         @Override
         protected void doInTransactionWithoutResult(TransactionStatus status) {
           releaseHistoryRepository.deletePhysicallyByIdIn(releaseHistoryIds);
-          releaseRepository.deletePhysicallyByIdIn(releaseIds);
+          if (!releaseIds.isEmpty()) {
+            releaseRepository.deletePhysicallyIfUnreferencedByIdIn(releaseIds);
+          }
         }
       });
       hasMore = cleanReleaseHistoryList.size() == 100;

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
@@ -16,10 +16,10 @@
  */
 package com.ctrip.framework.apollo.biz.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -39,9 +39,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -55,7 +55,7 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   private JdbcTemplate jdbcTemplate;
   private Path scriptDirectory;
 
-  @Before
+  @BeforeEach
   public void setUp() throws SQLException {
     DriverManagerDataSource testDataSource = new DriverManagerDataSource();
     testDataSource.setDriverClassName("org.h2.Driver");
@@ -69,7 +69,7 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     createSchema();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws SQLException {
     if (connection != null) {
       connection.close();
@@ -175,11 +175,12 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   @Test
   public void purgeExcludesNamespaceDeletionAndPreviousNamespaceIncarnation() throws Exception {
     insertMigrationFixture();
-    insertNamespace(2, "deleted-namespace", true, "2026-01-01 00:00:00");
+    insertNamespace(2, "deleted-namespace", true, 7, "2026-01-01 00:00:00");
     insertRelease(7, "release-7", "deleted-namespace", true, 7, "2026-02-01 00:00:00");
     insertReleaseHistory(3, "deleted-namespace", 7, 0, true, "2026-02-01 00:00:00");
 
-    insertNamespace(3, "recreated-namespace", false, "2026-03-01 00:00:00");
+    insertNamespace(3, "recreated-namespace", true, 8, "2026-02-01 00:00:00");
+    insertNamespace(4, "recreated-namespace", false, 0, "2026-03-01 00:00:00");
     insertRelease(8, "release-8", "recreated-namespace", true, 8, "2026-02-01 00:00:00");
     insertReleaseHistory(4, "recreated-namespace", 8, 0, true, "2026-02-01 00:00:00");
 
@@ -201,6 +202,44 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     assertTrue(releaseHistoryExists(4));
     assertTrue(releaseExists(7));
     assertTrue(releaseExists(8));
+  }
+
+  @Test
+  public void scriptsUseDeletedAtForSameSecondNamespaceRecreation() throws Exception {
+    insertMigrationFixture();
+    String sameSecond = "2026-04-01 00:00:00";
+    insertNamespace(2, "same-second", true, 1002, sameSecond);
+    insertNamespace(3, "same-second", false, 0, sameSecond);
+    insertRelease(7, "release-7", "same-second", true, 1001, sameSecond);
+    insertReleaseHistory(3, "same-second", 7, 0, true, 1001, sameSecond);
+    insertRelease(8, "release-8", "same-second", true, 1003, sameSecond);
+    insertReleaseHistory(4, "same-second", 8, 0, true, 1003, sameSecond);
+    insertRelease(9, "release-9", "same-second", true, 1001, sameSecond);
+    insertReleaseHistory(5, "same-second", 9, 0, false, 0, sameSecond);
+
+    List<List<Map<String, Object>>> restorePrecheck =
+        executeScript("01-precheck-releases-needing-restore.sql");
+    assertEquals(3, longValue(restorePrecheck.get(0).get(0), "ReleasesNeedingRestore"));
+    assertFalse(restorePrecheck.get(1).stream().anyMatch(row -> longValue(row, "Id") == 9));
+
+    List<List<Map<String, Object>>> precheck = executeScript("02-precheck-soft-deleted-rows.sql");
+    assertEquals(3, longValue(precheck.get(0).get(0), "SoftDeletedReleaseHistoryRows"));
+    assertEquals(2, longValue(precheck.get(0).get(0), "RetentionReleaseHistoryPurgeCandidates"));
+    assertEquals(1, longValue(precheck.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(8, longValue(precheck.get(1).get(0), "SoftDeletedReleaseRows"));
+    assertEquals(6, longValue(precheck.get(1).get(0), "RetentionScopedSoftDeletedReleaseRows"));
+    assertEquals(2, longValue(precheck.get(1).get(0), "ExcludedSoftDeletedReleaseRows"));
+
+    executeScript("03-restore-referenced-releases.sql");
+    assertTrue(isReleaseDeleted(9));
+    List<List<Map<String, Object>>> purgeResult = executeScript("04-purge-soft-deleted-rows.sql");
+    assertEquals(1, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(2, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseRows"));
+    assertTrue(releaseHistoryExists(3));
+    assertFalse(releaseHistoryExists(4));
+    assertTrue(releaseExists(7));
+    assertFalse(releaseExists(8));
+    assertTrue(releaseExists(9));
   }
 
   @Test
@@ -230,7 +269,8 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     jdbcTemplate.execute(
         "CREATE TABLE `Namespace` (" + "`Id` BIGINT PRIMARY KEY, `AppId` VARCHAR(64) NOT NULL, "
             + "`ClusterName` VARCHAR(32) NOT NULL, `NamespaceName` VARCHAR(32) NOT NULL, "
-            + "`IsDeleted` BOOLEAN NOT NULL, `DataChange_CreatedTime` TIMESTAMP NOT NULL)");
+            + "`IsDeleted` BOOLEAN NOT NULL, `DeletedAt` BIGINT NOT NULL, "
+            + "`DataChange_CreatedTime` TIMESTAMP NOT NULL)");
     jdbcTemplate.execute(
         "CREATE TABLE `Release` (" + "`Id` BIGINT PRIMARY KEY, `ReleaseKey` VARCHAR(64) NOT NULL, "
             + "`AppId` VARCHAR(64) NOT NULL, `ClusterName` VARCHAR(32) NOT NULL, "
@@ -242,7 +282,7 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
         + "`ClusterName` VARCHAR(32) NOT NULL, `NamespaceName` VARCHAR(32) NOT NULL, "
         + "`BranchName` VARCHAR(32) NOT NULL, `ReleaseId` BIGINT NOT NULL, "
         + "`PreviousReleaseId` BIGINT NOT NULL, `IsDeleted` BOOLEAN NOT NULL, "
-        + "`DataChange_LastTime` TIMESTAMP NOT NULL)");
+        + "`DeletedAt` BIGINT NOT NULL, `DataChange_LastTime` TIMESTAMP NOT NULL)");
     jdbcTemplate.execute("CREATE INDEX `IX_ReleaseId` ON `ReleaseHistory` (`ReleaseId`)");
     jdbcTemplate
         .execute("CREATE INDEX `IX_PreviousReleaseId` ON `ReleaseHistory` (`PreviousReleaseId`)");
@@ -252,7 +292,7 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   }
 
   private void insertMigrationFixture() {
-    insertNamespace(1, "application", false, "2026-01-01 00:00:00");
+    insertNamespace(1, "application", false, 0, "2026-01-01 00:00:00");
     insertRelease(1, "release-1", true, 1);
     insertRelease(2, "release-2", true, 2);
     insertRelease(3, "release-3", true, 3);
@@ -279,24 +319,32 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
 
   private void insertReleaseHistory(long id, long releaseId, long previousReleaseId,
       boolean deleted) {
-    insertReleaseHistory(id, "application", releaseId, previousReleaseId, deleted,
+    insertReleaseHistory(id, "application", releaseId, previousReleaseId, deleted, deleted ? id : 0,
         "2026-02-01 00:00:00");
   }
 
   private void insertReleaseHistory(long id, String namespaceName, long releaseId,
       long previousReleaseId, boolean deleted, String lastModifiedTime) {
+    insertReleaseHistory(id, namespaceName, releaseId, previousReleaseId, deleted, deleted ? id : 0,
+        lastModifiedTime);
+  }
+
+  private void insertReleaseHistory(long id, String namespaceName, long releaseId,
+      long previousReleaseId, boolean deleted, long deletedAt, String lastModifiedTime) {
     jdbcTemplate.update(
         "INSERT INTO `ReleaseHistory` (`Id`, `AppId`, `ClusterName`, "
             + "`NamespaceName`, `BranchName`, `ReleaseId`, `PreviousReleaseId`, `IsDeleted`, "
-            + "`DataChange_LastTime`) " + "VALUES (?, 'app', 'default', ?, 'default', ?, ?, ?, ?)",
-        id, namespaceName, releaseId, previousReleaseId, deleted, lastModifiedTime);
+            + "`DeletedAt`, `DataChange_LastTime`) "
+            + "VALUES (?, 'app', 'default', ?, 'default', ?, ?, ?, ?, ?)",
+        id, namespaceName, releaseId, previousReleaseId, deleted, deletedAt, lastModifiedTime);
   }
 
-  private void insertNamespace(long id, String namespaceName, boolean deleted, String createdTime) {
+  private void insertNamespace(long id, String namespaceName, boolean deleted, long deletedAt,
+      String createdTime) {
     jdbcTemplate.update(
         "INSERT INTO `Namespace` (`Id`, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, "
-            + "`DataChange_CreatedTime`) VALUES (?, 'app', 'default', ?, ?, ?)",
-        id, namespaceName, deleted, createdTime);
+            + "`DeletedAt`, `DataChange_CreatedTime`) VALUES (?, 'app', 'default', ?, ?, ?, ?)",
+        id, namespaceName, deleted, deletedAt, createdTime);
   }
 
   private void insertGrayReleaseRule(long id, long releaseId, int branchStatus) {

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
@@ -97,9 +97,16 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
         executeScript("02-precheck-soft-deleted-rows.sql");
     assertEquals(4, cleanupPrecheck.size());
     assertEquals(1, longValue(cleanupPrecheck.get(0).get(0), "SoftDeletedReleaseHistoryRows"));
-    assertEquals(5, longValue(cleanupPrecheck.get(1).get(0), "SoftDeletedReleaseRows"));
     assertEquals(1,
-        longValue(cleanupPrecheck.get(2).get(0), "SoftDeletedReleaseRowsEligibleForDeletion"));
+        longValue(cleanupPrecheck.get(0).get(0), "RetentionReleaseHistoryPurgeCandidates"));
+    assertEquals(0,
+        longValue(cleanupPrecheck.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(5, longValue(cleanupPrecheck.get(1).get(0), "SoftDeletedReleaseRows"));
+    assertEquals(5,
+        longValue(cleanupPrecheck.get(1).get(0), "RetentionScopedSoftDeletedReleaseRows"));
+    assertEquals(0, longValue(cleanupPrecheck.get(1).get(0), "ExcludedSoftDeletedReleaseRows"));
+    assertEquals(1,
+        longValue(cleanupPrecheck.get(2).get(0), "RetentionReleaseRowsEligibleForDeletion"));
     assertEquals(1, cleanupPrecheck.get(3).size());
     assertEquals(1, longValue(cleanupPrecheck.get(3).get(0), "SoftDeletedRows"));
   }
@@ -120,8 +127,10 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     assertTrue(isReleaseDeleted(5));
 
     List<List<Map<String, Object>>> purgeResult = executeScript("04-purge-soft-deleted-rows.sql");
-    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingSoftDeletedReleaseHistoryRows"));
-    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingSoftDeletedReleaseRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingRetentionReleaseHistoryRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingRetentionReleaseRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseRows"));
     assertEquals(1, countReleaseHistories());
     assertEquals(4, countReleases());
     assertTrue(releaseExists(1));
@@ -134,10 +143,64 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     assertEquals(0, longValue(executeScript("03-restore-referenced-releases.sql").get(0).get(0),
         "RemainingReleasesNeedingRestore"));
     List<List<Map<String, Object>>> secondPurge = executeScript("04-purge-soft-deleted-rows.sql");
-    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingSoftDeletedReleaseHistoryRows"));
-    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingSoftDeletedReleaseRows"));
+    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingRetentionReleaseHistoryRows"));
+    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingRetentionReleaseRows"));
     assertEquals(1, countReleaseHistories());
     assertEquals(4, countReleases());
+  }
+
+  @Test
+  public void inactiveGrayReleaseRulesDoNotRestoreOrProtectReleases() throws Exception {
+    insertMigrationFixture();
+    insertRelease(7, "release-7", true, 7);
+    insertRelease(8, "release-8", true, 8);
+    insertGrayReleaseRule(2, 7, 0);
+    insertGrayReleaseRule(3, 8, 2);
+
+    List<List<Map<String, Object>>> precheck =
+        executeScript("01-precheck-releases-needing-restore.sql");
+    assertEquals(3, longValue(precheck.get(0).get(0), "ReleasesNeedingRestore"));
+    assertFalse(precheck.get(1).stream().anyMatch(row -> longValue(row, "Id") == 7));
+    assertFalse(precheck.get(1).stream().anyMatch(row -> longValue(row, "Id") == 8));
+
+    executeScript("03-restore-referenced-releases.sql");
+    assertTrue(isReleaseDeleted(7));
+    assertTrue(isReleaseDeleted(8));
+
+    executeScript("04-purge-soft-deleted-rows.sql");
+    assertFalse(releaseExists(7));
+    assertFalse(releaseExists(8));
+  }
+
+  @Test
+  public void purgeExcludesNamespaceDeletionAndPreviousNamespaceIncarnation() throws Exception {
+    insertMigrationFixture();
+    insertNamespace(2, "deleted-namespace", true, "2026-01-01 00:00:00");
+    insertRelease(7, "release-7", "deleted-namespace", true, 7, "2026-02-01 00:00:00");
+    insertReleaseHistory(3, "deleted-namespace", 7, 0, true, "2026-02-01 00:00:00");
+
+    insertNamespace(3, "recreated-namespace", false, "2026-03-01 00:00:00");
+    insertRelease(8, "release-8", "recreated-namespace", true, 8, "2026-02-01 00:00:00");
+    insertReleaseHistory(4, "recreated-namespace", 8, 0, true, "2026-02-01 00:00:00");
+
+    List<List<Map<String, Object>>> precheck = executeScript("02-precheck-soft-deleted-rows.sql");
+    assertEquals(3, longValue(precheck.get(0).get(0), "SoftDeletedReleaseHistoryRows"));
+    assertEquals(1, longValue(precheck.get(0).get(0), "RetentionReleaseHistoryPurgeCandidates"));
+    assertEquals(2, longValue(precheck.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(7, longValue(precheck.get(1).get(0), "SoftDeletedReleaseRows"));
+    assertEquals(5, longValue(precheck.get(1).get(0), "RetentionScopedSoftDeletedReleaseRows"));
+    assertEquals(2, longValue(precheck.get(1).get(0), "ExcludedSoftDeletedReleaseRows"));
+
+    executeScript("03-restore-referenced-releases.sql");
+    List<List<Map<String, Object>>> purgeResult = executeScript("04-purge-soft-deleted-rows.sql");
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingRetentionReleaseHistoryRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingRetentionReleaseRows"));
+    assertEquals(2, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseHistoryRows"));
+    assertEquals(2, longValue(purgeResult.get(0).get(0), "ExcludedSoftDeletedReleaseRows"));
+    assertTrue(releaseHistoryExists(3));
+    assertTrue(releaseHistoryExists(4));
+    assertTrue(releaseExists(7));
+    assertTrue(releaseExists(8));
   }
 
   @Test
@@ -165,25 +228,31 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
 
   private void createSchema() {
     jdbcTemplate.execute(
+        "CREATE TABLE `Namespace` (" + "`Id` BIGINT PRIMARY KEY, `AppId` VARCHAR(64) NOT NULL, "
+            + "`ClusterName` VARCHAR(32) NOT NULL, `NamespaceName` VARCHAR(32) NOT NULL, "
+            + "`IsDeleted` BOOLEAN NOT NULL, `DataChange_CreatedTime` TIMESTAMP NOT NULL)");
+    jdbcTemplate.execute(
         "CREATE TABLE `Release` (" + "`Id` BIGINT PRIMARY KEY, `ReleaseKey` VARCHAR(64) NOT NULL, "
             + "`AppId` VARCHAR(64) NOT NULL, `ClusterName` VARCHAR(32) NOT NULL, "
             + "`NamespaceName` VARCHAR(32) NOT NULL, `IsDeleted` BOOLEAN NOT NULL, "
             + "`DeletedAt` BIGINT NOT NULL, `DataChange_LastModifiedBy` VARCHAR(64), "
-            + "UNIQUE (`ReleaseKey`, `DeletedAt`))");
+            + "`DataChange_LastTime` TIMESTAMP NOT NULL, " + "UNIQUE (`ReleaseKey`, `DeletedAt`))");
     jdbcTemplate.execute("CREATE TABLE `ReleaseHistory` ("
         + "`Id` BIGINT PRIMARY KEY, `AppId` VARCHAR(64) NOT NULL, "
         + "`ClusterName` VARCHAR(32) NOT NULL, `NamespaceName` VARCHAR(32) NOT NULL, "
         + "`BranchName` VARCHAR(32) NOT NULL, `ReleaseId` BIGINT NOT NULL, "
-        + "`PreviousReleaseId` BIGINT NOT NULL, `IsDeleted` BOOLEAN NOT NULL)");
+        + "`PreviousReleaseId` BIGINT NOT NULL, `IsDeleted` BOOLEAN NOT NULL, "
+        + "`DataChange_LastTime` TIMESTAMP NOT NULL)");
     jdbcTemplate.execute("CREATE INDEX `IX_ReleaseId` ON `ReleaseHistory` (`ReleaseId`)");
     jdbcTemplate
         .execute("CREATE INDEX `IX_PreviousReleaseId` ON `ReleaseHistory` (`PreviousReleaseId`)");
     jdbcTemplate.execute("CREATE TABLE `GrayReleaseRule` ("
         + "`Id` BIGINT PRIMARY KEY, `ReleaseId` BIGINT NOT NULL, "
-        + "`IsDeleted` BOOLEAN NOT NULL)");
+        + "`BranchStatus` INTEGER NOT NULL, `IsDeleted` BOOLEAN NOT NULL)");
   }
 
   private void insertMigrationFixture() {
+    insertNamespace(1, "application", false, "2026-01-01 00:00:00");
     insertRelease(1, "release-1", true, 1);
     insertRelease(2, "release-2", true, 2);
     insertRelease(3, "release-3", true, 3);
@@ -192,25 +261,48 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     insertRelease(6, "release-6", false, 0);
     insertReleaseHistory(1, 1, 2, false);
     insertReleaseHistory(2, 4, 0, true);
-    jdbcTemplate.update(
-        "INSERT INTO `GrayReleaseRule` (`Id`, `ReleaseId`, `IsDeleted`) " + "VALUES (1, 3, FALSE)");
+    insertGrayReleaseRule(1, 3, 1);
   }
 
   private void insertRelease(long id, String releaseKey, boolean deleted, long deletedAt) {
+    insertRelease(id, releaseKey, "application", deleted, deletedAt, "2026-02-01 00:00:00");
+  }
+
+  private void insertRelease(long id, String releaseKey, String namespaceName, boolean deleted,
+      long deletedAt, String lastModifiedTime) {
     jdbcTemplate.update(
         "INSERT INTO `Release` (`Id`, `ReleaseKey`, `AppId`, `ClusterName`, "
-            + "`NamespaceName`, `IsDeleted`, `DeletedAt`, `DataChange_LastModifiedBy`) "
-            + "VALUES (?, ?, 'app', 'default', 'application', ?, ?, '')",
-        id, releaseKey, deleted, deletedAt);
+            + "`NamespaceName`, `IsDeleted`, `DeletedAt`, `DataChange_LastModifiedBy`, "
+            + "`DataChange_LastTime`) " + "VALUES (?, ?, 'app', 'default', ?, ?, ?, '', ?)",
+        id, releaseKey, namespaceName, deleted, deletedAt, lastModifiedTime);
   }
 
   private void insertReleaseHistory(long id, long releaseId, long previousReleaseId,
       boolean deleted) {
+    insertReleaseHistory(id, "application", releaseId, previousReleaseId, deleted,
+        "2026-02-01 00:00:00");
+  }
+
+  private void insertReleaseHistory(long id, String namespaceName, long releaseId,
+      long previousReleaseId, boolean deleted, String lastModifiedTime) {
     jdbcTemplate.update(
         "INSERT INTO `ReleaseHistory` (`Id`, `AppId`, `ClusterName`, "
-            + "`NamespaceName`, `BranchName`, `ReleaseId`, `PreviousReleaseId`, `IsDeleted`) "
-            + "VALUES (?, 'app', 'default', 'application', 'default', ?, ?, ?)",
-        id, releaseId, previousReleaseId, deleted);
+            + "`NamespaceName`, `BranchName`, `ReleaseId`, `PreviousReleaseId`, `IsDeleted`, "
+            + "`DataChange_LastTime`) " + "VALUES (?, 'app', 'default', ?, 'default', ?, ?, ?, ?)",
+        id, namespaceName, releaseId, previousReleaseId, deleted, lastModifiedTime);
+  }
+
+  private void insertNamespace(long id, String namespaceName, boolean deleted, String createdTime) {
+    jdbcTemplate.update(
+        "INSERT INTO `Namespace` (`Id`, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, "
+            + "`DataChange_CreatedTime`) VALUES (?, 'app', 'default', ?, ?, ?)",
+        id, namespaceName, deleted, createdTime);
+  }
+
+  private void insertGrayReleaseRule(long id, long releaseId, int branchStatus) {
+    jdbcTemplate
+        .update("INSERT INTO `GrayReleaseRule` (`Id`, `ReleaseId`, `BranchStatus`, `IsDeleted`) "
+            + "VALUES (?, ?, ?, FALSE)", id, releaseId, branchStatus);
   }
 
   private List<List<Map<String, Object>>> executeScript(String scriptName)
@@ -293,6 +385,11 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   private boolean releaseExists(long releaseId) {
     return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `Release` WHERE `Id` = ?",
         Integer.class, releaseId) > 0;
+  }
+
+  private boolean releaseHistoryExists(long releaseHistoryId) {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `ReleaseHistory` WHERE `Id` = ?",
+        Integer.class, releaseHistoryId) > 0;
   }
 
   private int countSoftDeletedReleases() {

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.biz.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/** Verifies the manual release history retention scripts against H2 in MySQL mode. */
+public class ReleaseHistoryRetentionMigrationSqlTest {
+
+  private static final String SCRIPT_DIRECTORY = "scripts/sql/migration/release-history-retention";
+
+  private Connection connection;
+  private DataSource dataSource;
+  private JdbcTemplate jdbcTemplate;
+  private Path scriptDirectory;
+
+  @Before
+  public void setUp() throws SQLException {
+    DriverManagerDataSource testDataSource = new DriverManagerDataSource();
+    testDataSource.setDriverClassName("org.h2.Driver");
+    testDataSource.setUrl("jdbc:h2:mem:release-history-retention-" + UUID.randomUUID()
+        + ";MODE=MySQL;DATABASE_TO_UPPER=FALSE");
+    testDataSource.setUsername("sa");
+    dataSource = testDataSource;
+    connection = dataSource.getConnection();
+    jdbcTemplate = new JdbcTemplate(dataSource);
+    scriptDirectory = findScriptDirectory();
+    createSchema();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  @Test
+  public void precheckScriptsReportRepairAndCleanupScope() throws Exception {
+    insertMigrationFixture();
+
+    List<List<Map<String, Object>>> restorePrecheck =
+        executeScript("01-precheck-releases-needing-restore.sql");
+    assertEquals(2, restorePrecheck.size());
+    assertEquals(3, longValue(restorePrecheck.get(0).get(0), "ReleasesNeedingRestore"));
+    assertEquals(0, longValue(restorePrecheck.get(0).get(0), "ActiveReleaseKeyConflicts"));
+
+    Map<Long, Map<String, Object>> restoreCandidates = restorePrecheck.get(1).stream()
+        .collect(Collectors.toMap(row -> longValue(row, "Id"), row -> row));
+    assertEquals(3, restoreCandidates.size());
+    assertTrue(booleanValue(restoreCandidates.get(1L), "ReferencedByReleaseHistory"));
+    assertTrue(booleanValue(restoreCandidates.get(2L), "ReferencedAsPreviousRelease"));
+    assertTrue(booleanValue(restoreCandidates.get(3L), "ReferencedByGrayReleaseRule"));
+
+    List<List<Map<String, Object>>> cleanupPrecheck =
+        executeScript("02-precheck-soft-deleted-rows.sql");
+    assertEquals(4, cleanupPrecheck.size());
+    assertEquals(1, longValue(cleanupPrecheck.get(0).get(0), "SoftDeletedReleaseHistoryRows"));
+    assertEquals(5, longValue(cleanupPrecheck.get(1).get(0), "SoftDeletedReleaseRows"));
+    assertEquals(1,
+        longValue(cleanupPrecheck.get(2).get(0), "SoftDeletedReleaseRowsEligibleForDeletion"));
+    assertEquals(1, cleanupPrecheck.get(3).size());
+    assertEquals(1, longValue(cleanupPrecheck.get(3).get(0), "SoftDeletedRows"));
+  }
+
+  @Test
+  public void writeScriptsRestoreAndPurgeSafelyAndAreIdempotent() throws Exception {
+    insertMigrationFixture();
+
+    List<List<Map<String, Object>>> restoreResult =
+        executeScript("03-restore-referenced-releases.sql");
+    assertEquals(0, longValue(restoreResult.get(0).get(0), "RemainingReleasesNeedingRestore"));
+    for (long releaseId : Arrays.asList(1L, 2L, 3L)) {
+      assertFalse(isReleaseDeleted(releaseId));
+      assertEquals(0, releaseDeletedAt(releaseId));
+      assertEquals("release-history-retention-migration", releaseLastModifiedBy(releaseId));
+    }
+    assertTrue(isReleaseDeleted(4));
+    assertTrue(isReleaseDeleted(5));
+
+    List<List<Map<String, Object>>> purgeResult = executeScript("04-purge-soft-deleted-rows.sql");
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingSoftDeletedReleaseHistoryRows"));
+    assertEquals(0, longValue(purgeResult.get(0).get(0), "RemainingSoftDeletedReleaseRows"));
+    assertEquals(1, countReleaseHistories());
+    assertEquals(4, countReleases());
+    assertTrue(releaseExists(1));
+    assertTrue(releaseExists(2));
+    assertTrue(releaseExists(3));
+    assertFalse(releaseExists(4));
+    assertFalse(releaseExists(5));
+    assertTrue(releaseExists(6));
+
+    assertEquals(0, longValue(executeScript("03-restore-referenced-releases.sql").get(0).get(0),
+        "RemainingReleasesNeedingRestore"));
+    List<List<Map<String, Object>>> secondPurge = executeScript("04-purge-soft-deleted-rows.sql");
+    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingSoftDeletedReleaseHistoryRows"));
+    assertEquals(0, longValue(secondPurge.get(0).get(0), "RemainingSoftDeletedReleaseRows"));
+    assertEquals(1, countReleaseHistories());
+    assertEquals(4, countReleases());
+  }
+
+  @Test
+  public void restorePrecheckDetectsReleaseKeyConflictAndRestoreFailsSafely() throws Exception {
+    insertMigrationFixture();
+    insertRelease(7, "release-1", false, 0);
+
+    List<List<Map<String, Object>>> precheck =
+        executeScript("01-precheck-releases-needing-restore.sql");
+    assertEquals(1, longValue(precheck.get(0).get(0), "ActiveReleaseKeyConflicts"));
+    assertTrue(booleanValue(precheck.get(1).get(0), "ActiveReleaseKeyConflict"));
+
+    assertThrows(SQLException.class, () -> executeScript("03-restore-referenced-releases.sql"));
+    assertTrue(isReleaseDeleted(1));
+    assertTrue(isReleaseDeleted(2));
+    assertTrue(isReleaseDeleted(3));
+    assertEquals(5, countSoftDeletedReleases());
+  }
+
+  @Test
+  public void writeScriptsUseBoundedBatches() throws IOException {
+    assertEquals(1, occurrences(readScript("03-restore-referenced-releases.sql"), "LIMIT 1000"));
+    assertEquals(2, occurrences(readScript("04-purge-soft-deleted-rows.sql"), "LIMIT 1000"));
+  }
+
+  private void createSchema() {
+    jdbcTemplate.execute(
+        "CREATE TABLE `Release` (" + "`Id` BIGINT PRIMARY KEY, `ReleaseKey` VARCHAR(64) NOT NULL, "
+            + "`AppId` VARCHAR(64) NOT NULL, `ClusterName` VARCHAR(32) NOT NULL, "
+            + "`NamespaceName` VARCHAR(32) NOT NULL, `IsDeleted` BOOLEAN NOT NULL, "
+            + "`DeletedAt` BIGINT NOT NULL, `DataChange_LastModifiedBy` VARCHAR(64), "
+            + "UNIQUE (`ReleaseKey`, `DeletedAt`))");
+    jdbcTemplate.execute("CREATE TABLE `ReleaseHistory` ("
+        + "`Id` BIGINT PRIMARY KEY, `AppId` VARCHAR(64) NOT NULL, "
+        + "`ClusterName` VARCHAR(32) NOT NULL, `NamespaceName` VARCHAR(32) NOT NULL, "
+        + "`BranchName` VARCHAR(32) NOT NULL, `ReleaseId` BIGINT NOT NULL, "
+        + "`PreviousReleaseId` BIGINT NOT NULL, `IsDeleted` BOOLEAN NOT NULL)");
+    jdbcTemplate.execute("CREATE INDEX `IX_ReleaseId` ON `ReleaseHistory` (`ReleaseId`)");
+    jdbcTemplate
+        .execute("CREATE INDEX `IX_PreviousReleaseId` ON `ReleaseHistory` (`PreviousReleaseId`)");
+    jdbcTemplate.execute("CREATE TABLE `GrayReleaseRule` ("
+        + "`Id` BIGINT PRIMARY KEY, `ReleaseId` BIGINT NOT NULL, "
+        + "`IsDeleted` BOOLEAN NOT NULL)");
+  }
+
+  private void insertMigrationFixture() {
+    insertRelease(1, "release-1", true, 1);
+    insertRelease(2, "release-2", true, 2);
+    insertRelease(3, "release-3", true, 3);
+    insertRelease(4, "release-4", true, 4);
+    insertRelease(5, "release-5", true, 5);
+    insertRelease(6, "release-6", false, 0);
+    insertReleaseHistory(1, 1, 2, false);
+    insertReleaseHistory(2, 4, 0, true);
+    jdbcTemplate.update(
+        "INSERT INTO `GrayReleaseRule` (`Id`, `ReleaseId`, `IsDeleted`) " + "VALUES (1, 3, FALSE)");
+  }
+
+  private void insertRelease(long id, String releaseKey, boolean deleted, long deletedAt) {
+    jdbcTemplate.update(
+        "INSERT INTO `Release` (`Id`, `ReleaseKey`, `AppId`, `ClusterName`, "
+            + "`NamespaceName`, `IsDeleted`, `DeletedAt`, `DataChange_LastModifiedBy`) "
+            + "VALUES (?, ?, 'app', 'default', 'application', ?, ?, '')",
+        id, releaseKey, deleted, deletedAt);
+  }
+
+  private void insertReleaseHistory(long id, long releaseId, long previousReleaseId,
+      boolean deleted) {
+    jdbcTemplate.update(
+        "INSERT INTO `ReleaseHistory` (`Id`, `AppId`, `ClusterName`, "
+            + "`NamespaceName`, `BranchName`, `ReleaseId`, `PreviousReleaseId`, `IsDeleted`) "
+            + "VALUES (?, 'app', 'default', 'application', 'default', ?, ?, ?)",
+        id, releaseId, previousReleaseId, deleted);
+  }
+
+  private List<List<Map<String, Object>>> executeScript(String scriptName)
+      throws IOException, SQLException {
+    List<List<Map<String, Object>>> queryResults = new ArrayList<>();
+    try (Statement statement = connection.createStatement()) {
+      for (String sql : readStatements(scriptDirectory.resolve(scriptName))) {
+        if (statement.execute(sql)) {
+          try (ResultSet resultSet = statement.getResultSet()) {
+            queryResults.add(readRows(resultSet));
+          }
+        }
+      }
+    } catch (SQLException ex) {
+      if (!connection.getAutoCommit()) {
+        connection.rollback();
+      }
+      connection.setAutoCommit(true);
+      throw ex;
+    }
+    return queryResults;
+  }
+
+  private List<String> readStatements(Path script) throws IOException {
+    String sql = Files.readAllLines(script, StandardCharsets.UTF_8).stream()
+        .filter(line -> !line.trim().startsWith("--")).collect(Collectors.joining("\n"));
+    return Arrays.stream(sql.split(";")).map(String::trim).filter(statement -> !statement.isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  private String readScript(String scriptName) throws IOException {
+    return Files.readString(scriptDirectory.resolve(scriptName), StandardCharsets.UTF_8);
+  }
+
+  private int occurrences(String value, String token) {
+    return value.split(token, -1).length - 1;
+  }
+
+  private List<Map<String, Object>> readRows(ResultSet resultSet) throws SQLException {
+    List<Map<String, Object>> rows = new ArrayList<>();
+    ResultSetMetaData metadata = resultSet.getMetaData();
+    while (resultSet.next()) {
+      Map<String, Object> row = new LinkedHashMap<>();
+      for (int column = 1; column <= metadata.getColumnCount(); column++) {
+        row.put(metadata.getColumnLabel(column), resultSet.getObject(column));
+      }
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private Path findScriptDirectory() {
+    Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      Path candidate = current.resolve(SCRIPT_DIRECTORY);
+      if (Files.isDirectory(candidate)) {
+        return candidate;
+      }
+      current = current.getParent();
+    }
+    throw new IllegalStateException("Could not locate " + SCRIPT_DIRECTORY);
+  }
+
+  private boolean isReleaseDeleted(long releaseId) {
+    return Boolean.TRUE.equals(jdbcTemplate.queryForObject(
+        "SELECT `IsDeleted` FROM `Release` WHERE `Id` = ?", Boolean.class, releaseId));
+  }
+
+  private long releaseDeletedAt(long releaseId) {
+    return jdbcTemplate.queryForObject("SELECT `DeletedAt` FROM `Release` WHERE `Id` = ?",
+        Long.class, releaseId);
+  }
+
+  private String releaseLastModifiedBy(long releaseId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT `DataChange_LastModifiedBy` FROM `Release` WHERE `Id` = ?", String.class,
+        releaseId);
+  }
+
+  private boolean releaseExists(long releaseId) {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `Release` WHERE `Id` = ?",
+        Integer.class, releaseId) > 0;
+  }
+
+  private int countSoftDeletedReleases() {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `Release` WHERE `IsDeleted` = TRUE",
+        Integer.class);
+  }
+
+  private int countReleases() {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `Release`", Integer.class);
+  }
+
+  private int countReleaseHistories() {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM `ReleaseHistory`", Integer.class);
+  }
+
+  private long longValue(Map<String, Object> row, String column) {
+    return ((Number) row.get(column)).longValue();
+  }
+
+  private boolean booleanValue(Map<String, Object> row, String column) {
+    Object value = row.get(column);
+    return value instanceof Boolean ? (Boolean) value : ((Number) value).intValue() != 0;
+  }
+}

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/ReleaseHistoryRetentionMigrationSqlTest.java
@@ -265,6 +265,14 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
     assertEquals(2, occurrences(readScript("04-purge-soft-deleted-rows.sql"), "LIMIT 1000"));
   }
 
+  @Test
+  public void scriptsForceReleaseHistoryReferenceIndexes() throws IOException {
+    assertReleaseHistoryIndexHints("01-precheck-releases-needing-restore.sql", 3);
+    assertReleaseHistoryIndexHints("02-precheck-soft-deleted-rows.sql", 1);
+    assertReleaseHistoryIndexHints("03-restore-referenced-releases.sql", 2);
+    assertReleaseHistoryIndexHints("04-purge-soft-deleted-rows.sql", 1);
+  }
+
   private void createSchema() {
     jdbcTemplate.execute(
         "CREATE TABLE `Namespace` (" + "`Id` BIGINT PRIMARY KEY, `AppId` VARCHAR(64) NOT NULL, "
@@ -377,8 +385,18 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   private List<String> readStatements(Path script) throws IOException {
     String sql = Files.readAllLines(script, StandardCharsets.UTF_8).stream()
         .filter(line -> !line.trim().startsWith("--")).collect(Collectors.joining("\n"));
+    // H2's MySQL mode does not support MySQL index hints. The raw script hints are asserted
+    // separately, while H2 verifies the equivalent query behavior without optimizer directives.
+    sql = sql.replaceAll("(?i)\\s+FORCE\\s+INDEX\\s*\\(`[^`]+`\\)", "");
     return Arrays.stream(sql.split(";")).map(String::trim).filter(statement -> !statement.isEmpty())
         .collect(Collectors.toList());
+  }
+
+  private void assertReleaseHistoryIndexHints(String scriptName, int expectedPerIndex)
+      throws IOException {
+    String sql = readScript(scriptName);
+    assertEquals(expectedPerIndex, occurrences(sql, "FORCE INDEX (`IX_ReleaseId`)"));
+    assertEquals(expectedPerIndex, occurrences(sql, "FORCE INDEX (`IX_PreviousReleaseId`)"));
   }
 
   private String readScript(String scriptName) throws IOException {
@@ -386,7 +404,13 @@ public class ReleaseHistoryRetentionMigrationSqlTest {
   }
 
   private int occurrences(String value, String token) {
-    return value.split(token, -1).length - 1;
+    int count = 0;
+    int offset = 0;
+    while ((offset = value.indexOf(token, offset)) >= 0) {
+      count++;
+      offset += token.length();
+    }
+    return count;
   }
 
   private List<Map<String, Object>> readRows(ResultSet resultSet) throws SQLException {

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
@@ -27,6 +27,7 @@ import com.ctrip.framework.apollo.biz.entity.Release;
 import com.ctrip.framework.apollo.biz.entity.ReleaseHistory;
 import com.ctrip.framework.apollo.biz.repository.ReleaseHistoryRepository;
 import com.ctrip.framework.apollo.biz.repository.ReleaseRepository;
+import com.ctrip.framework.apollo.common.constants.NamespaceBranchStatus;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.lang.reflect.Method;
@@ -178,15 +179,36 @@ public class ReleaseHistoryServiceTest {
       executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
   @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   public void testCleanReleaseHistoryKeepsReleaseReferencedByActiveGrayReleaseRule() {
-    jdbcTemplate.update("INSERT INTO GrayReleaseRule "
-        + "(AppId, ClusterName, NamespaceName, BranchName, Rules, ReleaseId, BranchStatus) "
-        + "VALUES ('kl-app', 'default', 'application', 'default', '[]', 1, 1)");
+    jdbcTemplate.update(
+        "INSERT INTO GrayReleaseRule "
+            + "(AppId, ClusterName, NamespaceName, BranchName, Rules, ReleaseId, BranchStatus) "
+            + "VALUES ('kl-app', 'default', 'application', 'default', '[]', 1, ?)",
+        NamespaceBranchStatus.ACTIVE);
 
     invokeCleanReleaseHistory(1);
 
     Assert.assertEquals(1, countReleaseHistoryRows());
     Assert.assertEquals(3, countReleaseRows());
     Assert.assertTrue(releaseRepository.findById(1L).isPresent());
+  }
+
+  @Test
+  @Sql(scripts = "/sql/release-history-test.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCleanReleaseHistoryIgnoresInactiveGrayReleaseRules() {
+    jdbcTemplate.update(
+        "INSERT INTO GrayReleaseRule "
+            + "(AppId, ClusterName, NamespaceName, BranchName, Rules, ReleaseId, BranchStatus) "
+            + "VALUES ('kl-app', 'default', 'application', 'deleted', '[]', 1, ?), "
+            + "('kl-app', 'default', 'application', 'merged', '[]', 1, ?)",
+        NamespaceBranchStatus.DELETED, NamespaceBranchStatus.MERGED);
+
+    invokeCleanReleaseHistory(1);
+
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(2, countReleaseRows());
+    Assert.assertFalse(releaseRepository.findById(1L).isPresent());
   }
 
   @Test

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
@@ -104,7 +104,7 @@ public class ReleaseHistoryServiceTest {
   @Sql(scripts = "/sql/release-history-test.sql",
       executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
   @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-  public void testCleanReleaseHistory() {
+  public void testCleanReleaseHistoryPhysicallyDeletesUnreferencedRows() {
     ReleaseHistoryService service =
         (ReleaseHistoryService) AopProxyUtils.getSingletonTarget(releaseHistoryService);
     assert service != null;
@@ -125,24 +125,84 @@ public class ReleaseHistoryServiceTest {
     when(bizConfig.releaseHistoryRetentionSizeOverride()).thenReturn(Maps.newHashMap());
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(2, releaseHistoryRepository.count());
-    Assert.assertEquals(2, releaseRepository.count());
+    Assert.assertEquals(3, releaseRepository.count());
     Assert.assertEquals(2, countReleaseHistoryRows());
-    Assert.assertEquals(2, countReleaseRows());
+    Assert.assertEquals(3, countReleaseRows());
 
     when(bizConfig.releaseHistoryRetentionSize()).thenReturn(2);
     when(bizConfig.releaseHistoryRetentionSizeOverride())
         .thenReturn(ImmutableMap.of("kl-app+default+application+default", 1));
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(1, releaseHistoryRepository.count());
-    Assert.assertEquals(1, releaseRepository.count());
+    Assert.assertEquals(2, releaseRepository.count());
     Assert.assertEquals(1, countReleaseHistoryRows());
-    Assert.assertEquals(1, countReleaseRows());
+    Assert.assertEquals(2, countReleaseRows());
 
     Iterable<ReleaseHistory> historyList = releaseHistoryRepository.findAll();
     historyList.forEach(history -> Assert.assertEquals(6, history.getId()));
 
     Iterable<Release> releaseList = releaseRepository.findAll();
-    releaseList.forEach(release -> Assert.assertEquals(6, release.getId()));
+    releaseList.forEach(release -> Assert.assertTrue(release.getId() >= 5));
+  }
+
+  @Test
+  @Sql(scripts = "/sql/release-history-test.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCleanReleaseHistoryKeepsReleaseReferencedByRetainedHistory() {
+    jdbcTemplate
+        .update("UPDATE ReleaseHistory SET ReleaseId = 1, PreviousReleaseId = 5 WHERE Id = 6");
+
+    invokeCleanReleaseHistory(1);
+
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(3, countReleaseRows());
+    Assert.assertTrue(releaseRepository.findById(1L).isPresent());
+  }
+
+  @Test
+  @Sql(scripts = "/sql/release-history-test.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCleanReleaseHistoryKeepsPreviousReleaseOfRetainedHistory() {
+    invokeCleanReleaseHistory(1);
+
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(2, countReleaseRows());
+    Assert.assertTrue(releaseRepository.findById(5L).isPresent());
+    Assert.assertTrue(releaseRepository.findById(6L).isPresent());
+  }
+
+  @Test
+  @Sql(scripts = "/sql/release-history-test.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCleanReleaseHistoryKeepsReleaseReferencedByActiveGrayReleaseRule() {
+    jdbcTemplate.update("INSERT INTO GrayReleaseRule "
+        + "(AppId, ClusterName, NamespaceName, BranchName, Rules, ReleaseId, BranchStatus) "
+        + "VALUES ('kl-app', 'default', 'application', 'default', '[]', 1, 1)");
+
+    invokeCleanReleaseHistory(1);
+
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(3, countReleaseRows());
+    Assert.assertTrue(releaseRepository.findById(1L).isPresent());
+  }
+
+  @Test
+  @Sql(scripts = "/sql/release-history-test.sql",
+      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCleanReleaseHistoryLeavesLegacySoftDeletedRowsForMigrationScript() {
+    jdbcTemplate.update("UPDATE ReleaseHistory SET IsDeleted = true, DeletedAt = 1 WHERE Id <= 4");
+    jdbcTemplate.update("UPDATE \"Release\" SET IsDeleted = true, DeletedAt = 1 WHERE Id <= 4");
+
+    invokeCleanReleaseHistory(2);
+
+    Assert.assertEquals(2, releaseHistoryRepository.count());
+    Assert.assertEquals(6, countReleaseHistoryRows());
+    Assert.assertEquals(2, releaseRepository.count());
+    Assert.assertEquals(6, countReleaseRows());
   }
 
   @Test
@@ -162,7 +222,7 @@ public class ReleaseHistoryServiceTest {
     when(bizConfig.releaseHistoryRetentionSizeOverride()).thenReturn(Maps.newHashMap());
     ReflectionTestUtils.setField(releaseHistoryService, "releaseRepository", mockReleaseRepository);
     doThrow(new JDBCConnectionException("error", new SQLException("sql")))
-        .when(mockReleaseRepository).deletePhysicallyByIdIn(any());
+        .when(mockReleaseRepository).deletePhysicallyIfUnreferencedByIdIn(any());
     Assert.assertThrows(JDBCConnectionException.class,
         () -> ReflectionUtils.invokeMethod(method, service, mockReleaseHistory));
 
@@ -175,9 +235,23 @@ public class ReleaseHistoryServiceTest {
 
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(1, releaseHistoryRepository.count());
-    Assert.assertEquals(1, releaseRepository.count());
+    Assert.assertEquals(2, releaseRepository.count());
     Assert.assertEquals(1, countReleaseHistoryRows());
-    Assert.assertEquals(1, countReleaseRows());
+    Assert.assertEquals(2, countReleaseRows());
+  }
+
+  private void invokeCleanReleaseHistory(int retentionSize) {
+    ReleaseHistoryService service =
+        (ReleaseHistoryService) AopProxyUtils.getSingletonTarget(releaseHistoryService);
+    assert service != null;
+    Method method =
+        ReflectionUtils.findMethod(service.getClass(), "cleanReleaseHistory", ReleaseHistory.class);
+    assert method != null;
+    ReflectionUtils.makeAccessible(method);
+
+    when(bizConfig.releaseHistoryRetentionSize()).thenReturn(retentionSize);
+    when(bizConfig.releaseHistoryRetentionSizeOverride()).thenReturn(Maps.newHashMap());
+    ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
   }
 
   private int countReleaseHistoryRows() {

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseHistoryServiceTest.java
@@ -43,6 +43,7 @@ import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.jdbc.Sql;
@@ -78,6 +79,8 @@ public class ReleaseHistoryServiceTest {
   private ReleaseHistoryRepository releaseHistoryRepository;
   @Autowired
   private ReleaseRepository releaseRepository;
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
 
   @Before
   public void setUp() throws Exception {
@@ -115,12 +118,16 @@ public class ReleaseHistoryServiceTest {
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(6, releaseHistoryRepository.count());
     Assert.assertEquals(6, releaseRepository.count());
+    Assert.assertEquals(6, countReleaseHistoryRows());
+    Assert.assertEquals(6, countReleaseRows());
 
     when(bizConfig.releaseHistoryRetentionSize()).thenReturn(2);
     when(bizConfig.releaseHistoryRetentionSizeOverride()).thenReturn(Maps.newHashMap());
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(2, releaseHistoryRepository.count());
     Assert.assertEquals(2, releaseRepository.count());
+    Assert.assertEquals(2, countReleaseHistoryRows());
+    Assert.assertEquals(2, countReleaseRows());
 
     when(bizConfig.releaseHistoryRetentionSize()).thenReturn(2);
     when(bizConfig.releaseHistoryRetentionSizeOverride())
@@ -128,6 +135,8 @@ public class ReleaseHistoryServiceTest {
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(1, releaseHistoryRepository.count());
     Assert.assertEquals(1, releaseRepository.count());
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(1, countReleaseRows());
 
     Iterable<ReleaseHistory> historyList = releaseHistoryRepository.findAll();
     historyList.forEach(history -> Assert.assertEquals(6, history.getId()));
@@ -153,18 +162,30 @@ public class ReleaseHistoryServiceTest {
     when(bizConfig.releaseHistoryRetentionSizeOverride()).thenReturn(Maps.newHashMap());
     ReflectionTestUtils.setField(releaseHistoryService, "releaseRepository", mockReleaseRepository);
     doThrow(new JDBCConnectionException("error", new SQLException("sql")))
-        .when(mockReleaseRepository).deleteAllById(any());
+        .when(mockReleaseRepository).deletePhysicallyByIdIn(any());
     Assert.assertThrows(JDBCConnectionException.class,
         () -> ReflectionUtils.invokeMethod(method, service, mockReleaseHistory));
 
     Assert.assertEquals(6, releaseHistoryRepository.count());
+    Assert.assertEquals(6, countReleaseHistoryRows());
 
     ReflectionTestUtils.setField(releaseHistoryService, "releaseRepository", releaseRepository);
     Assert.assertEquals(6, releaseRepository.count());
+    Assert.assertEquals(6, countReleaseRows());
 
     ReflectionUtils.invokeMethod(method, service, mockReleaseHistory);
     Assert.assertEquals(1, releaseHistoryRepository.count());
     Assert.assertEquals(1, releaseRepository.count());
+    Assert.assertEquals(1, countReleaseHistoryRows());
+    Assert.assertEquals(1, countReleaseRows());
+  }
+
+  private int countReleaseHistoryRows() {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM ReleaseHistory", Integer.class);
+  }
+
+  private int countReleaseRows() {
+    return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM \"Release\"", Integer.class);
   }
 
 }

--- a/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
+++ b/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
@@ -15,8 +15,10 @@
 --
 
 -- Run this read-only precheck against ApolloConfigDB.
--- A soft-deleted release must be restored when an active release history or
--- active gray release rule still references it.
+-- A soft-deleted release from the current active Namespace incarnation must be
+-- restored when an active release history or active gray release rule still
+-- references it. DeletedAt provides the millisecond-resolution incarnation
+-- boundary: namespace deletion soft-deletes releases before the Namespace row.
 
 SELECT COUNT(*) AS `ReleasesNeedingRestore`,
        COALESCE(SUM(EXISTS (
@@ -28,6 +30,23 @@ SELECT COUNT(*) AS `ReleasesNeedingRestore`,
        )), 0) AS `ActiveReleaseKeyConflicts`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = r.`AppId`
+      AND active_namespace.`ClusterName` = r.`ClusterName`
+      AND active_namespace.`NamespaceName` = r.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = r.`AppId`
+      AND deleted_namespace.`ClusterName` = r.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
+  )
   AND (
     EXISTS (
       SELECT 1
@@ -79,6 +98,23 @@ SELECT r.`Id`,
        ) AS `ActiveReleaseKeyConflict`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = r.`AppId`
+      AND active_namespace.`ClusterName` = r.`ClusterName`
+      AND active_namespace.`NamespaceName` = r.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = r.`AppId`
+      AND deleted_namespace.`ClusterName` = r.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
+  )
   AND (
     EXISTS (
       SELECT 1

--- a/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
+++ b/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
@@ -39,6 +39,7 @@ WHERE r.`IsDeleted` = TRUE
       SELECT 1
       FROM `GrayReleaseRule` g
       WHERE g.`IsDeleted` = FALSE
+        AND g.`BranchStatus` = 1
         AND g.`ReleaseId` = r.`Id`
     )
   );
@@ -66,6 +67,7 @@ SELECT r.`Id`,
          SELECT 1
          FROM `GrayReleaseRule` g
          WHERE g.`IsDeleted` = FALSE
+           AND g.`BranchStatus` = 1
            AND g.`ReleaseId` = r.`Id`
        ) AS `ReferencedByGrayReleaseRule`,
        EXISTS (
@@ -88,6 +90,7 @@ WHERE r.`IsDeleted` = TRUE
       SELECT 1
       FROM `GrayReleaseRule` g
       WHERE g.`IsDeleted` = FALSE
+        AND g.`BranchStatus` = 1
         AND g.`ReleaseId` = r.`Id`
     )
   )

--- a/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
+++ b/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
@@ -19,6 +19,7 @@
 -- restored when an active release history or active gray release rule still
 -- references it. DeletedAt provides the millisecond-resolution incarnation
 -- boundary: namespace deletion soft-deletes releases before the Namespace row.
+-- ReleaseId and PreviousReleaseId checks are split so MySQL 5.7 can use both indexes.
 
 SELECT COUNT(*) AS `ReleasesNeedingRestore`,
        COALESCE(SUM(EXISTS (
@@ -50,9 +51,15 @@ WHERE r.`IsDeleted` = TRUE
   AND (
     EXISTS (
       SELECT 1
-      FROM `ReleaseHistory` h
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
       WHERE h.`IsDeleted` = FALSE
-        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+        AND h.`ReleaseId` = r.`Id`
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+      WHERE h.`IsDeleted` = FALSE
+        AND h.`PreviousReleaseId` = r.`Id`
     )
     OR EXISTS (
       SELECT 1
@@ -72,13 +79,13 @@ SELECT r.`Id`,
        r.`NamespaceName`,
        EXISTS (
          SELECT 1
-         FROM `ReleaseHistory` h
+         FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
          WHERE h.`IsDeleted` = FALSE
            AND h.`ReleaseId` = r.`Id`
        ) AS `ReferencedByReleaseHistory`,
        EXISTS (
          SELECT 1
-         FROM `ReleaseHistory` h
+         FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
          WHERE h.`IsDeleted` = FALSE
            AND h.`PreviousReleaseId` = r.`Id`
        ) AS `ReferencedAsPreviousRelease`,
@@ -118,9 +125,15 @@ WHERE r.`IsDeleted` = TRUE
   AND (
     EXISTS (
       SELECT 1
-      FROM `ReleaseHistory` h
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
       WHERE h.`IsDeleted` = FALSE
-        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+        AND h.`ReleaseId` = r.`Id`
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+      WHERE h.`IsDeleted` = FALSE
+        AND h.`PreviousReleaseId` = r.`Id`
     )
     OR EXISTS (
       SELECT 1

--- a/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
+++ b/scripts/sql/migration/release-history-retention/01-precheck-releases-needing-restore.sql
@@ -1,0 +1,95 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Run this read-only precheck against ApolloConfigDB.
+-- A soft-deleted release must be restored when an active release history or
+-- active gray release rule still references it.
+
+SELECT COUNT(*) AS `ReleasesNeedingRestore`,
+       COALESCE(SUM(EXISTS (
+         SELECT 1
+         FROM `Release` active_release
+         WHERE active_release.`ReleaseKey` = r.`ReleaseKey`
+           AND active_release.`DeletedAt` = 0
+           AND active_release.`Id` <> r.`Id`
+       )), 0) AS `ActiveReleaseKeyConflicts`
+FROM `Release` r
+WHERE r.`IsDeleted` = TRUE
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h
+      WHERE h.`IsDeleted` = FALSE
+        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `GrayReleaseRule` g
+      WHERE g.`IsDeleted` = FALSE
+        AND g.`ReleaseId` = r.`Id`
+    )
+  );
+
+-- Inspect at most 100 affected releases. ActiveReleaseKeyConflict must be 0
+-- before running the restore script because DeletedAt is reset to 0.
+SELECT r.`Id`,
+       r.`ReleaseKey`,
+       r.`AppId`,
+       r.`ClusterName`,
+       r.`NamespaceName`,
+       EXISTS (
+         SELECT 1
+         FROM `ReleaseHistory` h
+         WHERE h.`IsDeleted` = FALSE
+           AND h.`ReleaseId` = r.`Id`
+       ) AS `ReferencedByReleaseHistory`,
+       EXISTS (
+         SELECT 1
+         FROM `ReleaseHistory` h
+         WHERE h.`IsDeleted` = FALSE
+           AND h.`PreviousReleaseId` = r.`Id`
+       ) AS `ReferencedAsPreviousRelease`,
+       EXISTS (
+         SELECT 1
+         FROM `GrayReleaseRule` g
+         WHERE g.`IsDeleted` = FALSE
+           AND g.`ReleaseId` = r.`Id`
+       ) AS `ReferencedByGrayReleaseRule`,
+       EXISTS (
+         SELECT 1
+         FROM `Release` active_release
+         WHERE active_release.`ReleaseKey` = r.`ReleaseKey`
+           AND active_release.`DeletedAt` = 0
+           AND active_release.`Id` <> r.`Id`
+       ) AS `ActiveReleaseKeyConflict`
+FROM `Release` r
+WHERE r.`IsDeleted` = TRUE
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h
+      WHERE h.`IsDeleted` = FALSE
+        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `GrayReleaseRule` g
+      WHERE g.`IsDeleted` = FALSE
+        AND g.`ReleaseId` = r.`Id`
+    )
+  )
+ORDER BY r.`Id`
+LIMIT 100;

--- a/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
@@ -93,6 +93,7 @@ WHERE r.`IsDeleted` = TRUE;
 
 -- These retention-scoped release rows can be physically deleted now. More rows
 -- may become eligible after retention-generated release histories are purged.
+-- Separate index-forced checks avoid the MySQL 5.7 full scan caused by an OR predicate.
 SELECT COUNT(*) AS `RetentionReleaseRowsEligibleForDeletion`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
@@ -115,9 +116,13 @@ WHERE r.`IsDeleted` = TRUE
   )
   AND NOT EXISTS (
     SELECT 1
-    FROM `ReleaseHistory` h
+    FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
     WHERE h.`ReleaseId` = r.`Id`
-       OR h.`PreviousReleaseId` = r.`Id`
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+    WHERE h.`PreviousReleaseId` = r.`Id`
   )
   AND NOT EXISTS (
     SELECT 1

--- a/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
@@ -1,0 +1,57 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Run this read-only precheck against ApolloConfigDB.
+
+SELECT COUNT(*) AS `SoftDeletedReleaseHistoryRows`
+FROM `ReleaseHistory`
+WHERE `IsDeleted` = TRUE;
+
+SELECT COUNT(*) AS `SoftDeletedReleaseRows`
+FROM `Release`
+WHERE `IsDeleted` = TRUE;
+
+-- These release rows can be physically deleted now. More rows may become
+-- eligible after soft-deleted release histories are purged.
+SELECT COUNT(*) AS `SoftDeletedReleaseRowsEligibleForDeletion`
+FROM `Release` r
+WHERE r.`IsDeleted` = TRUE
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `ReleaseHistory` h
+    WHERE h.`ReleaseId` = r.`Id`
+       OR h.`PreviousReleaseId` = r.`Id`
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `GrayReleaseRule` g
+    WHERE g.`IsDeleted` = FALSE
+      AND g.`ReleaseId` = r.`Id`
+  );
+
+-- Show the oldest affected namespaces to help estimate cleanup scope.
+SELECT `AppId`,
+       `ClusterName`,
+       `NamespaceName`,
+       `BranchName`,
+       COUNT(*) AS `SoftDeletedRows`,
+       MIN(`Id`) AS `OldestId`,
+       MAX(`Id`) AS `NewestId`
+FROM `ReleaseHistory`
+WHERE `IsDeleted` = TRUE
+GROUP BY `AppId`, `ClusterName`, `NamespaceName`, `BranchName`
+ORDER BY `SoftDeletedRows` DESC
+LIMIT 100;

--- a/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
@@ -15,28 +15,42 @@
 --
 
 -- Run this read-only precheck against ApolloConfigDB. Retention cleanup candidates
--- must belong to the current active Namespace incarnation and must have been
--- soft-deleted after that Namespace was created. This excludes normal namespace
--- deletion rows and rows left by an older, subsequently recreated Namespace.
+-- must belong to the current active Namespace incarnation. The millisecond-resolution
+-- DeletedAt boundary excludes normal namespace deletion rows and rows left by an
+-- older, subsequently recreated Namespace, including same-second recreation.
 
 SELECT COUNT(*) AS `SoftDeletedReleaseHistoryRows`,
        COALESCE(SUM(EXISTS (
          SELECT 1
-         FROM `Namespace` n
-         WHERE n.`AppId` = h.`AppId`
-           AND n.`ClusterName` = h.`ClusterName`
-           AND n.`NamespaceName` = h.`NamespaceName`
-           AND n.`IsDeleted` = FALSE
-           AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+         FROM `Namespace` active_namespace
+         WHERE active_namespace.`AppId` = h.`AppId`
+           AND active_namespace.`ClusterName` = h.`ClusterName`
+           AND active_namespace.`NamespaceName` = h.`NamespaceName`
+           AND active_namespace.`IsDeleted` = FALSE
+       ) AND NOT EXISTS (
+         SELECT 1
+         FROM `Namespace` deleted_namespace
+         WHERE deleted_namespace.`AppId` = h.`AppId`
+           AND deleted_namespace.`ClusterName` = h.`ClusterName`
+           AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+           AND deleted_namespace.`IsDeleted` = TRUE
+           AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
        )), 0) AS `RetentionReleaseHistoryPurgeCandidates`,
        COALESCE(SUM(NOT EXISTS (
          SELECT 1
-         FROM `Namespace` n
-         WHERE n.`AppId` = h.`AppId`
-           AND n.`ClusterName` = h.`ClusterName`
-           AND n.`NamespaceName` = h.`NamespaceName`
-           AND n.`IsDeleted` = FALSE
-           AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+         FROM `Namespace` active_namespace
+         WHERE active_namespace.`AppId` = h.`AppId`
+           AND active_namespace.`ClusterName` = h.`ClusterName`
+           AND active_namespace.`NamespaceName` = h.`NamespaceName`
+           AND active_namespace.`IsDeleted` = FALSE
+       ) OR EXISTS (
+         SELECT 1
+         FROM `Namespace` deleted_namespace
+         WHERE deleted_namespace.`AppId` = h.`AppId`
+           AND deleted_namespace.`ClusterName` = h.`ClusterName`
+           AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+           AND deleted_namespace.`IsDeleted` = TRUE
+           AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
        )), 0) AS `ExcludedSoftDeletedReleaseHistoryRows`
 FROM `ReleaseHistory` h
 WHERE h.`IsDeleted` = TRUE;
@@ -44,21 +58,35 @@ WHERE h.`IsDeleted` = TRUE;
 SELECT COUNT(*) AS `SoftDeletedReleaseRows`,
        COALESCE(SUM(EXISTS (
          SELECT 1
-         FROM `Namespace` n
-         WHERE n.`AppId` = r.`AppId`
-           AND n.`ClusterName` = r.`ClusterName`
-           AND n.`NamespaceName` = r.`NamespaceName`
-           AND n.`IsDeleted` = FALSE
-           AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+         FROM `Namespace` active_namespace
+         WHERE active_namespace.`AppId` = r.`AppId`
+           AND active_namespace.`ClusterName` = r.`ClusterName`
+           AND active_namespace.`NamespaceName` = r.`NamespaceName`
+           AND active_namespace.`IsDeleted` = FALSE
+       ) AND NOT EXISTS (
+         SELECT 1
+         FROM `Namespace` deleted_namespace
+         WHERE deleted_namespace.`AppId` = r.`AppId`
+           AND deleted_namespace.`ClusterName` = r.`ClusterName`
+           AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+           AND deleted_namespace.`IsDeleted` = TRUE
+           AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
        )), 0) AS `RetentionScopedSoftDeletedReleaseRows`,
        COALESCE(SUM(NOT EXISTS (
          SELECT 1
-         FROM `Namespace` n
-         WHERE n.`AppId` = r.`AppId`
-           AND n.`ClusterName` = r.`ClusterName`
-           AND n.`NamespaceName` = r.`NamespaceName`
-           AND n.`IsDeleted` = FALSE
-           AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+         FROM `Namespace` active_namespace
+         WHERE active_namespace.`AppId` = r.`AppId`
+           AND active_namespace.`ClusterName` = r.`ClusterName`
+           AND active_namespace.`NamespaceName` = r.`NamespaceName`
+           AND active_namespace.`IsDeleted` = FALSE
+       ) OR EXISTS (
+         SELECT 1
+         FROM `Namespace` deleted_namespace
+         WHERE deleted_namespace.`AppId` = r.`AppId`
+           AND deleted_namespace.`ClusterName` = r.`ClusterName`
+           AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+           AND deleted_namespace.`IsDeleted` = TRUE
+           AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
        )), 0) AS `ExcludedSoftDeletedReleaseRows`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE;
@@ -70,12 +98,20 @@ FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
   AND EXISTS (
     SELECT 1
-    FROM `Namespace` n
-    WHERE n.`AppId` = r.`AppId`
-      AND n.`ClusterName` = r.`ClusterName`
-      AND n.`NamespaceName` = r.`NamespaceName`
-      AND n.`IsDeleted` = FALSE
-      AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = r.`AppId`
+      AND active_namespace.`ClusterName` = r.`ClusterName`
+      AND active_namespace.`NamespaceName` = r.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = r.`AppId`
+      AND deleted_namespace.`ClusterName` = r.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
   )
   AND NOT EXISTS (
     SELECT 1
@@ -103,12 +139,20 @@ FROM `ReleaseHistory` h
 WHERE h.`IsDeleted` = TRUE
   AND EXISTS (
     SELECT 1
-    FROM `Namespace` n
-    WHERE n.`AppId` = h.`AppId`
-      AND n.`ClusterName` = h.`ClusterName`
-      AND n.`NamespaceName` = h.`NamespaceName`
-      AND n.`IsDeleted` = FALSE
-      AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = h.`AppId`
+      AND active_namespace.`ClusterName` = h.`ClusterName`
+      AND active_namespace.`NamespaceName` = h.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = h.`AppId`
+      AND deleted_namespace.`ClusterName` = h.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
   )
 GROUP BY h.`AppId`, h.`ClusterName`, h.`NamespaceName`, h.`BranchName`
 ORDER BY `SoftDeletedRows` DESC

--- a/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/02-precheck-soft-deleted-rows.sql
@@ -14,21 +14,69 @@
 -- limitations under the License.
 --
 
--- Run this read-only precheck against ApolloConfigDB.
+-- Run this read-only precheck against ApolloConfigDB. Retention cleanup candidates
+-- must belong to the current active Namespace incarnation and must have been
+-- soft-deleted after that Namespace was created. This excludes normal namespace
+-- deletion rows and rows left by an older, subsequently recreated Namespace.
 
-SELECT COUNT(*) AS `SoftDeletedReleaseHistoryRows`
-FROM `ReleaseHistory`
-WHERE `IsDeleted` = TRUE;
+SELECT COUNT(*) AS `SoftDeletedReleaseHistoryRows`,
+       COALESCE(SUM(EXISTS (
+         SELECT 1
+         FROM `Namespace` n
+         WHERE n.`AppId` = h.`AppId`
+           AND n.`ClusterName` = h.`ClusterName`
+           AND n.`NamespaceName` = h.`NamespaceName`
+           AND n.`IsDeleted` = FALSE
+           AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+       )), 0) AS `RetentionReleaseHistoryPurgeCandidates`,
+       COALESCE(SUM(NOT EXISTS (
+         SELECT 1
+         FROM `Namespace` n
+         WHERE n.`AppId` = h.`AppId`
+           AND n.`ClusterName` = h.`ClusterName`
+           AND n.`NamespaceName` = h.`NamespaceName`
+           AND n.`IsDeleted` = FALSE
+           AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+       )), 0) AS `ExcludedSoftDeletedReleaseHistoryRows`
+FROM `ReleaseHistory` h
+WHERE h.`IsDeleted` = TRUE;
 
-SELECT COUNT(*) AS `SoftDeletedReleaseRows`
-FROM `Release`
-WHERE `IsDeleted` = TRUE;
+SELECT COUNT(*) AS `SoftDeletedReleaseRows`,
+       COALESCE(SUM(EXISTS (
+         SELECT 1
+         FROM `Namespace` n
+         WHERE n.`AppId` = r.`AppId`
+           AND n.`ClusterName` = r.`ClusterName`
+           AND n.`NamespaceName` = r.`NamespaceName`
+           AND n.`IsDeleted` = FALSE
+           AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+       )), 0) AS `RetentionScopedSoftDeletedReleaseRows`,
+       COALESCE(SUM(NOT EXISTS (
+         SELECT 1
+         FROM `Namespace` n
+         WHERE n.`AppId` = r.`AppId`
+           AND n.`ClusterName` = r.`ClusterName`
+           AND n.`NamespaceName` = r.`NamespaceName`
+           AND n.`IsDeleted` = FALSE
+           AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+       )), 0) AS `ExcludedSoftDeletedReleaseRows`
+FROM `Release` r
+WHERE r.`IsDeleted` = TRUE;
 
--- These release rows can be physically deleted now. More rows may become
--- eligible after soft-deleted release histories are purged.
-SELECT COUNT(*) AS `SoftDeletedReleaseRowsEligibleForDeletion`
+-- These retention-scoped release rows can be physically deleted now. More rows
+-- may become eligible after retention-generated release histories are purged.
+SELECT COUNT(*) AS `RetentionReleaseRowsEligibleForDeletion`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` n
+    WHERE n.`AppId` = r.`AppId`
+      AND n.`ClusterName` = r.`ClusterName`
+      AND n.`NamespaceName` = r.`NamespaceName`
+      AND n.`IsDeleted` = FALSE
+      AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+  )
   AND NOT EXISTS (
     SELECT 1
     FROM `ReleaseHistory` h
@@ -39,19 +87,29 @@ WHERE r.`IsDeleted` = TRUE
     SELECT 1
     FROM `GrayReleaseRule` g
     WHERE g.`IsDeleted` = FALSE
+      AND g.`BranchStatus` = 1
       AND g.`ReleaseId` = r.`Id`
   );
 
--- Show the oldest affected namespaces to help estimate cleanup scope.
-SELECT `AppId`,
-       `ClusterName`,
-       `NamespaceName`,
-       `BranchName`,
+-- Show the oldest retention-scoped namespace branches to help estimate cleanup scope.
+SELECT h.`AppId`,
+       h.`ClusterName`,
+       h.`NamespaceName`,
+       h.`BranchName`,
        COUNT(*) AS `SoftDeletedRows`,
-       MIN(`Id`) AS `OldestId`,
-       MAX(`Id`) AS `NewestId`
-FROM `ReleaseHistory`
-WHERE `IsDeleted` = TRUE
-GROUP BY `AppId`, `ClusterName`, `NamespaceName`, `BranchName`
+       MIN(h.`Id`) AS `OldestId`,
+       MAX(h.`Id`) AS `NewestId`
+FROM `ReleaseHistory` h
+WHERE h.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` n
+    WHERE n.`AppId` = h.`AppId`
+      AND n.`ClusterName` = h.`ClusterName`
+      AND n.`NamespaceName` = h.`NamespaceName`
+      AND n.`IsDeleted` = FALSE
+      AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+  )
+GROUP BY h.`AppId`, h.`ClusterName`, h.`NamespaceName`, h.`BranchName`
 ORDER BY `SoftDeletedRows` DESC
 LIMIT 100;

--- a/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
+++ b/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
@@ -1,0 +1,64 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Run this script against ApolloConfigDB after the restore precheck.
+-- It restores at most 1000 releases per execution and is safe to rerun.
+
+SET AUTOCOMMIT = FALSE;
+
+UPDATE `Release` r
+SET `IsDeleted` = FALSE,
+    `DeletedAt` = 0,
+    `DataChange_LastModifiedBy` = 'release-history-retention-migration'
+WHERE r.`IsDeleted` = TRUE
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h
+      WHERE h.`IsDeleted` = FALSE
+        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `GrayReleaseRule` g
+      WHERE g.`IsDeleted` = FALSE
+        AND g.`ReleaseId` = r.`Id`
+    )
+  )
+ORDER BY r.`Id`
+LIMIT 1000;
+
+COMMIT;
+
+SET AUTOCOMMIT = TRUE;
+
+SELECT COUNT(*) AS `RemainingReleasesNeedingRestore`
+FROM `Release` r
+WHERE r.`IsDeleted` = TRUE
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h
+      WHERE h.`IsDeleted` = FALSE
+        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `GrayReleaseRule` g
+      WHERE g.`IsDeleted` = FALSE
+        AND g.`ReleaseId` = r.`Id`
+    )
+  );

--- a/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
+++ b/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
@@ -35,6 +35,7 @@ WHERE r.`IsDeleted` = TRUE
       SELECT 1
       FROM `GrayReleaseRule` g
       WHERE g.`IsDeleted` = FALSE
+        AND g.`BranchStatus` = 1
         AND g.`ReleaseId` = r.`Id`
     )
   )
@@ -59,6 +60,7 @@ WHERE r.`IsDeleted` = TRUE
       SELECT 1
       FROM `GrayReleaseRule` g
       WHERE g.`IsDeleted` = FALSE
+        AND g.`BranchStatus` = 1
         AND g.`ReleaseId` = r.`Id`
     )
   );

--- a/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
+++ b/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
@@ -18,6 +18,7 @@
 -- restores releases from the current active Namespace incarnation, using the
 -- millisecond-resolution DeletedAt boundary. It restores at most 1000 releases
 -- per execution and is safe to rerun.
+-- ReleaseId and PreviousReleaseId checks are split so MySQL 5.7 can use both indexes.
 
 SET AUTOCOMMIT = FALSE;
 
@@ -46,9 +47,15 @@ WHERE r.`IsDeleted` = TRUE
   AND (
     EXISTS (
       SELECT 1
-      FROM `ReleaseHistory` h
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
       WHERE h.`IsDeleted` = FALSE
-        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+        AND h.`ReleaseId` = r.`Id`
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+      WHERE h.`IsDeleted` = FALSE
+        AND h.`PreviousReleaseId` = r.`Id`
     )
     OR EXISTS (
       SELECT 1
@@ -88,9 +95,15 @@ WHERE r.`IsDeleted` = TRUE
   AND (
     EXISTS (
       SELECT 1
-      FROM `ReleaseHistory` h
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
       WHERE h.`IsDeleted` = FALSE
-        AND (h.`ReleaseId` = r.`Id` OR h.`PreviousReleaseId` = r.`Id`)
+        AND h.`ReleaseId` = r.`Id`
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+      WHERE h.`IsDeleted` = FALSE
+        AND h.`PreviousReleaseId` = r.`Id`
     )
     OR EXISTS (
       SELECT 1

--- a/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
+++ b/scripts/sql/migration/release-history-retention/03-restore-referenced-releases.sql
@@ -14,8 +14,10 @@
 -- limitations under the License.
 --
 
--- Run this script against ApolloConfigDB after the restore precheck.
--- It restores at most 1000 releases per execution and is safe to rerun.
+-- Run this script against ApolloConfigDB after the restore precheck. It only
+-- restores releases from the current active Namespace incarnation, using the
+-- millisecond-resolution DeletedAt boundary. It restores at most 1000 releases
+-- per execution and is safe to rerun.
 
 SET AUTOCOMMIT = FALSE;
 
@@ -24,6 +26,23 @@ SET `IsDeleted` = FALSE,
     `DeletedAt` = 0,
     `DataChange_LastModifiedBy` = 'release-history-retention-migration'
 WHERE r.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = r.`AppId`
+      AND active_namespace.`ClusterName` = r.`ClusterName`
+      AND active_namespace.`NamespaceName` = r.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = r.`AppId`
+      AND deleted_namespace.`ClusterName` = r.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
+  )
   AND (
     EXISTS (
       SELECT 1
@@ -49,6 +68,23 @@ SET AUTOCOMMIT = TRUE;
 SELECT COUNT(*) AS `RemainingReleasesNeedingRestore`
 FROM `Release` r
 WHERE r.`IsDeleted` = TRUE
+  AND EXISTS (
+    SELECT 1
+    FROM `Namespace` active_namespace
+    WHERE active_namespace.`AppId` = r.`AppId`
+      AND active_namespace.`ClusterName` = r.`ClusterName`
+      AND active_namespace.`NamespaceName` = r.`NamespaceName`
+      AND active_namespace.`IsDeleted` = FALSE
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `Namespace` deleted_namespace
+    WHERE deleted_namespace.`AppId` = r.`AppId`
+      AND deleted_namespace.`ClusterName` = r.`ClusterName`
+      AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+      AND deleted_namespace.`IsDeleted` = TRUE
+      AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
+  )
   AND (
     EXISTS (
       SELECT 1

--- a/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
@@ -1,0 +1,68 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Run this script against ApolloConfigDB only after referenced releases have
+-- been restored. It deletes at most 1000 rows from each table per execution
+-- and is safe to rerun until both reported counts are 0.
+
+SET AUTOCOMMIT = FALSE;
+
+DELETE FROM `ReleaseHistory`
+WHERE `Id` IN (
+  SELECT `Id`
+  FROM (
+    SELECT `Id`
+    FROM `ReleaseHistory`
+    WHERE `IsDeleted` = TRUE
+    ORDER BY `Id`
+    LIMIT 1000
+  ) release_history_batch
+);
+
+DELETE FROM `Release`
+WHERE `Id` IN (
+  SELECT `Id`
+  FROM (
+    SELECT r.`Id`
+    FROM `Release` r
+    WHERE r.`IsDeleted` = TRUE
+      AND NOT EXISTS (
+        SELECT 1
+        FROM `ReleaseHistory` h
+        WHERE h.`ReleaseId` = r.`Id`
+           OR h.`PreviousReleaseId` = r.`Id`
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM `GrayReleaseRule` g
+        WHERE g.`IsDeleted` = FALSE
+          AND g.`ReleaseId` = r.`Id`
+      )
+    ORDER BY r.`Id`
+    LIMIT 1000
+  ) release_batch
+);
+
+COMMIT;
+
+SET AUTOCOMMIT = TRUE;
+
+SELECT (SELECT COUNT(*)
+        FROM `ReleaseHistory`
+        WHERE `IsDeleted` = TRUE) AS `RemainingSoftDeletedReleaseHistoryRows`,
+       (SELECT COUNT(*)
+        FROM `Release`
+        WHERE `IsDeleted` = TRUE) AS `RemainingSoftDeletedReleaseRows`;

--- a/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
@@ -15,8 +15,9 @@
 --
 
 -- Run this script against ApolloConfigDB only after referenced releases have
--- been restored. It deletes at most 1000 rows from each table per execution
--- and is safe to rerun until both reported counts are 0.
+-- been restored. It only purges rows belonging to the current active Namespace
+-- incarnation and soft-deleted after that Namespace was created. It deletes at
+-- most 1000 rows from each table per execution and is safe to rerun.
 
 SET AUTOCOMMIT = FALSE;
 
@@ -24,10 +25,19 @@ DELETE FROM `ReleaseHistory`
 WHERE `Id` IN (
   SELECT `Id`
   FROM (
-    SELECT `Id`
-    FROM `ReleaseHistory`
-    WHERE `IsDeleted` = TRUE
-    ORDER BY `Id`
+    SELECT h.`Id`
+    FROM `ReleaseHistory` h
+    WHERE h.`IsDeleted` = TRUE
+      AND EXISTS (
+        SELECT 1
+        FROM `Namespace` n
+        WHERE n.`AppId` = h.`AppId`
+          AND n.`ClusterName` = h.`ClusterName`
+          AND n.`NamespaceName` = h.`NamespaceName`
+          AND n.`IsDeleted` = FALSE
+          AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+      )
+    ORDER BY h.`Id`
     LIMIT 1000
   ) release_history_batch
 );
@@ -39,6 +49,15 @@ WHERE `Id` IN (
     SELECT r.`Id`
     FROM `Release` r
     WHERE r.`IsDeleted` = TRUE
+      AND EXISTS (
+        SELECT 1
+        FROM `Namespace` n
+        WHERE n.`AppId` = r.`AppId`
+          AND n.`ClusterName` = r.`ClusterName`
+          AND n.`NamespaceName` = r.`NamespaceName`
+          AND n.`IsDeleted` = FALSE
+          AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+      )
       AND NOT EXISTS (
         SELECT 1
         FROM `ReleaseHistory` h
@@ -49,6 +68,7 @@ WHERE `Id` IN (
         SELECT 1
         FROM `GrayReleaseRule` g
         WHERE g.`IsDeleted` = FALSE
+          AND g.`BranchStatus` = 1
           AND g.`ReleaseId` = r.`Id`
       )
     ORDER BY r.`Id`
@@ -61,8 +81,50 @@ COMMIT;
 SET AUTOCOMMIT = TRUE;
 
 SELECT (SELECT COUNT(*)
-        FROM `ReleaseHistory`
-        WHERE `IsDeleted` = TRUE) AS `RemainingSoftDeletedReleaseHistoryRows`,
+        FROM `ReleaseHistory` h
+        WHERE h.`IsDeleted` = TRUE
+          AND EXISTS (
+            SELECT 1
+            FROM `Namespace` n
+            WHERE n.`AppId` = h.`AppId`
+              AND n.`ClusterName` = h.`ClusterName`
+              AND n.`NamespaceName` = h.`NamespaceName`
+              AND n.`IsDeleted` = FALSE
+              AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+          )) AS `RemainingRetentionReleaseHistoryRows`,
        (SELECT COUNT(*)
-        FROM `Release`
-        WHERE `IsDeleted` = TRUE) AS `RemainingSoftDeletedReleaseRows`;
+        FROM `Release` r
+        WHERE r.`IsDeleted` = TRUE
+          AND EXISTS (
+            SELECT 1
+            FROM `Namespace` n
+            WHERE n.`AppId` = r.`AppId`
+              AND n.`ClusterName` = r.`ClusterName`
+              AND n.`NamespaceName` = r.`NamespaceName`
+              AND n.`IsDeleted` = FALSE
+              AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+          )) AS `RemainingRetentionReleaseRows`,
+       (SELECT COUNT(*)
+        FROM `ReleaseHistory` h
+        WHERE h.`IsDeleted` = TRUE
+          AND NOT EXISTS (
+            SELECT 1
+            FROM `Namespace` n
+            WHERE n.`AppId` = h.`AppId`
+              AND n.`ClusterName` = h.`ClusterName`
+              AND n.`NamespaceName` = h.`NamespaceName`
+              AND n.`IsDeleted` = FALSE
+              AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+          )) AS `ExcludedSoftDeletedReleaseHistoryRows`,
+       (SELECT COUNT(*)
+        FROM `Release` r
+        WHERE r.`IsDeleted` = TRUE
+          AND NOT EXISTS (
+            SELECT 1
+            FROM `Namespace` n
+            WHERE n.`AppId` = r.`AppId`
+              AND n.`ClusterName` = r.`ClusterName`
+              AND n.`NamespaceName` = r.`NamespaceName`
+              AND n.`IsDeleted` = FALSE
+              AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+          )) AS `ExcludedSoftDeletedReleaseRows`;

--- a/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
@@ -19,6 +19,7 @@
 -- incarnation. The millisecond-resolution DeletedAt boundary remains unambiguous
 -- for same-second namespace recreation. It deletes at most 1000 rows from each
 -- table per execution and is safe to rerun.
+-- ReleaseId and PreviousReleaseId checks are split so MySQL 5.7 can use both indexes.
 
 SET AUTOCOMMIT = FALSE;
 
@@ -77,9 +78,13 @@ WHERE `Id` IN (
       )
       AND NOT EXISTS (
         SELECT 1
-        FROM `ReleaseHistory` h
+        FROM `ReleaseHistory` h FORCE INDEX (`IX_ReleaseId`)
         WHERE h.`ReleaseId` = r.`Id`
-           OR h.`PreviousReleaseId` = r.`Id`
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM `ReleaseHistory` h FORCE INDEX (`IX_PreviousReleaseId`)
+        WHERE h.`PreviousReleaseId` = r.`Id`
       )
       AND NOT EXISTS (
         SELECT 1

--- a/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
+++ b/scripts/sql/migration/release-history-retention/04-purge-soft-deleted-rows.sql
@@ -16,8 +16,9 @@
 
 -- Run this script against ApolloConfigDB only after referenced releases have
 -- been restored. It only purges rows belonging to the current active Namespace
--- incarnation and soft-deleted after that Namespace was created. It deletes at
--- most 1000 rows from each table per execution and is safe to rerun.
+-- incarnation. The millisecond-resolution DeletedAt boundary remains unambiguous
+-- for same-second namespace recreation. It deletes at most 1000 rows from each
+-- table per execution and is safe to rerun.
 
 SET AUTOCOMMIT = FALSE;
 
@@ -30,12 +31,20 @@ WHERE `Id` IN (
     WHERE h.`IsDeleted` = TRUE
       AND EXISTS (
         SELECT 1
-        FROM `Namespace` n
-        WHERE n.`AppId` = h.`AppId`
-          AND n.`ClusterName` = h.`ClusterName`
-          AND n.`NamespaceName` = h.`NamespaceName`
-          AND n.`IsDeleted` = FALSE
-          AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+        FROM `Namespace` active_namespace
+        WHERE active_namespace.`AppId` = h.`AppId`
+          AND active_namespace.`ClusterName` = h.`ClusterName`
+          AND active_namespace.`NamespaceName` = h.`NamespaceName`
+          AND active_namespace.`IsDeleted` = FALSE
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM `Namespace` deleted_namespace
+        WHERE deleted_namespace.`AppId` = h.`AppId`
+          AND deleted_namespace.`ClusterName` = h.`ClusterName`
+          AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+          AND deleted_namespace.`IsDeleted` = TRUE
+          AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
       )
     ORDER BY h.`Id`
     LIMIT 1000
@@ -51,12 +60,20 @@ WHERE `Id` IN (
     WHERE r.`IsDeleted` = TRUE
       AND EXISTS (
         SELECT 1
-        FROM `Namespace` n
-        WHERE n.`AppId` = r.`AppId`
-          AND n.`ClusterName` = r.`ClusterName`
-          AND n.`NamespaceName` = r.`NamespaceName`
-          AND n.`IsDeleted` = FALSE
-          AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+        FROM `Namespace` active_namespace
+        WHERE active_namespace.`AppId` = r.`AppId`
+          AND active_namespace.`ClusterName` = r.`ClusterName`
+          AND active_namespace.`NamespaceName` = r.`NamespaceName`
+          AND active_namespace.`IsDeleted` = FALSE
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM `Namespace` deleted_namespace
+        WHERE deleted_namespace.`AppId` = r.`AppId`
+          AND deleted_namespace.`ClusterName` = r.`ClusterName`
+          AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+          AND deleted_namespace.`IsDeleted` = TRUE
+          AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
       )
       AND NOT EXISTS (
         SELECT 1
@@ -85,46 +102,78 @@ SELECT (SELECT COUNT(*)
         WHERE h.`IsDeleted` = TRUE
           AND EXISTS (
             SELECT 1
-            FROM `Namespace` n
-            WHERE n.`AppId` = h.`AppId`
-              AND n.`ClusterName` = h.`ClusterName`
-              AND n.`NamespaceName` = h.`NamespaceName`
-              AND n.`IsDeleted` = FALSE
-              AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+            FROM `Namespace` active_namespace
+            WHERE active_namespace.`AppId` = h.`AppId`
+              AND active_namespace.`ClusterName` = h.`ClusterName`
+              AND active_namespace.`NamespaceName` = h.`NamespaceName`
+              AND active_namespace.`IsDeleted` = FALSE
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM `Namespace` deleted_namespace
+            WHERE deleted_namespace.`AppId` = h.`AppId`
+              AND deleted_namespace.`ClusterName` = h.`ClusterName`
+              AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+              AND deleted_namespace.`IsDeleted` = TRUE
+              AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
           )) AS `RemainingRetentionReleaseHistoryRows`,
        (SELECT COUNT(*)
         FROM `Release` r
         WHERE r.`IsDeleted` = TRUE
           AND EXISTS (
             SELECT 1
-            FROM `Namespace` n
-            WHERE n.`AppId` = r.`AppId`
-              AND n.`ClusterName` = r.`ClusterName`
-              AND n.`NamespaceName` = r.`NamespaceName`
-              AND n.`IsDeleted` = FALSE
-              AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
+            FROM `Namespace` active_namespace
+            WHERE active_namespace.`AppId` = r.`AppId`
+              AND active_namespace.`ClusterName` = r.`ClusterName`
+              AND active_namespace.`NamespaceName` = r.`NamespaceName`
+              AND active_namespace.`IsDeleted` = FALSE
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM `Namespace` deleted_namespace
+            WHERE deleted_namespace.`AppId` = r.`AppId`
+              AND deleted_namespace.`ClusterName` = r.`ClusterName`
+              AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+              AND deleted_namespace.`IsDeleted` = TRUE
+              AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
           )) AS `RemainingRetentionReleaseRows`,
        (SELECT COUNT(*)
         FROM `ReleaseHistory` h
         WHERE h.`IsDeleted` = TRUE
-          AND NOT EXISTS (
-            SELECT 1
-            FROM `Namespace` n
-            WHERE n.`AppId` = h.`AppId`
-              AND n.`ClusterName` = h.`ClusterName`
-              AND n.`NamespaceName` = h.`NamespaceName`
-              AND n.`IsDeleted` = FALSE
-              AND h.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
-          )) AS `ExcludedSoftDeletedReleaseHistoryRows`,
+          AND (NOT EXISTS (
+                 SELECT 1
+                 FROM `Namespace` active_namespace
+                 WHERE active_namespace.`AppId` = h.`AppId`
+                   AND active_namespace.`ClusterName` = h.`ClusterName`
+                   AND active_namespace.`NamespaceName` = h.`NamespaceName`
+                   AND active_namespace.`IsDeleted` = FALSE
+               )
+               OR EXISTS (
+                 SELECT 1
+                 FROM `Namespace` deleted_namespace
+                 WHERE deleted_namespace.`AppId` = h.`AppId`
+                   AND deleted_namespace.`ClusterName` = h.`ClusterName`
+                   AND deleted_namespace.`NamespaceName` = h.`NamespaceName`
+                   AND deleted_namespace.`IsDeleted` = TRUE
+                   AND deleted_namespace.`DeletedAt` >= h.`DeletedAt`
+               ))) AS `ExcludedSoftDeletedReleaseHistoryRows`,
        (SELECT COUNT(*)
         FROM `Release` r
         WHERE r.`IsDeleted` = TRUE
-          AND NOT EXISTS (
-            SELECT 1
-            FROM `Namespace` n
-            WHERE n.`AppId` = r.`AppId`
-              AND n.`ClusterName` = r.`ClusterName`
-              AND n.`NamespaceName` = r.`NamespaceName`
-              AND n.`IsDeleted` = FALSE
-              AND r.`DataChange_LastTime` >= n.`DataChange_CreatedTime`
-          )) AS `ExcludedSoftDeletedReleaseRows`;
+          AND (NOT EXISTS (
+                 SELECT 1
+                 FROM `Namespace` active_namespace
+                 WHERE active_namespace.`AppId` = r.`AppId`
+                   AND active_namespace.`ClusterName` = r.`ClusterName`
+                   AND active_namespace.`NamespaceName` = r.`NamespaceName`
+                   AND active_namespace.`IsDeleted` = FALSE
+               )
+               OR EXISTS (
+                 SELECT 1
+                 FROM `Namespace` deleted_namespace
+                 WHERE deleted_namespace.`AppId` = r.`AppId`
+                   AND deleted_namespace.`ClusterName` = r.`ClusterName`
+                   AND deleted_namespace.`NamespaceName` = r.`NamespaceName`
+                   AND deleted_namespace.`IsDeleted` = TRUE
+                   AND deleted_namespace.`DeletedAt` >= r.`DeletedAt`
+               ))) AS `ExcludedSoftDeletedReleaseRows`;

--- a/scripts/sql/migration/release-history-retention/README.md
+++ b/scripts/sql/migration/release-history-retention/README.md
@@ -1,0 +1,23 @@
+# Release history retention migration
+
+These manual MySQL scripts repair data left by the old soft-delete retention behavior and then
+physically purge it. They must be run against `ApolloConfigDB`; they are intentionally outside
+`scripts/sql/src` and are not executed as part of an automatic Apollo schema upgrade.
+
+Before running a write script, back up the database, stop Apollo Admin Service instances that can
+publish or clean releases, and confirm that replication and binary-log capacity can handle the
+operation.
+
+Run the scripts in this order:
+
+1. Run `01-precheck-releases-needing-restore.sql`. `ActiveReleaseKeyConflicts` must be `0` before
+   continuing; investigate the sample rows if it is not.
+2. Run `02-precheck-soft-deleted-rows.sql` and record the expected cleanup scope.
+3. Run `03-restore-referenced-releases.sql` repeatedly until
+   `RemainingReleasesNeedingRestore` is `0`.
+4. Run the first precheck again. `ReleasesNeedingRestore` must now be `0`.
+5. Run `04-purge-soft-deleted-rows.sql` repeatedly until both reported remaining-row counts are `0`.
+6. Run both prechecks again and restart the stopped services.
+
+The write scripts use batches of 1000 rows to limit transaction size. They are idempotent and may
+be stopped between batches. Do not run the purge script before the restore step.

--- a/scripts/sql/migration/release-history-retention/README.md
+++ b/scripts/sql/migration/release-history-retention/README.md
@@ -4,10 +4,12 @@ These manual MySQL scripts repair data left by the old soft-delete retention beh
 physically purge it. They must be run against `ApolloConfigDB`; they are intentionally outside
 `scripts/sql/src` and are not executed as part of an automatic Apollo schema upgrade.
 
-The purge is deliberately limited to rows belonging to the current active `Namespace` incarnation
-and soft-deleted after that `Namespace` was created. This identifies rows produced by the old
-retention cleanup while excluding normal namespace-deletion rows and rows from a deleted and later
-recreated namespace. The precheck reports excluded rows separately; the purge never deletes them.
+The repair and purge are deliberately limited to rows belonging to the current active `Namespace`
+incarnation. The scripts use the millisecond-resolution `DeletedAt` values as the incarnation
+boundary: namespace deletion soft-deletes releases and release histories before soft-deleting the
+`Namespace` row, so rows whose `DeletedAt` is not later than a matching deleted `Namespace` are
+excluded. This remains unambiguous when deletion and recreation happen within the same second. The
+precheck reports excluded rows separately; the write scripts never modify them.
 
 Before running a write script, back up the database, stop Apollo Admin Service instances that can
 publish or clean releases, and confirm that replication and binary-log capacity can handle the

--- a/scripts/sql/migration/release-history-retention/README.md
+++ b/scripts/sql/migration/release-history-retention/README.md
@@ -4,6 +4,11 @@ These manual MySQL scripts repair data left by the old soft-delete retention beh
 physically purge it. They must be run against `ApolloConfigDB`; they are intentionally outside
 `scripts/sql/src` and are not executed as part of an automatic Apollo schema upgrade.
 
+The purge is deliberately limited to rows belonging to the current active `Namespace` incarnation
+and soft-deleted after that `Namespace` was created. This identifies rows produced by the old
+retention cleanup while excluding normal namespace-deletion rows and rows from a deleted and later
+recreated namespace. The precheck reports excluded rows separately; the purge never deletes them.
+
 Before running a write script, back up the database, stop Apollo Admin Service instances that can
 publish or clean releases, and confirm that replication and binary-log capacity can handle the
 operation.
@@ -12,11 +17,13 @@ Run the scripts in this order:
 
 1. Run `01-precheck-releases-needing-restore.sql`. `ActiveReleaseKeyConflicts` must be `0` before
    continuing; investigate the sample rows if it is not.
-2. Run `02-precheck-soft-deleted-rows.sql` and record the expected cleanup scope.
+2. Run `02-precheck-soft-deleted-rows.sql` and record the retention-scoped and excluded row counts.
 3. Run `03-restore-referenced-releases.sql` repeatedly until
    `RemainingReleasesNeedingRestore` is `0`.
 4. Run the first precheck again. `ReleasesNeedingRestore` must now be `0`.
-5. Run `04-purge-soft-deleted-rows.sql` repeatedly until both reported remaining-row counts are `0`.
+5. Run `04-purge-soft-deleted-rows.sql` repeatedly until both
+   `RemainingRetentionReleaseHistoryRows` and `RemainingRetentionReleaseRows` are `0`. Excluded
+   soft-deleted rows may remain and must not be removed by this migration.
 6. Run both prechecks again and restart the stopped services.
 
 The write scripts use batches of 1000 rows to limit transaction size. They are idempotent and may

--- a/scripts/sql/profiles/h2-default/apolloconfigdb.sql
+++ b/scripts/sql/profiles/h2-default/apolloconfigdb.sql
@@ -179,7 +179,8 @@ CREATE TABLE `GrayReleaseRule` (
   `DataChange_LastTime` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '最后修改时间',
   PRIMARY KEY (`Id`),
   KEY `GrayReleaseRule_DataChange_LastTime` (`DataChange_LastTime`),
-  KEY `GrayReleaseRule_IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`)
+  KEY `GrayReleaseRule_IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`),
+  KEY `GrayReleaseRule_IX_ReleaseId_BranchStatus_IsDeleted` (`ReleaseId`,`BranchStatus`,`IsDeleted`)
 )   COMMENT='灰度规则表';
 
 

--- a/scripts/sql/profiles/h2-default/delta/v250-v300/apolloconfigdb-v250-v300.sql
+++ b/scripts/sql/profiles/h2-default/delta/v250-v300/apolloconfigdb-v250-v300.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- delta schema to upgrade apollo config db from v2.5.0 to v3.0.0
+
+CREATE INDEX `GrayReleaseRule_IX_ReleaseId_BranchStatus_IsDeleted`
+ON `GrayReleaseRule` (`ReleaseId`, `BranchStatus`, `IsDeleted`);

--- a/scripts/sql/profiles/mysql-database-not-specified/apolloconfigdb.sql
+++ b/scripts/sql/profiles/mysql-database-not-specified/apolloconfigdb.sql
@@ -180,7 +180,8 @@ CREATE TABLE `GrayReleaseRule` (
   `DataChange_LastTime` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '最后修改时间',
   PRIMARY KEY (`Id`),
   KEY `DataChange_LastTime` (`DataChange_LastTime`),
-  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`)
+  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`),
+  KEY `IX_ReleaseId_BranchStatus_IsDeleted` (`ReleaseId`,`BranchStatus`,`IsDeleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='灰度规则表';
 
 

--- a/scripts/sql/profiles/mysql-database-not-specified/delta/v250-v300/apolloconfigdb-v250-v300.sql
+++ b/scripts/sql/profiles/mysql-database-not-specified/delta/v250-v300/apolloconfigdb-v250-v300.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- delta schema to upgrade apollo config db from v2.5.0 to v3.0.0
+
+CREATE INDEX `IX_ReleaseId_BranchStatus_IsDeleted`
+ON `GrayReleaseRule` (`ReleaseId`, `BranchStatus`, `IsDeleted`);

--- a/scripts/sql/profiles/mysql-default/apolloconfigdb.sql
+++ b/scripts/sql/profiles/mysql-default/apolloconfigdb.sql
@@ -185,7 +185,8 @@ CREATE TABLE `GrayReleaseRule` (
   `DataChange_LastTime` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '最后修改时间',
   PRIMARY KEY (`Id`),
   KEY `DataChange_LastTime` (`DataChange_LastTime`),
-  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`)
+  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`),
+  KEY `IX_ReleaseId_BranchStatus_IsDeleted` (`ReleaseId`,`BranchStatus`,`IsDeleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='灰度规则表';
 
 

--- a/scripts/sql/profiles/mysql-default/delta/v250-v300/apolloconfigdb-v250-v300.sql
+++ b/scripts/sql/profiles/mysql-default/delta/v250-v300/apolloconfigdb-v250-v300.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- delta schema to upgrade apollo config db from v2.5.0 to v3.0.0
+
+CREATE INDEX `IX_ReleaseId_BranchStatus_IsDeleted`
+ON `GrayReleaseRule` (`ReleaseId`, `BranchStatus`, `IsDeleted`);

--- a/scripts/sql/src/apolloconfigdb.sql
+++ b/scripts/sql/src/apolloconfigdb.sql
@@ -173,7 +173,8 @@ CREATE TABLE `GrayReleaseRule` (
   `DataChange_LastTime` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '最后修改时间',
   PRIMARY KEY (`Id`),
   KEY `DataChange_LastTime` (`DataChange_LastTime`),
-  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`)
+  KEY `IX_Namespace` (`AppId`,`ClusterName`,`NamespaceName`),
+  KEY `IX_ReleaseId_BranchStatus_IsDeleted` (`ReleaseId`,`BranchStatus`,`IsDeleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='灰度规则表';
 
 

--- a/scripts/sql/src/delta/v250-v300/apolloconfigdb-v250-v300.sql
+++ b/scripts/sql/src/delta/v250-v300/apolloconfigdb-v250-v300.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2026 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- delta schema to upgrade apollo config db from v2.5.0 to v3.0.0
+
+CREATE INDEX `IX_ReleaseId_BranchStatus_IsDeleted`
+ON `GrayReleaseRule` (`ReleaseId`, `BranchStatus`, `IsDeleted`);


### PR DESCRIPTION
## What
Fix release history retention cleanup so stale `ReleaseHistory` rows and their associated `Release` rows are physically deleted instead of only being soft-deleted through Hibernate `@SQLDelete`.

## Why
`apollo.release-history.retention.size` is intended to reduce accumulated release-history database pressure. The existing cleanup path called repository delete methods that honor entity soft-delete mappings, so old rows remained in MySQL tables and indexes.

## How
- Add retention-only native delete repository methods for `ReleaseHistory` and `Release`.
- Use those physical delete methods inside the existing retention cleanup transaction.
- Extend `ReleaseHistoryServiceTest` with native SQL row-count assertions so the test distinguishes physical deletion from soft deletion.

## Which issue(s) this PR fixes:
Fixes #5640

## Brief changelog
Fix release history retention cleanup to physically delete stale release history and release rows.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request does not break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).

## Tests
- `./mvnw -pl apollo-biz -am -Dtest=ReleaseHistoryServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl apollo-biz spotless:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release-history retention cleanup to physically delete eligible retained history and physically remove only releases that are no longer referenced.
  * Improved cleanup batching/termination and ensured physical row-count stability during transactional rollback.
* **Documentation**
  * Added release note entry and a manual SQL migration runbook (prechecks, restore, and bounded purge flow).
* **Tests**
  * Enhanced retention cleanup and migration-script tests with physical row-count assertions, idempotency checks, and retention boundary scenarios.
* **Performance**
  * Added/updated indexes on gray release rules to accelerate retention/cleanup lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->