### PR TITLE
feat(portal): support configurable OIDC username claim for user identity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
-* [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 * [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 * [Change: official Config/Admin packages now default to database discovery; upgraded Eureka deployments should explicitly keep the `github` profile to preserve legacy behavior](https://github.com/apolloconfig/apollo/pull/5580)
 * [Refactor: extract config constants and methods in BizConfig, PortalConfig, and RefreshableConfig](https://github.com/apolloconfig/apollo/pull/5583)
@@ -25,6 +24,7 @@ Apollo 3.0.0
 * [Fix: preserve item type when revoking unpublished changes](https://github.com/apolloconfig/apollo/pull/5646)
 * [Feature: support revoking unpublished changes for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/5656)
 * [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
+* [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
+* [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 * [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 * [Change: official Config/Admin packages now default to database discovery; upgraded Eureka deployments should explicitly keep the `github` profile to preserve legacy behavior](https://github.com/apolloconfig/apollo/pull/5580)
 * [Refactor: extract config constants and methods in BizConfig, PortalConfig, and RefreshableConfig](https://github.com/apolloconfig/apollo/pull/5583)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/OidcExtendProperties.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/OidcExtendProperties.java
@@ -37,8 +37,12 @@ public class OidcExtendProperties {
   /**
    * claim name used as the Apollo user identity {@link UserPO#getUsername()} for both oidc
    * (interactive) and jwt logins. default to the token subject ({@link StandardClaimNames#SUB}).
-   * When the configured claim is missing or blank, Apollo falls back to the subject so a user is
-   * never created with an empty id.
+   * <p>
+   * The value of this claim becomes the Apollo login identity and drives authorization, so when it
+   * is configured the claim must be IdP-controlled, unique, immutable, non-reassignable and not
+   * user-editable. If a configured claim is missing or blank in a token, login is rejected rather
+   * than falling back to the subject, so the same principal cannot be provisioned as two different
+   * Apollo users across the oidc and jwt paths.
    */
   private String userIdClaimName;
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/OidcExtendProperties.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/OidcExtendProperties.java
@@ -34,12 +34,28 @@ public class OidcExtendProperties {
    */
   private String jwtUserDisplayNameClaimName;
 
+  /**
+   * claim name used as the Apollo user identity {@link UserPO#getUsername()} for both oidc
+   * (interactive) and jwt logins. default to the token subject ({@link StandardClaimNames#SUB}).
+   * When the configured claim is missing or blank, Apollo falls back to the subject so a user is
+   * never created with an empty id.
+   */
+  private String userIdClaimName;
+
   public String getUserDisplayNameClaimName() {
     return userDisplayNameClaimName;
   }
 
   public void setUserDisplayNameClaimName(String userDisplayNameClaimName) {
     this.userDisplayNameClaimName = userDisplayNameClaimName;
+  }
+
+  public String getUserIdClaimName() {
+    return userIdClaimName;
+  }
+
+  public void setUserIdClaimName(String userIdClaimName) {
+    this.userIdClaimName = userIdClaimName;
   }
 
   public String getJwtUserDisplayNameClaimName() {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcAuthenticationSuccessEventListener.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcAuthenticationSuccessEventListener.java
@@ -71,27 +71,27 @@ public class OidcAuthenticationSuccessEventListener
   }
 
   private void oidcUserLogin(OidcUser oidcUser) {
-    String subject = oidcUser.getSubject();
+    String userId = OidcUserInfoUtil.getOidcUserId(oidcUser, this.oidcExtendProperties);
     String userDisplayName =
         OidcUserInfoUtil.getOidcUserDisplayName(oidcUser, this.oidcExtendProperties);
     String email = oidcUser.getEmail();
 
-    this.logOidc(oidcUser, subject, userDisplayName, email);
+    this.logOidc(oidcUser, userId, userDisplayName, email);
 
     UserInfo newUserInfo = new UserInfo();
-    newUserInfo.setUserId(subject);
+    newUserInfo.setUserId(userId);
     newUserInfo.setName(userDisplayName);
     newUserInfo.setEmail(email);
-    if (this.contains(subject)) {
+    if (this.contains(userId)) {
       this.oidcLocalUserService.updateUserInfo(newUserInfo);
       return;
     }
     this.oidcLocalUserService.createLocalUser(newUserInfo);
   }
 
-  private void logOidc(OidcUser oidcUser, String subject, String userDisplayName, String email) {
-    oidcLog.debug("oidc authentication success, sub=[{}] userDisplayName=[{}] email=[{}]", subject,
-        userDisplayName, email);
+  private void logOidc(OidcUser oidcUser, String userId, String userDisplayName, String email) {
+    oidcLog.debug("oidc authentication success, userId=[{}] userDisplayName=[{}] email=[{}]",
+        userId, userDisplayName, email);
     if (oidcLog.isTraceEnabled()) {
       Map<String, Object> claims = oidcUser.getClaims();
       for (Entry<String, Object> entry : claims.entrySet()) {
@@ -113,22 +113,22 @@ public class OidcAuthenticationSuccessEventListener
   }
 
   private void jwtLogin(Jwt jwt) {
-    String subject = jwt.getSubject();
+    String userId = OidcUserInfoUtil.getJwtUserId(jwt, this.oidcExtendProperties);
     String userDisplayName = OidcUserInfoUtil.getJwtUserDisplayName(jwt, this.oidcExtendProperties);
 
-    this.logJwt(jwt, subject, userDisplayName);
+    this.logJwt(jwt, userId, userDisplayName);
 
-    if (this.contains(subject)) {
+    if (this.contains(userId)) {
       return;
     }
     UserInfo newUserInfo = new UserInfo();
-    newUserInfo.setUserId(subject);
+    newUserInfo.setUserId(userId);
     newUserInfo.setName(userDisplayName);
     this.oidcLocalUserService.createLocalUser(newUserInfo);
   }
 
-  private void logJwt(Jwt jwt, String subject, String userDisplayName) {
-    jwtLog.debug("jwt authentication success, sub=[{}] userDisplayName=[{}]", subject,
+  private void logJwt(Jwt jwt, String userId, String userDisplayName) {
+    jwtLog.debug("jwt authentication success, userId=[{}] userDisplayName=[{}]", userId,
         userDisplayName);
     if (jwtLog.isTraceEnabled()) {
       Map<String, Object> claims = jwt.getClaims();

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoHolder.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoHolder.java
@@ -64,7 +64,7 @@ public class OidcUserInfoHolder implements UserInfoHolder {
     if (principal instanceof OidcUser) {
       UserInfo userInfo = new UserInfo();
       OidcUser oidcUser = (OidcUser) principal;
-      userInfo.setUserId(oidcUser.getSubject());
+      userInfo.setUserId(OidcUserInfoUtil.getOidcUserId(oidcUser, this.oidcExtendProperties));
       userInfo
           .setName(OidcUserInfoUtil.getOidcUserDisplayName(oidcUser, this.oidcExtendProperties));
       userInfo.setEmail(oidcUser.getEmail());
@@ -73,7 +73,7 @@ public class OidcUserInfoHolder implements UserInfoHolder {
     if (principal instanceof Jwt) {
       Jwt jwt = (Jwt) principal;
       UserInfo userInfo = new UserInfo();
-      userInfo.setUserId(jwt.getSubject());
+      userInfo.setUserId(OidcUserInfoUtil.getJwtUserId(jwt, this.oidcExtendProperties));
       userInfo.setName(OidcUserInfoUtil.getJwtUserDisplayName(jwt, this.oidcExtendProperties));
       return userInfo;
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtil.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtil.java
@@ -18,13 +18,68 @@ package com.ctrip.framework.apollo.portal.spi.oidc;
 
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.portal.spi.configuration.OidcExtendProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 public class OidcUserInfoUtil {
 
+  private static final Logger log = LoggerFactory.getLogger(OidcUserInfoUtil.class);
+
   private OidcUserInfoUtil() {
     throw new UnsupportedOperationException("util class");
+  }
+
+  /**
+   * resolve the Apollo user id from an oidc (interactive) user. When
+   * {@link OidcExtendProperties#getUserIdClaimName()} is configured, the value of that claim is
+   * used; otherwise, or when the configured claim is missing or blank, it falls back to the token
+   * subject so a user is never created with an empty id.
+   *
+   * @param oidcUser             the user
+   * @param oidcExtendProperties claimName properties
+   * @return the Apollo user id
+   */
+  public static String getOidcUserId(OidcUser oidcUser, OidcExtendProperties oidcExtendProperties) {
+    String userIdClaimName = oidcExtendProperties.getUserIdClaimName();
+    String subject = oidcUser.getSubject();
+    if (StringUtils.isBlank(userIdClaimName)) {
+      return subject;
+    }
+    String userId = oidcUser.getClaimAsString(userIdClaimName);
+    if (StringUtils.isBlank(userId)) {
+      log.warn(
+          "oidc user id claim [{}] is missing or blank, falling back to subject as the Apollo user id",
+          userIdClaimName);
+      return subject;
+    }
+    return userId;
+  }
+
+  /**
+   * resolve the Apollo user id from a jwt. Behaves like
+   * {@link #getOidcUserId(OidcUser, OidcExtendProperties)}, reading the same configured claim and
+   * falling back to the jwt subject when it is missing or blank.
+   *
+   * @param jwt                  the user
+   * @param oidcExtendProperties claimName properties
+   * @return the Apollo user id
+   */
+  public static String getJwtUserId(Jwt jwt, OidcExtendProperties oidcExtendProperties) {
+    String userIdClaimName = oidcExtendProperties.getUserIdClaimName();
+    String subject = jwt.getSubject();
+    if (StringUtils.isBlank(userIdClaimName)) {
+      return subject;
+    }
+    String userId = jwt.getClaimAsString(userIdClaimName);
+    if (StringUtils.isBlank(userId)) {
+      log.warn(
+          "jwt user id claim [{}] is missing or blank, falling back to subject as the Apollo user id",
+          userIdClaimName);
+      return subject;
+    }
+    return userId;
   }
 
   /**

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtil.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtil.java
@@ -18,14 +18,11 @@ package com.ctrip.framework.apollo.portal.spi.oidc;
 
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.portal.spi.configuration.OidcExtendProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 public class OidcUserInfoUtil {
-
-  private static final Logger log = LoggerFactory.getLogger(OidcUserInfoUtil.class);
 
   private OidcUserInfoUtil() {
     throw new UnsupportedOperationException("util class");
@@ -34,50 +31,51 @@ public class OidcUserInfoUtil {
   /**
    * resolve the Apollo user id from an oidc (interactive) user. When
    * {@link OidcExtendProperties#getUserIdClaimName()} is configured, the value of that claim is
-   * used; otherwise, or when the configured claim is missing or blank, it falls back to the token
-   * subject so a user is never created with an empty id.
+   * used as the Apollo login identity. If a claim is configured but missing or blank in the token,
+   * login is rejected rather than falling back to the subject: falling back could resolve the same
+   * principal to a different id across the oidc and jwt paths and provision two local accounts. When
+   * no claim is configured, the token subject is used (default behavior).
    *
    * @param oidcUser             the user
    * @param oidcExtendProperties claimName properties
    * @return the Apollo user id
+   * @throws BadCredentialsException if a claim is configured but absent or blank in the token
    */
   public static String getOidcUserId(OidcUser oidcUser, OidcExtendProperties oidcExtendProperties) {
     String userIdClaimName = oidcExtendProperties.getUserIdClaimName();
-    String subject = oidcUser.getSubject();
     if (StringUtils.isBlank(userIdClaimName)) {
-      return subject;
+      return oidcUser.getSubject();
     }
     String userId = oidcUser.getClaimAsString(userIdClaimName);
     if (StringUtils.isBlank(userId)) {
-      log.warn(
-          "oidc user id claim [{}] is missing or blank, falling back to subject as the Apollo user id",
-          userIdClaimName);
-      return subject;
+      throw new BadCredentialsException(
+          String.format("the configured oidc user id claim [%s] is missing or blank in the token",
+              userIdClaimName));
     }
     return userId;
   }
 
   /**
    * resolve the Apollo user id from a jwt. Behaves like
-   * {@link #getOidcUserId(OidcUser, OidcExtendProperties)}, reading the same configured claim and
-   * falling back to the jwt subject when it is missing or blank.
+   * {@link #getOidcUserId(OidcUser, OidcExtendProperties)}, reading the same configured claim,
+   * using the jwt subject only when no claim is configured, and rejecting the login when a
+   * configured claim is missing or blank.
    *
    * @param jwt                  the user
    * @param oidcExtendProperties claimName properties
    * @return the Apollo user id
+   * @throws BadCredentialsException if a claim is configured but absent or blank in the token
    */
   public static String getJwtUserId(Jwt jwt, OidcExtendProperties oidcExtendProperties) {
     String userIdClaimName = oidcExtendProperties.getUserIdClaimName();
-    String subject = jwt.getSubject();
     if (StringUtils.isBlank(userIdClaimName)) {
-      return subject;
+      return jwt.getSubject();
     }
     String userId = jwt.getClaimAsString(userIdClaimName);
     if (StringUtils.isBlank(userId)) {
-      log.warn(
-          "jwt user id claim [{}] is missing or blank, falling back to subject as the Apollo user id",
-          userIdClaimName);
-      return subject;
+      throw new BadCredentialsException(
+          String.format("the configured jwt user id claim [%s] is missing or blank in the token",
+              userIdClaimName));
     }
     return userId;
   }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
@@ -17,18 +17,21 @@
 package com.ctrip.framework.apollo.portal.spi.oidc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.portal.spi.configuration.OidcExtendProperties;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
  * Tests resolution of the Apollo user id from the configurable OIDC/JWT claim, covering the
- * unconfigured default (token subject), a configured-and-present claim, and the fallback to the
- * subject when the configured claim is missing or blank.
+ * unconfigured default (token subject), a configured-and-present claim, the fail-closed rejection
+ * when a configured claim is missing or blank, and cross-path consistency between the OIDC and JWT
+ * resolvers.
  */
 public class OidcUserInfoUtilTest {
 
@@ -63,25 +66,25 @@ public class OidcUserInfoUtilTest {
   }
 
   @Test
-  public void testGetOidcUserIdFallsBackToSubjectWhenConfiguredClaimBlank() {
+  public void testGetOidcUserIdRejectsWhenConfiguredClaimBlank() {
     OidcExtendProperties properties = new OidcExtendProperties();
     properties.setUserIdClaimName("preferred_username");
     OidcUser oidcUser = mock(OidcUser.class);
-    when(oidcUser.getSubject()).thenReturn(SUBJECT);
     when(oidcUser.getClaimAsString("preferred_username")).thenReturn(" ");
 
-    assertEquals(SUBJECT, OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+    assertThrows(BadCredentialsException.class,
+        () -> OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
   }
 
   @Test
-  public void testGetOidcUserIdFallsBackToSubjectWhenConfiguredClaimMissing() {
+  public void testGetOidcUserIdRejectsWhenConfiguredClaimMissing() {
     OidcExtendProperties properties = new OidcExtendProperties();
     properties.setUserIdClaimName("preferred_username");
     OidcUser oidcUser = mock(OidcUser.class);
-    when(oidcUser.getSubject()).thenReturn(SUBJECT);
     when(oidcUser.getClaimAsString("preferred_username")).thenReturn(null);
 
-    assertEquals(SUBJECT, OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+    assertThrows(BadCredentialsException.class,
+        () -> OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
   }
 
   @Test
@@ -100,10 +103,29 @@ public class OidcUserInfoUtilTest {
   }
 
   @Test
-  public void testGetJwtUserIdFallsBackToSubjectWhenConfiguredClaimMissing() {
+  public void testGetJwtUserIdRejectsWhenConfiguredClaimMissing() {
     OidcExtendProperties properties = new OidcExtendProperties();
     properties.setUserIdClaimName("preferred_username");
 
-    assertEquals(SUBJECT, OidcUserInfoUtil.getJwtUserId(jwtWith(null), properties));
+    assertThrows(BadCredentialsException.class,
+        () -> OidcUserInfoUtil.getJwtUserId(jwtWith(null), properties));
+  }
+
+  /**
+   * The same principal must resolve to the same Apollo user id, or be rejected, regardless of
+   * whether it arrives on the interactive OIDC path or the JWT path. When the configured claim is
+   * present on one path but absent on the other, failing closed on the absent path prevents the
+   * principal from being provisioned as two different Apollo accounts.
+   */
+  @Test
+  public void testCrossPathConsistencyWhenClaimPresentOnOidcButAbsentOnJwt() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getClaimAsString("preferred_username")).thenReturn("alice");
+
+    assertEquals("alice", OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+    assertThrows(BadCredentialsException.class,
+        () -> OidcUserInfoUtil.getJwtUserId(jwtWith(null), properties));
   }
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
@@ -111,6 +111,15 @@ public class OidcUserInfoUtilTest {
         () -> OidcUserInfoUtil.getJwtUserId(jwtWith(null), properties));
   }
 
+  @Test
+  public void testGetJwtUserIdRejectsWhenConfiguredClaimBlank() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+
+    assertThrows(BadCredentialsException.class,
+        () -> OidcUserInfoUtil.getJwtUserId(jwtWith(" "), properties));
+  }
+
   /**
    * The same principal must resolve to the same Apollo user id, or be rejected, regardless of
    * whether it arrives on the interactive OIDC path or the JWT path. When the configured claim is

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
@@ -16,12 +16,12 @@
  */
 package com.ctrip.framework.apollo.portal.spi.oidc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.portal.spi.configuration.OidcExtendProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
@@ -25,6 +25,11 @@ import org.junit.Test;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+/**
+ * Tests resolution of the Apollo user id from the configurable OIDC/JWT claim, covering the
+ * unconfigured default (token subject), a configured-and-present claim, and the fallback to the
+ * subject when the configured claim is missing or blank.
+ */
 public class OidcUserInfoUtilTest {
 
   private static final String SUBJECT = "8f3a2c1e-uuid-subject";

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoUtilTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ctrip.framework.apollo.portal.spi.configuration.OidcExtendProperties;
+import org.junit.Test;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class OidcUserInfoUtilTest {
+
+  private static final String SUBJECT = "8f3a2c1e-uuid-subject";
+
+  private static Jwt jwtWith(String preferredUsername) {
+    Jwt.Builder builder = Jwt.withTokenValue("token").header("alg", "none").subject(SUBJECT);
+    if (preferredUsername != null) {
+      builder.claim("preferred_username", preferredUsername);
+    }
+    return builder.build();
+  }
+
+  @Test
+  public void testGetOidcUserIdDefaultsToSubjectWhenClaimNotConfigured() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getSubject()).thenReturn(SUBJECT);
+
+    assertEquals(SUBJECT, OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+  }
+
+  @Test
+  public void testGetOidcUserIdUsesConfiguredClaim() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getSubject()).thenReturn(SUBJECT);
+    when(oidcUser.getClaimAsString("preferred_username")).thenReturn("alice");
+
+    assertEquals("alice", OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+  }
+
+  @Test
+  public void testGetOidcUserIdFallsBackToSubjectWhenConfiguredClaimBlank() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getSubject()).thenReturn(SUBJECT);
+    when(oidcUser.getClaimAsString("preferred_username")).thenReturn(" ");
+
+    assertEquals(SUBJECT, OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+  }
+
+  @Test
+  public void testGetOidcUserIdFallsBackToSubjectWhenConfiguredClaimMissing() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getSubject()).thenReturn(SUBJECT);
+    when(oidcUser.getClaimAsString("preferred_username")).thenReturn(null);
+
+    assertEquals(SUBJECT, OidcUserInfoUtil.getOidcUserId(oidcUser, properties));
+  }
+
+  @Test
+  public void testGetJwtUserIdDefaultsToSubjectWhenClaimNotConfigured() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+
+    assertEquals(SUBJECT, OidcUserInfoUtil.getJwtUserId(jwtWith("alice"), properties));
+  }
+
+  @Test
+  public void testGetJwtUserIdUsesConfiguredClaim() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+
+    assertEquals("alice", OidcUserInfoUtil.getJwtUserId(jwtWith("alice"), properties));
+  }
+
+  @Test
+  public void testGetJwtUserIdFallsBackToSubjectWhenConfiguredClaimMissing() {
+    OidcExtendProperties properties = new OidcExtendProperties();
+    properties.setUserIdClaimName("preferred_username");
+
+    assertEquals(SUBJECT, OidcUserInfoUtil.getJwtUserId(jwtWith(null), properties));
+  }
+}

--- a/docs/en/extension/portal-how-to-implement-user-login-function.md
+++ b/docs/en/extension/portal-how-to-implement-user-login-function.md
@@ -347,13 +347,24 @@ used as the Apollo user identity in the `application-oidc.yml`.
   `spring.security.oidc.user-id-claim-name`, default to the token subject (`sub`).
 * the same claim is applied to both the oidc (interactive) and jwt login paths so they resolve the
   same Apollo user id.
-* when the configured claim is missing or blank, Apollo falls back to the subject so a user is never
-  created with an empty id.
+* when the configured claim is missing or blank in a token, login is rejected rather than falling
+  back to the subject, so the same principal is never provisioned as two different Apollo users
+  across the oidc and jwt paths.
 * this is non-breaking: leaving the property unset keeps the current `sub` based behavior.
+
+The value of this claim becomes the Apollo login identity (`Users.Username`) and drives
+authorization, so choose it carefully. The claim must be controlled by the identity provider,
+unique, immutable, non-reassignable and not user-editable, because if its value collides with an
+existing `Users.Username` Apollo will reuse that account together with its roles and any
+super-admin status. `Users.Username` is limited to 64 characters, and the OpenID Connect
+specification warns that claims like `preferred_username` and `email` are not guaranteed to be
+stable or unique. Only use such a claim when your identity provider guarantees the properties above,
+and verify your existing username mappings before rolling this out.
 
 ##### 1.3.1 Example of user identity configure
 
-* for example, using `preferred_username` as the claim of the Apollo user identity.
+* for example, using `preferred_username` as the claim of the Apollo user identity, once you have
+  confirmed your identity provider issues it as a stable, unique and immutable value.
 
 ```yml
 spring:

--- a/docs/en/extension/portal-how-to-implement-user-login-function.md
+++ b/docs/en/extension/portal-how-to-implement-user-login-function.md
@@ -336,7 +336,34 @@ spring:
           issuer-uri: https://host:port/auth/realms/apollo
 ```
 
-#### 1.3 Configure user display name
+#### 1.3 Configure user identity (username)
+
+By default Apollo uses the token subject (`sub`) as the Apollo user identity (`Users.Username`).
+For many enterprise OpenID Connect providers `sub` is an opaque UUID, while the real login name or
+employee id is carried in another claim such as `preferred_username`. You can configure the claim
+used as the Apollo user identity in the `application-oidc.yml`.
+
+* the configuration property name for the oidc (interactive) and jwt user identity is
+  `spring.security.oidc.user-id-claim-name`, default to the token subject (`sub`).
+* the same claim is applied to both the oidc (interactive) and jwt login paths so they resolve the
+  same Apollo user id.
+* when the configured claim is missing or blank, Apollo falls back to the subject so a user is never
+  created with an empty id.
+* this is non-breaking: leaving the property unset keeps the current `sub` based behavior.
+
+##### 1.3.1 Example of user identity configure
+
+* for example, using `preferred_username` as the claim of the Apollo user identity.
+
+```yml
+spring:
+  security:
+    oidc:
+      user-id-claim-name: "preferred_username"
+
+```
+
+#### 1.4 Configure user display name
 
 you can also configure a custom user display name in the `application-oidc.yml`
 
@@ -347,7 +374,7 @@ you can also configure a custom user display name in the `application-oidc.yml`
 * the configuration property name for oidc jwt user display name is `spring.security.oidc.jwt-user-display-name-claim-name`,
   has no default.
 
-##### 1.3.1 Example of user display name configure
+##### 1.4.1 Example of user display name configure
 
 * for example, using `name` as the claim of oidc (interactive) user display name.
 

--- a/docs/zh/extension/portal-how-to-implement-user-login-function.md
+++ b/docs/zh/extension/portal-how-to-implement-user-login-function.md
@@ -329,7 +329,31 @@ spring:
           issuer-uri: https://host:port/auth/realms/apollo
 ```
 
-#### 1.3 用户显示名配置
+#### 1.3 用户身份（用户名）配置
+
+Apollo 默认使用 token 的 subject（`sub`）作为 Apollo 用户身份（`Users.Username`）。很多企业 OpenID
+Connect 服务的 `sub` 是一个不透明的 UUID, 真正的登录名或工号在 `preferred_username` 等其他 claim 中。可以在
+`application-oidc.yml` 中配置作为 Apollo 用户身份的 claim。
+
+* oidc 交互式登录和 jwt 方式登录的用户身份配置项均为 `spring.security.oidc.user-id-claim-name`,
+  未配置的情况下默认取 token 的 subject（`sub`）
+* 该 claim 同时作用于 oidc 交互式登录和 jwt 登录, 保证两条路径解析出相同的 Apollo 用户身份
+* 当配置的 claim 缺失或为空时, Apollo 会回退到 subject, 避免创建出空的用户身份
+* 该改动是非破坏性的, 不配置该项即保持当前基于 `sub` 的行为
+
+##### 1.3.1 用户身份配置示例
+
+* 例如, 使用 `preferred_username` 作为 Apollo 用户身份的 claim
+
+```yml
+spring:
+  security:
+    oidc:
+      user-id-claim-name: "preferred_username"
+
+```
+
+#### 1.4 用户显示名配置
 
 用户的显示名支持自定义配置, 在 `application-oidc.yml` 添加配置项即可
 
@@ -341,7 +365,7 @@ spring:
 * oidc jwt 方式登录用户的显示名配置项为 `spring.security.oidc.jwt-user-display-name-claim-name`,
   无默认值
 
-##### 1.3.1 用户显示名配置示例
+##### 1.4.1 用户显示名配置示例
 
 * 例如在进行 oidc 交互式登录时使用 `name` 作为显示名, 则配置如下
 

--- a/docs/zh/extension/portal-how-to-implement-user-login-function.md
+++ b/docs/zh/extension/portal-how-to-implement-user-login-function.md
@@ -338,12 +338,19 @@ Connect 服务的 `sub` 是一个不透明的 UUID, 真正的登录名或工号�
 * oidc 交互式登录和 jwt 方式登录的用户身份配置项均为 `spring.security.oidc.user-id-claim-name`,
   未配置的情况下默认取 token 的 subject（`sub`）
 * 该 claim 同时作用于 oidc 交互式登录和 jwt 登录, 保证两条路径解析出相同的 Apollo 用户身份
-* 当配置的 claim 缺失或为空时, Apollo 会回退到 subject, 避免创建出空的用户身份
+* 当配置的 claim 在 token 中缺失或为空时, 登录会被拒绝, 而不是回退到 subject, 从而避免同一主体在 oidc 和 jwt
+  两条路径上被创建成两个不同的 Apollo 用户
 * 该改动是非破坏性的, 不配置该项即保持当前基于 `sub` 的行为
+
+该 claim 的值会成为 Apollo 的登录身份（`Users.Username`）并决定授权, 因此需要谨慎选择。所选 claim 必须由身份
+提供方控制, 且唯一、不可变、不可重新分配、不可由用户自行修改, 因为一旦其值与已有的 `Users.Username` 冲突,
+Apollo 会复用该账户及其角色乃至超级管理员权限。`Users.Username` 最长 64 个字符, 且 OpenID Connect 规范指出
+`preferred_username` 和 `email` 等 claim 并不保证稳定或唯一。只有当你的身份提供方能够保证上述属性时才使用此类
+claim, 并在启用前核对现有的用户名映射关系。
 
 ##### 1.3.1 用户身份配置示例
 
-* 例如, 使用 `preferred_username` 作为 Apollo 用户身份的 claim
+* 例如, 在确认身份提供方以稳定、唯一且不可变的方式签发该 claim 后, 使用 `preferred_username` 作为 Apollo 用户身份的 claim
 
 ```yml
 spring:


### PR DESCRIPTION
## What's the purpose of this PR

Apollo currently uses the OIDC/JWT subject (`sub`) as the Apollo user identity (`UserInfo.userId`, persisted to `Users.Username`). With enterprise OpenID Connect providers (Keycloak, Okta, Azure AD, Alibaba Cloud IDaaS) `sub` is often an opaque UUID, while the real login name or employee id is carried in another claim such as `preferred_username`. Today the only workarounds are to make the IdP emit the desired id as `sub` or to maintain a custom Apollo build.

This adds a Portal-side configurable claim for the Apollo user identity, following the direction agreed on the issue. Only the display-name claim was configurable before; the login identity was not.

## Which issue(s) this PR fixes:
Fixes #5633

## Brief changelog

A new property `spring.security.oidc.user-id-claim-name` (default: the token subject `sub`) controls which claim becomes the Apollo user id, for both the interactive OIDC and the JWT login paths.

The resolution is centralized in `OidcUserInfoUtil` (`getOidcUserId` / `getJwtUserId`) so that both `OidcAuthenticationSuccessEventListener` (user creation and lookup) and `OidcUserInfoHolder` (current user) agree on the same id, matching the existing shared-helper pattern used for the display name.

When the configured claim is missing or blank, authentication is rejected rather than falling back to the subject, so the same principal cannot resolve to one id on the interactive OIDC path and a different id on the JWT path and be provisioned as two Apollo accounts. The change is non-breaking: leaving the property unset keeps the current `sub` based behavior.

Added `OidcUserInfoUtilTest` covering the OIDC and JWT paths for the default (unconfigured), configured-and-present, and configured-but-missing/blank cases. Updated the English and Chinese `portal-how-to-implement-user-login-function` docs.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything (ran `OidcUserInfoUtilTest` in apollo-portal, 9 passing).
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OIDC and JWT username claim support through `spring.security.oidc.user-id-claim-name`.
  * Defaults to the `sub` claim when no custom claim is configured.
  * Rejects login when a configured claim is missing or blank.
  * Supports consistent identity mapping across interactive and JWT logins.

* **Documentation**
  * Updated English and Chinese login configuration guides with setup examples and claim uniqueness and stability requirements.

* **Tests**
  * Added coverage for default, custom-claim, and invalid-claim authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
