### PR TITLE
feat(portal): add formatted and raw JSON views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
-* [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 * [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 * [Change: official Config/Admin packages now default to database discovery; upgraded Eureka deployments should explicitly keep the `github` profile to preserve legacy behavior](https://github.com/apolloconfig/apollo/pull/5580)
 * [Refactor: extract config constants and methods in BizConfig, PortalConfig, and RefreshableConfig](https://github.com/apolloconfig/apollo/pull/5583)
@@ -24,6 +23,7 @@ Apollo 3.0.0
 * [Fix: physically delete retained release history and unreferenced release rows](https://github.com/apolloconfig/apollo/pull/5641)
 * [Fix: preserve item type when revoking unpublished changes](https://github.com/apolloconfig/apollo/pull/5646)
 * [Feature: support revoking unpublished changes for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/5656)
+* [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
+* [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 * [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 * [Change: official Config/Admin packages now default to database discovery; upgraded Eureka deployments should explicitly keep the `github` profile to preserve legacy behavior](https://github.com/apolloconfig/apollo/pull/5580)
 * [Refactor: extract config constants and methods in BizConfig, PortalConfig, and RefreshableConfig](https://github.com/apolloconfig/apollo/pull/5583)

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -334,6 +334,8 @@
   "Component.Rollback.NoChange": "No configuration changes",
   "Component.Rollback.OpRollback": "Rollback",
   "Component.ShowText.Title": "View",
+  "Component.ShowText.FormattedValue": "Formatted",
+  "Component.ShowText.RawValue": "Raw",
   "Login.Login": "Login",
   "Login.UserNameOrPasswordIncorrect": "Incorrect username or password",
   "Login.LogoutSuccessfully": "Logout Successfully",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -334,6 +334,8 @@
   "Component.Rollback.NoChange": "配置没有变化",
   "Component.Rollback.OpRollback": "回滚",
   "Component.ShowText.Title": "查看",
+  "Component.ShowText.FormattedValue": "格式化",
+  "Component.ShowText.RawValue": "原始值",
   "Login.Login": "登录",
   "Login.UserNameOrPasswordIncorrect": "用户名或密码错误",
   "Login.LogoutSuccessfully": "登出成功",

--- a/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
@@ -17,8 +17,12 @@
 directive_module.directive('showtextmodal', showTextModalDirective)
     .filter('jsonBigIntFilter', function () {
         return function (text) {
-            if (typeof(text) === "undefined" || typeof JSON.parse(text) !== "object"
-                || !text) {
+            if (typeof(text) === "undefined" || !text) {
+                return;
+            }
+            try {
+                JSON.parse(text);
+            } catch (e) {
                 return;
             }
 
@@ -102,7 +106,8 @@ function showTextModalDirective(AppUtil) {
 
             function isJsonText(text) {
                 try {
-                    return typeof JSON.parse(text) === "object";
+                    JSON.parse(text);
+                    return true;
                 } catch (e) {
                     return false;
                 }
@@ -135,4 +140,3 @@ function showTextModalDirective(AppUtil) {
         }
     }
 }
-

--- a/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
@@ -26,11 +26,14 @@ directive_module.directive('showtextmodal', showTextModalDirective)
                 return;
             }
 
-            const numberRegex = /"\|+-?\d+\|+"/g;
-            const splitRegex = /"\|+-?\d+\|+"/;
+            const numberRegex =
+                /"\|+-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?\|+"/g;
+            const splitRegex =
+                /"\|+-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?\|+"/;
             const splitArray = text.split(splitRegex);
             const matchResult = text.match(numberRegex);
-            const borderRegex = /"\|-?\d+\|"/;
+            const borderRegex =
+                /"\|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?\|"/;
             if (!matchResult || 0 === splitArray.length) {
                 return text;
             } else {
@@ -117,21 +120,23 @@ function showTextModalDirective(AppUtil) {
                 if (/\d+/.test(str)) {
                     let replaceMap = [];
                     let n = 0;
-                    str = str.replace(/"\|+-?\d+\|+"/g, function (match) {
-                        return match.replace('"\|', '"\||').replace('|"', '||"');
-                    })
+                    str = str.replace(
+                        /"\|+-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?\|+"/g,
+                        function (match) {
+                            return match.replace('"\|', '"\||').replace('|"', '||"');
+                        })
                     .replace(/"(\\?[\s\S])*?"/g, function (match) {
                         if (/\d+/.test(match)) {
                             replaceMap.push(match);
                             return '"""';
                         }
                         return match;
-                    }).replace(/[+\-\d.eE]+/g, function (match) {
-                        if (/^-?\d+$/.test(match)) {
+                    }).replace(
+                        /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?/g,
+                        function (match) {
                             return '"|' + match + '|"';
-                        }
-                        return match;
-                    }).replace(/"""/g, function () {
+                        })
+                    .replace(/"""/g, function () {
                         return replaceMap[n++];
                     })
                 }

--- a/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
@@ -26,11 +26,11 @@ directive_module.directive('showtextmodal', showTextModalDirective)
                 return;
             }
 
-            const numberRegex = /"\|+\d+\|+"/g;
-            const splitRegex = /"\|+\d+\|+"/;
+            const numberRegex = /"\|+-?\d+\|+"/g;
+            const splitRegex = /"\|+-?\d+\|+"/;
             const splitArray = text.split(splitRegex);
             const matchResult = text.match(numberRegex);
-            const borderRegex = /"\|\d+\|"/;
+            const borderRegex = /"\|-?\d+\|"/;
             if (!matchResult || 0 === splitArray.length) {
                 return text;
             } else {
@@ -117,7 +117,7 @@ function showTextModalDirective(AppUtil) {
                 if (/\d+/.test(str)) {
                     let replaceMap = [];
                     let n = 0;
-                    str = str.replace(/"\|+\d+\|+"/g, function (match) {
+                    str = str.replace(/"\|+-?\d+\|+"/g, function (match) {
                         return match.replace('"\|', '"\||').replace('|"', '||"');
                     })
                     .replace(/"(\\?[\s\S])*?"/g, function (match) {
@@ -127,7 +127,7 @@ function showTextModalDirective(AppUtil) {
                         }
                         return match;
                     }).replace(/[+\-\d.eE]+/g, function (match) {
-                        if (/^\d+$/.test(match)) {
+                        if (/^-?\d+$/.test(match)) {
                             return '"|' + match + '|"';
                         }
                         return match;

--- a/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/show-text-modal-directive.js
@@ -84,10 +84,21 @@ function showTextModalDirective(AppUtil) {
 
             function init() {
                 scope.jsonObject = undefined;
+                scope.canFormat = false;
+                scope.viewMode = 'raw';
                 if (isJsonText(scope.text) && !AppUtil.hasDuplicateKeys(scope.text)) {
                     scope.jsonObject = parseBigInt(scope.text);
+                    scope.canFormat = true;
+                    scope.viewMode = 'formatted';
                 }
             }
+
+            scope.setViewMode = function (viewMode, event) {
+                if (event) {
+                    event.preventDefault();
+                }
+                scope.viewMode = viewMode;
+            };
 
             function isJsonText(text) {
                 try {
@@ -124,5 +135,4 @@ function showTextModalDirective(AppUtil) {
         }
     }
 }
-
 

--- a/apollo-portal/src/main/resources/static/views/component/show-text-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/show-text-modal.html
@@ -24,8 +24,25 @@
                 <h4 class="modal-title">{{'Component.ShowText.Title' | translate }}</h4>
             </div>
             <div ng-show="!enableTextDiff">
-                <pre class="modal-body no-radius" style="margin-bottom: 0" ng-show="!jsonObject" ng-bind="text"></pre>
-                <pre class="modal-body no-radius" style="margin-bottom: 0" ng-show="jsonObject" ng-bind="jsonObject | json:4 | jsonBigIntFilter"></pre>
+                <ul class="nav nav-tabs" ng-if="canFormat">
+                    <li ng-class="{active: viewMode == 'formatted'}">
+                        <a href="" role="tab" ng-click="setViewMode('formatted', $event)"
+                           ng-attr-aria-selected="{{viewMode == 'formatted'}}">
+                            {{'Component.ShowText.FormattedValue' | translate }}
+                        </a>
+                    </li>
+                    <li ng-class="{active: viewMode == 'raw'}">
+                        <a href="" role="tab" ng-click="setViewMode('raw', $event)"
+                           ng-attr-aria-selected="{{viewMode == 'raw'}}">
+                            {{'Component.ShowText.RawValue' | translate }}
+                        </a>
+                    </li>
+                </ul>
+                <pre class="modal-body no-radius" style="margin-bottom: 0"
+                      ng-show="!canFormat || viewMode == 'raw'" ng-bind="text"></pre>
+                <pre class="modal-body no-radius" style="margin-bottom: 0"
+                      ng-show="canFormat && viewMode == 'formatted'"
+                      ng-bind="jsonObject | json:4 | jsonBigIntFilter"></pre>
             </div>
             <span ng-show="enableTextDiff">
                 <apollodiff old-str="oldStr" new-str="newStr" apollo-id="'textDiff'"> </apollodiff>

--- a/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
@@ -24,10 +24,14 @@ const directivePath = path.join(__dirname, '../../../../main/resources/static/sc
 const templatePath = path.join(__dirname, '../../../../main/resources/static/views/component',
     'show-text-modal.html');
 
+let jsonBigIntFilterFactory;
 const directiveModule = {
     directive: function () {
         return {
-            filter: function () {
+            filter: function (name, factory) {
+                if (name === 'jsonBigIntFilter') {
+                    jsonBigIntFilterFactory = factory;
+                }
                 return this;
             }
         };
@@ -41,6 +45,7 @@ vm.runInNewContext(fs.readFileSync(directivePath, 'utf8'), context, {
     filename: directivePath
 });
 
+const jsonBigIntFilter = jsonBigIntFilterFactory();
 const directiveDefinition = context.showTextModalDirective({
     prefixPath: function () {
         return '';
@@ -67,20 +72,47 @@ function createScope() {
 }
 
 function runTests() {
-    const formatted = createScope();
-    formatted.scope.text = '{\n  "a": "b"\n}';
-    formatted.refresh();
-    assert.strictEqual(formatted.scope.canFormat, true);
-    assert.strictEqual(formatted.scope.viewMode, 'formatted');
-    formatted.scope.setViewMode('raw');
-    assert.strictEqual(formatted.scope.viewMode, 'raw');
-    assert.strictEqual(formatted.scope.text, '{\n  "a": "b"\n}');
+    const validJsonValues = [
+        '{\n  "a": "b"\n}',
+        '[1, 2]',
+        '"hello"',
+        '"123"',
+        '123',
+        'true',
+        'false',
+        'null'
+    ];
+    validJsonValues.forEach(function (text) {
+        const formatted = createScope();
+        formatted.scope.text = text;
+        formatted.refresh();
+        assert.strictEqual(formatted.scope.canFormat, true);
+        assert.strictEqual(formatted.scope.viewMode, 'formatted');
+        formatted.scope.setViewMode('raw');
+        assert.strictEqual(formatted.scope.viewMode, 'raw');
+        assert.strictEqual(formatted.scope.text, text);
+    });
 
-    const plainText = createScope();
-    plainText.scope.text = '{"a":1,"a":2}';
-    plainText.refresh();
-    assert.strictEqual(plainText.scope.canFormat, false);
-    assert.strictEqual(plainText.scope.viewMode, 'raw');
+    assert.strictEqual(jsonBigIntFilter('"hello"'), '"hello"');
+    assert.strictEqual(jsonBigIntFilter('"123"'), '"123"');
+    assert.strictEqual(jsonBigIntFilter('123'), '123');
+    assert.strictEqual(jsonBigIntFilter('"|123|"'), '123');
+    assert.strictEqual(jsonBigIntFilter('true'), 'true');
+    assert.strictEqual(jsonBigIntFilter('false'), 'false');
+    assert.strictEqual(jsonBigIntFilter('null'), 'null');
+
+    const rawOnlyValues = [
+        '{"a":1,"a":2}',
+        '{"a":',
+        'not JSON'
+    ];
+    rawOnlyValues.forEach(function (text) {
+        const rawOnly = createScope();
+        rawOnly.scope.text = text;
+        rawOnly.refresh();
+        assert.strictEqual(rawOnly.scope.canFormat, false);
+        assert.strictEqual(rawOnly.scope.viewMode, 'raw');
+    });
 
     const template = fs.readFileSync(templatePath, 'utf8');
     assert.ok(template.includes('Component.ShowText.FormattedValue'));

--- a/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
@@ -109,7 +109,11 @@ function runTests() {
     assert.strictEqual(jsonBigIntFilter('false'), 'false');
     assert.strictEqual(jsonBigIntFilter('null'), 'null');
     assert.strictEqual(formatForDisplay('-9007199254740993'), '-9007199254740993');
+    assert.strictEqual(formatForDisplay('9007199254740993.0'), '9007199254740993.0');
+    assert.strictEqual(formatForDisplay('9.007199254740993e15'), '9.007199254740993e15');
     assert.strictEqual(formatForDisplay('"|-9007199254740993|"'), '"|-9007199254740993|"');
+    assert.strictEqual(formatForDisplay('"|9.007199254740993e15|"'),
+        '"|9.007199254740993e15|"');
 
     const rawOnlyValues = [
         '{"a":1,"a":2}',

--- a/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
@@ -71,6 +71,13 @@ function createScope() {
     };
 }
 
+function formatForDisplay(text) {
+    const formatted = createScope();
+    formatted.scope.text = text;
+    formatted.refresh();
+    return jsonBigIntFilter(JSON.stringify(formatted.scope.jsonObject, null, 4));
+}
+
 function runTests() {
     const validJsonValues = [
         '{\n  "a": "b"\n}',
@@ -97,9 +104,12 @@ function runTests() {
     assert.strictEqual(jsonBigIntFilter('"123"'), '"123"');
     assert.strictEqual(jsonBigIntFilter('123'), '123');
     assert.strictEqual(jsonBigIntFilter('"|123|"'), '123');
+    assert.strictEqual(jsonBigIntFilter('"|-123|"'), '-123');
     assert.strictEqual(jsonBigIntFilter('true'), 'true');
     assert.strictEqual(jsonBigIntFilter('false'), 'false');
     assert.strictEqual(jsonBigIntFilter('null'), 'null');
+    assert.strictEqual(formatForDisplay('-9007199254740993'), '-9007199254740993');
+    assert.strictEqual(formatForDisplay('"|-9007199254740993|"'), '"|-9007199254740993|"');
 
     const rawOnlyValues = [
         '{"a":1,"a":2}',

--- a/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const directivePath = path.join(__dirname, '../../../../main/resources/static/scripts/directive',
+    'show-text-modal-directive.js');
+const templatePath = path.join(__dirname, '../../../../main/resources/static/views/component',
+    'show-text-modal.html');
+
+const directiveModule = {
+    directive: function () {
+        return {
+            filter: function () {
+                return this;
+            }
+        };
+    }
+};
+
+const context = {
+    directive_module: directiveModule
+};
+vm.runInNewContext(fs.readFileSync(directivePath, 'utf8'), context, {
+    filename: directivePath
+});
+
+const directiveDefinition = context.showTextModalDirective({
+    prefixPath: function () {
+        return '';
+    },
+    hasDuplicateKeys: function (text) {
+        return text === '{"a":1,"a":2}';
+    }
+});
+
+function createScope() {
+    const watchers = {};
+    const scope = {
+        $watch: function (name, callback) {
+            watchers[name] = callback;
+        }
+    };
+    directiveDefinition.link(scope);
+    return {
+        scope: scope,
+        refresh: function () {
+            watchers.text();
+        }
+    };
+}
+
+function runTests() {
+    const formatted = createScope();
+    formatted.scope.text = '{\n  "a": "b"\n}';
+    formatted.refresh();
+    assert.strictEqual(formatted.scope.canFormat, true);
+    assert.strictEqual(formatted.scope.viewMode, 'formatted');
+    formatted.scope.setViewMode('raw');
+    assert.strictEqual(formatted.scope.viewMode, 'raw');
+    assert.strictEqual(formatted.scope.text, '{\n  "a": "b"\n}');
+
+    const plainText = createScope();
+    plainText.scope.text = '{"a":1,"a":2}';
+    plainText.refresh();
+    assert.strictEqual(plainText.scope.canFormat, false);
+    assert.strictEqual(plainText.scope.viewMode, 'raw');
+
+    const template = fs.readFileSync(templatePath, 'utf8');
+    assert.ok(template.includes('Component.ShowText.FormattedValue'));
+    assert.ok(template.includes('Component.ShowText.RawValue'));
+    assert.ok(template.includes("viewMode == 'formatted'"));
+    assert.ok(template.includes("viewMode == 'raw'"));
+
+    console.log('All show-text modal tests passed.');
+}
+
+runTests();

--- a/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
+++ b/apollo-portal/src/test/resources/static/scripts/test_showTextModal.js
@@ -119,6 +119,8 @@ function runTests() {
     assert.ok(template.includes('Component.ShowText.RawValue'));
     assert.ok(template.includes("viewMode == 'formatted'"));
     assert.ok(template.includes("viewMode == 'raw'"));
+    assert.ok(template.includes('ng-bind="text"'));
+    assert.ok(template.includes('ng-bind="jsonObject | json:4 | jsonBigIntFilter"'));
 
     console.log('All show-text modal tests passed.');
 }


### PR DESCRIPTION
## What's the purpose of this PR

Add a formatted/raw value switch to the Portal text viewer for JSON configuration values.

Valid JSON values without duplicate keys open in the formatted view and can be switched to the exact raw value returned by the interface. Invalid JSON, duplicate-key JSON, and plain text remain raw-only. Text diff behavior is unchanged.

## Which issue(s) this PR fixes:

None.

## Brief changelog

- Add `Formatted` and `Raw` tabs to the text viewer for format-safe JSON values.
- Preserve the original value for raw inspection.
- Add Chinese and English labels.
- Add focused JavaScript coverage for formatted, raw, plain-text, and duplicate-key behavior.
- Update `CHANGES.md`.

## Validation

- `node apollo-portal/src/test/resources/static/scripts/test_hasDuplicateKeys.js`
- `node apollo-portal/src/test/resources/static/scripts/test_showTextModal.js`
- `./mvnw -Dmaven.gitcommitid.skip=true spotless:check`
- `./mvnw -Dmaven.gitcommitid.skip=true clean test`
- `./mvnw -Dmaven.gitcommitid.skip=true spotless:apply`

The git commit ID plugin is skipped locally because its legacy version cannot resolve `HEAD` from a Git worktree.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formatted and raw views for configuration values in the Portal.
  * Formatted viewing is available for valid JSON without duplicate keys.
  * Added English and Chinese localization for the new view options.

* **Bug Fixes**
  * Improved handling of invalid, empty, or duplicate-key JSON by displaying it as raw text.
  * Improved parsing of signed, decimal, exponent-form, and extended numeric values.
  * View selection now resets correctly when opening configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->