### PR TITLE
fix: restrict quick start H2 console access

### DIFF
--- a/apollo-assembly/src/main/resources/application-github.properties
+++ b/apollo-assembly/src/main/resources/application-github.properties
@@ -35,7 +35,7 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.metadata_builder_contributor=com.ctrip.framework.apollo.common.jpa.SqlFunctionsMetadataBuilderContributor
 spring.h2.console.enabled=true
-spring.h2.console.settings.web-allow-others=true
+spring.h2.console.settings.web-allow-others=false
 
 # Sql logging
 #logging.level.org.hibernate.SQL=DEBUG

--- a/docs/en/deployment/quick-start.md
+++ b/docs/en/deployment/quick-start.md
@@ -70,11 +70,13 @@ Quick Start is only for local testing, so generally users do not need to downloa
 #### Precautions
 1. The Apollo server process needs to use ports 8070, 8080, 8090 respectively, please ensure these three ports are not currently in use.
 2. The `github` in the SPRING_PROFILES_ACTIVE environment variable in the script is a required profile, `database-discovery` specifies the use of database service discovery, `auth` is a profile that provides simple authentication for the portal, it can be removed if authentication is not required or other authentication methods are used.
+3. Quick Start is only for local testing. Do not expose ports 8070, 8080, or 8090 to the public Internet. The following startup commands disable the H2 Console by default. If you need it for local debugging, adjust `SPRING_H2_CONSOLE_ENABLED` yourself and avoid allowing external network access.
 ## 2.1 Use H2 in-memory database, automatic initialization
 No configuration is required, just use the following command to start
 > Note: When using the in-memory database, any operation will be lost after the Apollo process restarts
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 unset SPRING_SQL_CONFIG_INIT_MODE
 unset SPRING_SQL_PORTAL_INIT_MODE
 java -jar apollo-all-in-one.jar
@@ -88,6 +90,7 @@ java -jar apollo-all-in-one.jar
 Use the SPRING_SQL_CONFIG_INIT_MODE="always" and SPRING_SQL_PORTAL_INIT_MODE="always" environment variable for initialization at the first startup
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 export SPRING_SQL_CONFIG_INIT_MODE="always"
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:h2:file:~/apollo/apollo-config-db;mode=mysql;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;BUILTIN_ALIAS_OVERRIDE=TRUE;DATABASE_TO_UPPER=FALSE"
@@ -102,6 +105,7 @@ java -jar apollo-all-in-one.jar
 Remove the SPRING_SQL_CONFIG_INIT_MODE and SPRING_SQL_PORTAL_INIT_MODE environment variable to avoid repeated initialization at subsequent startup
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:h2:file:~/apollo/apollo-config-db;mode=mysql;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;BUILTIN_ALIAS_OVERRIDE=TRUE;DATABASE_TO_UPPER=FALSE"
@@ -121,6 +125,7 @@ java -jar apollo-all-in-one.jar
 Use the SPRING_SQL_INIT_MODE="always" environment variable for initialization at the first startup
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 export SPRING_SQL_CONFIG_INIT_MODE="always"
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"
@@ -139,6 +144,7 @@ java -jar apollo-all-in-one.jar
 Remove the SPRING_SQL_CONFIG_INIT_MODE and SPRING_SQL_PORTAL_INIT_MODE environment variable to avoid repeated initialization at subsequent startup
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"
@@ -166,6 +172,7 @@ You can import [apolloportaldb.sql](https://github.com/apolloconfig/apollo/blob/
 
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"

--- a/docs/zh/deployment/quick-start.md
+++ b/docs/zh/deployment/quick-start.md
@@ -70,12 +70,14 @@ Quick Start只针对本地测试使用，所以一般用户不需要自己下载
 #### 注意事项
 1. apollo 服务端进程需要分别使用8070, 8080, 8090端口，请确保这3个端口当前没有被使用。
 2. 脚本中的 SPRING_PROFILES_ACTIVE 环境变量中的 `github` 是必须的 profile，`database-discovery` 指定使用数据库服务发现， `auth` 是 portal 提供简单认证的 profile，不需要认证或者使用其它认证方式时可以去掉
+3. Quick Start 仅用于本地测试，请勿将 8070, 8080, 8090 端口暴露到公网。以下启动命令默认关闭 H2 Console；如需本地调试打开，请自行调整 `SPRING_H2_CONSOLE_ENABLED`，并避免允许外部网络访问。
 
 ## 2.1 使用 H2 内存数据库，自动初始化
 无需任何配置，直接使用如下命令启动即可
 > 注：使用内存数据库时，任何操作都会在 apollo 进程重启后丢失
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 unset SPRING_SQL_CONFIG_INIT_MODE
 unset SPRING_SQL_PORTAL_INIT_MODE
 java -jar apollo-all-in-one.jar
@@ -90,6 +92,7 @@ java -jar apollo-all-in-one.jar
 首次启动使用 SPRING_SQL_CONFIG_INIT_MODE="always" 和 SPRING_SQL_PORTAL_INIT_MODE="always" 环境变量来进行初始化
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 export SPRING_SQL_CONFIG_INIT_MODE="always"
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:h2:file:~/apollo/apollo-config-db;mode=mysql;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;BUILTIN_ALIAS_OVERRIDE=TRUE;DATABASE_TO_UPPER=FALSE"
@@ -104,6 +107,7 @@ java -jar apollo-all-in-one.jar
 后续启动去掉 SPRING_SQL_CONFIG_INIT_MODE 和 SPRING_SQL_PORTAL_INIT_MODE 环境变量来避免重复初始化
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:h2:file:~/apollo/apollo-config-db;mode=mysql;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;BUILTIN_ALIAS_OVERRIDE=TRUE;DATABASE_TO_UPPER=FALSE"
@@ -123,6 +127,7 @@ java -jar apollo-all-in-one.jar
 首次启动使用 SPRING_SQL_INIT_MODE="always" 环境变量来进行初始化
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 export SPRING_SQL_CONFIG_INIT_MODE="always"
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"
@@ -141,6 +146,7 @@ java -jar apollo-all-in-one.jar
 后续启动去掉 SPRING_SQL_CONFIG_INIT_MODE 和 SPRING_SQL_PORTAL_INIT_MODE 环境变量来避免重复初始化
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"
@@ -168,6 +174,7 @@ ApolloPortalDB 通过各种MySQL客户端导入[apolloportaldb.sql](https://gith
 
 ```bash
 export SPRING_PROFILES_ACTIVE="github,database-discovery,auth"
+export SPRING_H2_CONSOLE_ENABLED=false
 # config db
 unset SPRING_SQL_CONFIG_INIT_MODE
 export SPRING_CONFIG_DATASOURCE_URL="jdbc:mysql://your-mysql-server:3306/ApolloConfigDB?useUnicode=true&characterEncoding=UTF8"


### PR DESCRIPTION
## What's the purpose of this PR

Harden the Quick Start H2 Console defaults without removing local development access.

This PR keeps `apollo-assembly`'s H2 Console enabled for local development, but disables remote H2 Console access by default with `spring.h2.console.settings.web-allow-others=false`. It also updates the Chinese and English Quick Start docs to explicitly disable the H2 Console in `java -jar apollo-all-in-one.jar` startup examples and warn users not to expose Quick Start ports to the public Internet.

## Which issue(s) this PR fixes:

N/A

## Brief changelog

- Disable remote H2 Console access in `apollo-assembly`'s `application-github.properties`
- Document Quick Start as local-test-only and not suitable for public Internet exposure
- Add `SPRING_H2_CONSOLE_ENABLED=false` to all Quick Start `java -jar` examples

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code. (Not applicable: configuration and documentation only.)
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything. (Not run: configuration and documentation only.)
- [ ] Run `mvn spotless:apply` to format your code. (Not run: no Java code changes.)
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md). (Not updated: Quick Start hardening and documentation only.)

## Tests

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted H2 Console access to the local host, improving default security.

* **Documentation**
  * Added warnings that Quick Start is intended for local testing only.
  * Clarified that ports 8070, 8080, and 8090 must not be publicly exposed.
  * Updated startup examples to disable the H2 Console by default, with guidance for local debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->