### PR TITLE
fix(portal): preserve item type when revoking changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Apollo 3.0.0
 * [Feature: add user access tokens for AI agents and automation](https://github.com/apolloconfig/apollo/pull/5632)
 * [Fix: return 429 instead of redirecting to sign-in for OpenAPI user token rate limits](https://github.com/apolloconfig/apollo/pull/5637)
 * [Fix: physically delete retained release history and unreferenced release rows](https://github.com/apolloconfig/apollo/pull/5641)
+* [Fix: preserve item type when revoking unpublished changes](https://github.com/apolloconfig/apollo/pull/5646)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
@@ -239,12 +239,12 @@ public class ItemService {
         ItemDTO deletedItemDto = deletedItemDTOs.computeIfAbsent(key, k -> new ItemDTO());
         int newLineNum =
             0 == deletedItemDto.getLineNum() ? lineNum.get() : deletedItemDto.getLineNum();
-        changeSets.addCreateItem(
-            buildNormalItem(0L, namespaceId, key, value, deletedItemDto.getComment(), newLineNum));
+        changeSets.addCreateItem(buildNormalItem(0L, namespaceId, key, deletedItemDto.getType(),
+            value, deletedItemDto.getComment(), newLineNum));
       } else if (!StringUtils.equals(oldItem.getValue(), value)
           || lineNum.get() != oldItem.getLineNum()) {
-        changeSets.addUpdateItem(buildNormalItem(oldItem.getId(), namespaceId, key, value,
-            oldItem.getComment(), oldItem.getLineNum()));
+        changeSets.addUpdateItem(buildNormalItem(oldItem.getId(), namespaceId, key,
+            oldItem.getType(), value, oldItem.getComment(), oldItem.getLineNum()));
       }
       oldKeyMapItem.remove(key);
       lineNum.set(lineNum.get() + 1);
@@ -348,11 +348,12 @@ public class ItemService {
     return createdItem;
   }
 
-  private ItemDTO buildNormalItem(Long id, Long namespaceId, String key, String value,
+  private ItemDTO buildNormalItem(Long id, Long namespaceId, String key, int type, String value,
       String comment, int lineNum) {
     ItemDTO item = new ItemDTO(key, value, comment, lineNum);
     item.setId(id);
     item.setNamespaceId(namespaceId);
+    item.setType(type);
     return item;
   }
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.portal.service;
 import com.ctrip.framework.apollo.common.dto.ItemChangeSets;
 import com.ctrip.framework.apollo.common.dto.ItemDTO;
 import com.ctrip.framework.apollo.common.dto.NamespaceDTO;
+import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
@@ -33,6 +34,7 @@ import com.ctrip.framework.apollo.portal.entity.vo.NamespaceIdentifier;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -41,7 +43,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ConfigServiceTest extends AbstractUnitTest {
@@ -120,6 +124,77 @@ public class ConfigServiceTest extends AbstractUnitTest {
     when(resolver.resolve(someNamespaceId, model.getConfigText(), itemDTOs)).thenReturn(changeSets);
 
     configService.updateConfigItemByText(model, "test");
+  }
+
+  @Test
+  public void testRevokeItemShouldPreserveTypeWhenUpdatingPublishedItem() {
+    String appId = "6666";
+    Env env = Env.DEV;
+    String clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
+    String namespaceName = ConfigConsts.NAMESPACE_APPLICATION;
+    long namespaceId = 123L;
+
+    NamespaceDTO namespace = generateNamespaceDTO(appId, clusterName, namespaceName);
+    namespace.setId(namespaceId);
+    ReleaseDTO release = new ReleaseDTO();
+    release.setConfigurations("{\"number\":\"42\"}");
+
+    ItemDTO currentItem = new ItemDTO("number", "41", "comment", 1);
+    currentItem.setId(1L);
+    currentItem.setNamespaceId(namespaceId);
+    currentItem.setType(1);
+
+    when(namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName)).thenReturn(namespace);
+    when(releaseAPI.loadLatestRelease(appId, env, clusterName, namespaceName)).thenReturn(release);
+    when(itemAPI.findItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.singletonList(currentItem));
+    when(itemAPI.findDeletedItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.emptyList());
+
+    configService.revokeItem(appId, env, clusterName, namespaceName, "test");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemAPI).updateItemsByChangeSet(eq(appId), eq(env), eq(clusterName), eq(namespaceName),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertEquals(1, changeSets.getUpdateItems().size());
+    assertEquals("42", changeSets.getUpdateItems().get(0).getValue());
+    assertEquals(1, changeSets.getUpdateItems().get(0).getType());
+  }
+
+  @Test
+  public void testRevokeItemShouldRestoreTypeWhenRecreatingDeletedPublishedItem() {
+    String appId = "6666";
+    Env env = Env.DEV;
+    String clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
+    String namespaceName = ConfigConsts.NAMESPACE_APPLICATION;
+    long namespaceId = 123L;
+
+    NamespaceDTO namespace = generateNamespaceDTO(appId, clusterName, namespaceName);
+    namespace.setId(namespaceId);
+    ReleaseDTO release = new ReleaseDTO();
+    release.setConfigurations("{\"flag\":\"true\"}");
+
+    ItemDTO deletedItem = new ItemDTO("flag", "true", "comment", 1);
+    deletedItem.setNamespaceId(namespaceId);
+    deletedItem.setType(2);
+
+    when(namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName)).thenReturn(namespace);
+    when(releaseAPI.loadLatestRelease(appId, env, clusterName, namespaceName)).thenReturn(release);
+    when(itemAPI.findItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.emptyList());
+    when(itemAPI.findDeletedItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.singletonList(deletedItem));
+
+    configService.revokeItem(appId, env, clusterName, namespaceName, "test");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemAPI).updateItemsByChangeSet(eq(appId), eq(env), eq(clusterName), eq(namespaceName),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertEquals(1, changeSets.getCreateItems().size());
+    assertEquals("true", changeSets.getCreateItems().get(0).getValue());
+    assertEquals(2, changeSets.getCreateItems().get(0).getType());
   }
 
   /**


### PR DESCRIPTION
## What's the purpose of this PR

Prevent `revoke-items` from resetting typed configuration items to `Type = 0` when unpublished changes are discarded.

The latest release configurations contain key/value pairs only. During revoke, Portal rebuilds the affected `ItemDTO` objects. The previous implementation did not copy `type`, so the primitive `int` defaulted to `0` and was then explicitly persisted by Admin Service.

This change preserves:

- the current item's type when restoring an existing item's released value;
- the deleted item's recorded type when recreating a deleted published item.

Release snapshots still do not contain type metadata, so this PR intentionally fixes the unintended reset to `0`; it does not attempt to restore an arbitrary historical published type.

The issue is reproducible in the latest `v2.5.2` release. Please consider backporting the fix to the `2.x` branch.

## Which issue(s) this PR fixes:

Fixes #5645

## Brief changelog

- Preserve item type in both revoke update and recreate paths.
- Add regression tests for existing typed items and deleted typed items.

## Verification

- `ConfigServiceTest`: 6 tests, 0 failures.
- `mvn clean test`.
- `mvn spotless:apply` and `mvn -pl apollo-portal spotless:check`.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md) after the PR number is assigned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item revocation so existing item types are preserved when updating published configurations.
  * Fixed item recreation so deleted configuration items retain their original types.
* **Tests**
  * Added coverage for restoring and preserving item types during revoke operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->