### PR TITLE
feat(portal): support revoking non-properties namespace changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Apollo 3.0.0
 * [Fix: return 429 instead of redirecting to sign-in for OpenAPI user token rate limits](https://github.com/apolloconfig/apollo/pull/5637)
 * [Fix: physically delete retained release history and unreferenced release rows](https://github.com/apolloconfig/apollo/pull/5641)
 * [Fix: preserve item type when revoking unpublished changes](https://github.com/apolloconfig/apollo/pull/5646)
+* [Feature: support revoking unpublished changes for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/5656)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/src/main/resources/static/styles/common-style.css
+++ b/apollo-portal/src/main/resources/static/styles/common-style.css
@@ -388,6 +388,17 @@ table th {
     border-top: solid 1px #ffffff;
 }
 
+.config-item-container .second-panel-heading .ns-icon-button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+}
+
+.config-item-container .second-panel-heading .ns-icon-button img {
+    width: 25px;
+    height: 25px;
+}
+
 .config-item-container .second-panel-heading .nav-tabs .node_active {
     border-bottom: 3px #1b6d85 solid;
 }

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -181,6 +181,13 @@
                          ng-click="goToDiffPage(namespace)"
                          ng-show="namespace.displayControl.currentOperateBranch == 'master' && !namespace.isPropertiesFormat && !namespace.isTextEditing">
                     &nbsp;
+                    <img src="img/rollback.png" class="ns_btn cursor-pointer"
+                         data-tooltip="tooltip" data-placement="bottom"
+                         title="{{'Component.Namespace.Master.Items.RevokeItemTips' | translate }}"
+                         ng-click="preRevokeItem(namespace)"
+                         ng-show="namespace.viewType == 'text' && namespace.displayControl.currentOperateBranch == 'master'
+                         && !namespace.isPropertiesFormat && !namespace.isTextEditing && namespace.hasModifyPermission">
+                    &nbsp;
                     <img src="img/copy.png" class="ns_btn clipboard cursor-pointer"
                         data-clipboard-text="{{namespace.text}}" data-tooltip="tooltip" data-placement="bottom"
                         title="{{'Component.Namespace.Master.Items.CopyText' | translate }}"

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -181,12 +181,15 @@
                          ng-click="goToDiffPage(namespace)"
                          ng-show="namespace.displayControl.currentOperateBranch == 'master' && !namespace.isPropertiesFormat && !namespace.isTextEditing">
                     &nbsp;
-                    <img src="img/rollback.png" class="ns_btn cursor-pointer"
-                         data-tooltip="tooltip" data-placement="bottom"
-                         title="{{'Component.Namespace.Master.Items.RevokeItemTips' | translate }}"
-                         ng-click="preRevokeItem(namespace)"
-                         ng-show="namespace.viewType == 'text' && namespace.displayControl.currentOperateBranch == 'master'
-                         && !namespace.isPropertiesFormat && !namespace.isTextEditing && namespace.hasModifyPermission">
+                    <button type="button" class="ns_btn ns-icon-button cursor-pointer"
+                            data-tooltip="tooltip" data-placement="bottom"
+                            title="{{'Component.Namespace.Master.Items.RevokeItemTips' | translate }}"
+                            aria-label="{{'Component.Namespace.Master.Items.RevokeItem' | translate }}"
+                            ng-click="preRevokeItem(namespace)"
+                            ng-show="namespace.viewType == 'text' && namespace.displayControl.currentOperateBranch == 'master'
+                            && !namespace.isPropertiesFormat && !namespace.isTextEditing && namespace.hasModifyPermission">
+                        <img src="img/rollback.png" alt="">
+                    </button>
                     &nbsp;
                     <img src="img/copy.png" class="ns_btn clipboard cursor-pointer"
                         data-clipboard-text="{{namespace.text}}" data-tooltip="tooltip" data-placement="bottom"

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
@@ -197,6 +197,79 @@ public class ConfigServiceTest extends AbstractUnitTest {
     assertEquals(2, changeSets.getCreateItems().get(0).getType());
   }
 
+  @Test
+  public void testRevokeItemShouldRestorePublishedFileContent() {
+    String appId = "6666";
+    Env env = Env.DEV;
+    String clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
+    String namespaceName = "application.yaml";
+    long namespaceId = 123L;
+    String publishedContent = "server:\n  port: 8080";
+
+    NamespaceDTO namespace = generateNamespaceDTO(appId, clusterName, namespaceName);
+    namespace.setId(namespaceId);
+    ReleaseDTO release = new ReleaseDTO();
+    release.setConfigurations("{\"content\":\"server:\\n  port: 8080\"}");
+
+    ItemDTO currentItem =
+        new ItemDTO(ConfigConsts.CONFIG_FILE_CONTENT_KEY, "server:\n  port: 9090", "", 1);
+    currentItem.setId(1L);
+    currentItem.setNamespaceId(namespaceId);
+
+    when(namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName)).thenReturn(namespace);
+    when(releaseAPI.loadLatestRelease(appId, env, clusterName, namespaceName)).thenReturn(release);
+    when(itemAPI.findItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.singletonList(currentItem));
+    when(itemAPI.findDeletedItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.emptyList());
+
+    configService.revokeItem(appId, env, clusterName, namespaceName, "test");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemAPI).updateItemsByChangeSet(eq(appId), eq(env), eq(clusterName), eq(namespaceName),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertEquals(0, changeSets.getCreateItems().size());
+    assertEquals(1, changeSets.getUpdateItems().size());
+    assertEquals(0, changeSets.getDeleteItems().size());
+    assertEquals(ConfigConsts.CONFIG_FILE_CONTENT_KEY, changeSets.getUpdateItems().get(0).getKey());
+    assertEquals(publishedContent, changeSets.getUpdateItems().get(0).getValue());
+  }
+
+  @Test
+  public void testRevokeItemShouldRemoveUnpublishedFileContent() {
+    String appId = "6666";
+    Env env = Env.DEV;
+    String clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
+    String namespaceName = "application.json";
+    long namespaceId = 123L;
+
+    NamespaceDTO namespace = generateNamespaceDTO(appId, clusterName, namespaceName);
+    namespace.setId(namespaceId);
+    ItemDTO currentItem =
+        new ItemDTO(ConfigConsts.CONFIG_FILE_CONTENT_KEY, "{\"enabled\":true}", "", 1);
+    currentItem.setId(1L);
+    currentItem.setNamespaceId(namespaceId);
+
+    when(namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName)).thenReturn(namespace);
+    when(releaseAPI.loadLatestRelease(appId, env, clusterName, namespaceName)).thenReturn(null);
+    when(itemAPI.findItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.singletonList(currentItem));
+    when(itemAPI.findDeletedItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.emptyList());
+
+    configService.revokeItem(appId, env, clusterName, namespaceName, "test");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemAPI).updateItemsByChangeSet(eq(appId), eq(env), eq(clusterName), eq(namespaceName),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertEquals(0, changeSets.getCreateItems().size());
+    assertEquals(0, changeSets.getUpdateItems().size());
+    assertEquals(1, changeSets.getDeleteItems().size());
+    assertEquals(ConfigConsts.CONFIG_FILE_CONTENT_KEY, changeSets.getDeleteItems().get(0).getKey());
+  }
+
   /**
    * a=b b=c c=d
    */

--- a/apollo-portal/src/test/resources/static/scripts/test_revokeNonPropertiesNamespace.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_revokeNonPropertiesNamespace.js
@@ -27,9 +27,12 @@ var revokeControls =
 
 var hasNonPropertiesRevokeControl = revokeControls.some(function (control) {
     return control.indexOf("namespace.viewType == 'text'") >= 0
+        && control.indexOf("namespace.displayControl.currentOperateBranch == 'master'") >= 0
         && control.indexOf("!namespace.isPropertiesFormat") >= 0
         && control.indexOf("!namespace.isTextEditing") >= 0
-        && control.indexOf("namespace.hasModifyPermission") >= 0;
+        && control.indexOf("namespace.hasModifyPermission") >= 0
+        && control.indexOf('aria-label=') >= 0
+        && control.indexOf('<button') === 0;
 });
 
 if (!hasNonPropertiesRevokeControl) {

--- a/apollo-portal/src/test/resources/static/scripts/test_revokeNonPropertiesNamespace.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_revokeNonPropertiesNamespace.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var templatePath = path.resolve(
+    __dirname,
+    '../../../../main/resources/static/views/component/namespace-panel-master-tab.html'
+);
+var template = fs.readFileSync(templatePath, 'utf8');
+var revokeControls =
+    template.match(/<(?:button|img)\b[^>]*ng-click="preRevokeItem\(namespace\)"[^>]*>/g) || [];
+
+var hasNonPropertiesRevokeControl = revokeControls.some(function (control) {
+    return control.indexOf("namespace.viewType == 'text'") >= 0
+        && control.indexOf("!namespace.isPropertiesFormat") >= 0
+        && control.indexOf("!namespace.isTextEditing") >= 0
+        && control.indexOf("namespace.hasModifyPermission") >= 0;
+});
+
+if (!hasNonPropertiesRevokeControl) {
+    console.error('Non-properties namespace revoke control is missing or has incomplete guards.');
+    process.exit(1);
+}
+
+console.log('Non-properties namespace revoke control is available.');


### PR DESCRIPTION
## What's the purpose of this PR

Extend the Portal's "revoke unpublished changes" action to non-properties namespaces such as YAML, JSON, XML, and TXT.

The existing backend revocation flow already restores file-format namespaces from the latest release or removes an unpublished file-content item when no release exists. The Portal UI only exposed the action for properties namespaces, so users could not trigger the existing behavior for file-format namespaces.

## Which issue(s) this PR fixes:

N/A

## Brief changelog

- Show the revoke action in the non-properties text editor toolbar when viewing the master namespace and the user has modify permission.
- Keep the action hidden while text editing is active to avoid accidental revocation.
- Add regression tests for restoring published file content and removing unpublished file content.
- Add a JavaScript template test for the non-properties revoke control.

Validation completed:

- `mvn spotless:check`
- `./mvnw -pl apollo-portal -am test` (685 tests passed, 0 failures, 0 errors, 1 skipped)
- All static JavaScript tests
- `./mvnw -pl apollo-assembly -am -DskipTests package`

The `CHANGES.md` entry will be added after this PR receives its URL, per repository contribution guidelines.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the Contributing Guide before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn spotless:apply` to format your code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the `CHANGES` log after the PR URL is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for revoking unpublished changes in non-properties namespaces.
  * Added an accessible rollback control for eligible file-format namespaces in the namespace toolbar.

* **Bug Fixes**
  * Restoring published file content now works correctly when revoking changes.
  * Unpublished file content is removed when no prior release exists.

* **Style**
  * Improved the appearance and consistency of namespace toolbar controls.

* **Tests**
  * Added coverage for revoke behavior and rollback control visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->