### PR TITLE
fix: strict JSON/YAML well-formedness validation at the authoritative save path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Apollo 3.0.0
 * [Feature: support revoking unpublished changes for non-properties namespaces](https://github.com/apolloconfig/apollo/pull/5656)
 * [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 * [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
+* [Fix: strict JSON/YAML well-formedness validation at the authoritative save path](https://github.com/apolloconfig/apollo/pull/5660)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
@@ -76,7 +76,18 @@ public class ItemController {
   public ItemDTO create(@PathVariable("appId") String appId,
       @PathVariable("clusterName") String clusterName,
       @PathVariable("namespaceName") String namespaceName, @RequestBody ItemDTO dto) {
+    Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
+    if (namespace == null) {
+      throw NotFoundException.namespaceNotFound(appId, clusterName, namespaceName);
+    }
+
     Item entity = BeanUtils.transform(Item.class, dto);
+    // the namespace the item belongs to is resolved from the URL, not trusted from the request
+    // body - otherwise a caller could post to one namespace's URL while supplying another
+    // namespace's ID, saving the item under a different namespace than the one being called and,
+    // since ItemService looks up the format via namespaceId, bypassing that other namespace's
+    // syntax validation
+    entity.setNamespaceId(namespace.getId());
 
     Item managedEntity = itemService.findOne(appId, clusterName, namespaceName, entity.getKey());
     if (managedEntity != null) {

--- a/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ItemControllerTest.java
+++ b/apollo-adminservice/src/test/java/com/ctrip/framework/apollo/adminservice/controller/ItemControllerTest.java
@@ -90,6 +90,40 @@ public class ItemControllerTest extends AbstractControllerTest {
   @Test
   @Sql(scripts = "/controller/test-itemset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
   @Sql(scripts = "/controller/cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCreateIgnoresNamespaceIdMismatchFromRequestBody() {
+    String appId = "someAppId";
+    AppDTO app = restTemplate.getForObject(appBaseUrl(), AppDTO.class, appId);
+    assert app != null;
+    ClusterDTO cluster =
+        restTemplate.getForObject(clusterBaseUrl(), ClusterDTO.class, app.getAppId(), "default");
+    assert cluster != null;
+    NamespaceDTO namespace = restTemplate.getForObject(namespaceBaseUrl(), NamespaceDTO.class,
+        app.getAppId(), cluster.getName(), "application");
+    NamespaceDTO otherNamespace = restTemplate.getForObject(namespaceBaseUrl(), NamespaceDTO.class,
+        app.getAppId(), cluster.getName(), "someNamespace");
+    assert namespace != null;
+    assert otherNamespace != null;
+
+    // posting to "application"'s URL, but with someNamespace's ID in the request body - the
+    // resolved namespace (from the URL) must win, not the caller-supplied ID
+    ItemDTO item = new ItemDTO("test-key", "test-value", "", 1);
+    item.setNamespaceId(otherNamespace.getId());
+    item.setDataChangeLastModifiedBy("apollo");
+
+    ResponseEntity<ItemDTO> response = restTemplate.postForEntity(itemBaseUrl(), item,
+        ItemDTO.class, app.getAppId(), cluster.getName(), namespace.getNamespaceName());
+    Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+    Assert.assertEquals(namespace.getId(),
+        Objects.requireNonNull(response.getBody()).getNamespaceId());
+
+    long itemId = response.getBody().getId();
+    itemRepository.findById(itemId)
+        .ifPresent(savedItem -> Assert.assertEquals(namespace.getId(), savedItem.getNamespaceId()));
+  }
+
+  @Test
+  @Sql(scripts = "/controller/test-itemset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/controller/cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   public void testUpdate() {
     this.testCreate();
 

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
@@ -23,9 +23,11 @@ import com.ctrip.framework.apollo.biz.entity.Item;
 import com.ctrip.framework.apollo.biz.entity.Namespace;
 import com.ctrip.framework.apollo.biz.repository.ItemRepository;
 import com.ctrip.framework.apollo.common.dto.ItemInfoDTO;
+import com.ctrip.framework.apollo.common.entity.AppNamespace;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.common.exception.NotFoundException;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
+import com.ctrip.framework.apollo.common.utils.NamespaceContentSyntaxValidator;
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 
 import org.springframework.context.annotation.Lazy;
@@ -45,14 +47,17 @@ public class ItemService {
 
   private final ItemRepository itemRepository;
   private final NamespaceService namespaceService;
+  private final AppNamespaceService appNamespaceService;
   private final AuditService auditService;
   private final BizConfig bizConfig;
 
   public ItemService(final ItemRepository itemRepository,
-      final @Lazy NamespaceService namespaceService, final AuditService auditService,
+      final @Lazy NamespaceService namespaceService,
+      final @Lazy AppNamespaceService appNamespaceService, final AuditService auditService,
       final BizConfig bizConfig) {
     this.itemRepository = itemRepository;
     this.namespaceService = namespaceService;
+    this.appNamespaceService = appNamespaceService;
     this.auditService = auditService;
     this.bizConfig = bizConfig;
   }
@@ -169,6 +174,7 @@ public class ItemService {
     checkItemKeyLength(entity.getKey());
     checkItemType(entity.getType());
     checkItemValueLength(entity.getNamespaceId(), entity.getValue());
+    checkItemValueSyntax(entity.getNamespaceId(), entity.getValue());
 
     entity.setId(0);// protection
 
@@ -210,6 +216,7 @@ public class ItemService {
   public Item update(Item item) {
     checkItemType(item.getType());
     checkItemValueLength(item.getNamespaceId(), item.getValue());
+    checkItemValueSyntax(item.getNamespaceId(), item.getValue());
     Item managedItem = itemRepository.findById(item.getId()).orElse(null);
     BeanUtils.copyEntityProperties(item, managedItem);
     managedItem = itemRepository.save(managedItem);
@@ -234,6 +241,31 @@ public class ItemService {
       throw new BadRequestException("value too long. length limit:" + limit);
     }
     return true;
+  }
+
+  /**
+   * Rejects a json/yml/yaml namespace's item value if it isn't well-formed. This is the single,
+   * authoritative enforcement point: every entry route (portal whole-text save, portal
+   * single-item edit, OpenAPI/AdminService callers) funnels through {@link #save(Item)}/
+   * {@link #update(Item)}.
+   */
+  private void checkItemValueSyntax(long namespaceId, String value) {
+    Namespace currentNamespace = namespaceService.findOne(namespaceId);
+    if (currentNamespace == null) {
+      return;
+    }
+    AppNamespace appNamespace = appNamespaceService.findOne(currentNamespace.getAppId(),
+        currentNamespace.getNamespaceName());
+    // a namespace with no recognizable format can't be json/yml/yaml anyway - and
+    // formatAsEnum() would throw on a blank value rather than treat it as "unknown"
+    if (appNamespace == null || StringUtils.isBlank(appNamespace.getFormat())) {
+      return;
+    }
+    try {
+      NamespaceContentSyntaxValidator.validate(appNamespace.formatAsEnum(), value);
+    } catch (IllegalArgumentException ex) {
+      throw new BadRequestException(ex.getMessage());
+    }
   }
 
   private int getGrayNamespaceItemValueLengthLimit(Namespace grayNamespace,

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ItemServiceGrayNamespaceLimitTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ItemServiceGrayNamespaceLimitTest.java
@@ -93,7 +93,8 @@ class ItemServiceGrayNamespaceLimitTest {
     // Create ItemService with mocked dependencies
     ItemService itemService = new ItemService(
         org.mockito.Mockito.mock(com.ctrip.framework.apollo.biz.repository.ItemRepository.class),
-        mockNamespaceService, org.mockito.Mockito.mock(AuditService.class), mockBizConfig);
+        mockNamespaceService, org.mockito.Mockito.mock(AppNamespaceService.class),
+        org.mockito.Mockito.mock(AuditService.class), mockBizConfig);
 
     // Act: Call the private method via reflection
     java.lang.reflect.Method method = ItemService.class
@@ -145,7 +146,8 @@ class ItemServiceGrayNamespaceLimitTest {
 
     ItemService itemService = new ItemService(
         org.mockito.Mockito.mock(com.ctrip.framework.apollo.biz.repository.ItemRepository.class),
-        mockNamespaceService, org.mockito.Mockito.mock(AuditService.class), mockBizConfig);
+        mockNamespaceService, org.mockito.Mockito.mock(AppNamespaceService.class),
+        org.mockito.Mockito.mock(AuditService.class), mockBizConfig);
 
     // Create a value that exceeds gray namespace's limit (20000) but fits in parent's limit (50000)
     String value = "x".repeat(30000);

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ItemServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ItemServiceTest.java
@@ -47,6 +47,8 @@ public class ItemServiceTest extends AbstractIntegrationTest {
   @Autowired
   private NamespaceService namespaceService;
   @Autowired
+  private AppNamespaceService appNamespaceService;
+  @Autowired
   private AuditService auditService;
 
   @Mock
@@ -58,7 +60,8 @@ public class ItemServiceTest extends AbstractIntegrationTest {
   @Before
   public void setUp() throws Exception {
     mocks = MockitoAnnotations.openMocks(this);
-    itemService2 = new ItemService(itemRepository, namespaceService, auditService, bizConfig);
+    itemService2 = new ItemService(itemRepository, namespaceService, appNamespaceService,
+        auditService, bizConfig);
   }
 
   @After
@@ -176,6 +179,77 @@ public class ItemServiceTest extends AbstractIntegrationTest {
     Assert.assertEquals(itemInfoDTO.toString(),
         ExpectedItemInfoDTOSByValue.getContent().get(0).toString());
 
+  }
+
+  @Test
+  @Sql(scripts = "/sql/namespace-format-test.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testSaveItemRejectsMalformedJsonOnJsonNamespace() {
+    Item item = createItem(900001L, "content", "{\"name\": \"apollo\"", 0);
+    try {
+      itemService.save(item);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof BadRequestException);
+      Assert.assertTrue(e.getMessage().contains("invalid json content"));
+    }
+  }
+
+  @Test
+  @Sql(scripts = "/sql/namespace-format-test.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testSaveItemRejectsJsonWithTrailingTokensOnJsonNamespace() {
+    Item item = createItem(900001L, "content", "{\"name\": \"apollo\"} garbage", 0);
+    try {
+      itemService.save(item);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof BadRequestException);
+    }
+  }
+
+  @Test
+  @Sql(scripts = "/sql/namespace-format-test.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testSaveItemAcceptsWellFormedJsonOnJsonNamespace() {
+    Item item = createItem(900001L, "content", "{\"name\": \"apollo\", \"age\": 1}", 0);
+    Item dbItem = itemService.save(item);
+    Assert.assertEquals("{\"name\": \"apollo\", \"age\": 1}", dbItem.getValue());
+  }
+
+  @Test
+  @Sql(scripts = "/sql/namespace-format-test.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testUpdateItemRejectsMalformedJsonOnJsonNamespace() {
+    Item item = createItem(900001L, "content", "{\"name\": \"apollo\"}", 0);
+    Item dbItem = itemService.save(item);
+
+    Item update = createItem(900001L, "content", "not even json", 0);
+    update.setId(dbItem.getId());
+    update.setLineNum(dbItem.getLineNum());
+    try {
+      itemService.update(update);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof BadRequestException);
+    }
+  }
+
+  @Test
+  @Sql(scripts = "/sql/namespace-blank-format-test.sql",
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testSaveItemOnNamespaceWithBlankFormatIsNotSyntaxChecked() {
+    // a namespace whose AppNamespace has no recognizable format (e.g. a fixture/row that never
+    // set one) must not crash formatAsEnum() - it's simply not json/yml/yaml, so any value is
+    // accepted the same way it always was
+    Item item = createItem(900002L, "content", "not valid json or yaml either: [", 0);
+    Item dbItem = itemService.save(item);
+    Assert.assertEquals("not valid json or yaml either: [", dbItem.getValue());
   }
 
   private Item createItem(long namespaceId, String key, String value, int type) {

--- a/apollo-biz/src/test/resources/sql/namespace-blank-format-test.sql
+++ b/apollo-biz/src/test/resources/sql/namespace-blank-format-test.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2025 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Deliberately omits `Format` on the AppNamespace insert - some existing fixtures/rows do this,
+-- and it resolves to a blank value rather than a recognizable format in the test DB.
+INSERT INTO "App" ( `AppId`, `Name`, `OrgId`, `OrgName`, `OwnerName`, `OwnerEmail`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES('blankFormatTestApp', 'test', 'default', 'default', 'default', 'default', 0, 'default', 'default');
+
+INSERT INTO "Cluster" (`Id`, `Name`, `AppId`, `ParentClusterId`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES (900002, 'default', 'blankFormatTestApp', 0, 0, 'default', 'default');
+
+INSERT INTO "AppNamespace" (`Name`, `AppId`) VALUES ( 'blank.format', 'blankFormatTestApp');
+
+INSERT INTO "Namespace" (`Id`, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(900002,'blankFormatTestApp', 'default', 'blank.format', 0, 'apollo', 'apollo');

--- a/apollo-biz/src/test/resources/sql/namespace-format-test.sql
+++ b/apollo-biz/src/test/resources/sql/namespace-format-test.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2025 Apollo Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+INSERT INTO "App" ( `AppId`, `Name`, `OrgId`, `OrgName`, `OwnerName`, `OwnerEmail`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES('formatTestApp', 'test', 'default', 'default', 'default', 'default', 0, 'default', 'default');
+
+INSERT INTO "Cluster" (`Id`, `Name`, `AppId`, `ParentClusterId`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES (900001, 'default', 'formatTestApp', 0, 0, 'default', 'default');
+
+INSERT INTO "AppNamespace" (`Name`, `AppId`, `Format`, `IsPublic`) VALUES ( 'format.json', 'formatTestApp', 'json', 0);
+
+INSERT INTO "Namespace" (`Id`, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(900001,'formatTestApp', 'default', 'format.json', 0, 'apollo', 'apollo');

--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -97,6 +97,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <!-- yml processing, used by NamespaceContentSyntaxValidator -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
 
         <!-- Micrometer core dependency -->
         <dependency>

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/NamespaceContentSyntaxValidator.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/NamespaceContentSyntaxValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.utils;
+
+import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Validates that a {@code json}/{@code yml}/{@code yaml} namespace's content is well-formed.
+ * This checks syntax only - whether the text actually parses as JSON/YAML - it does not check
+ * the content against any particular structure.
+ *
+ * <p>This class is intentionally shared (apollo-common) so it can be used both as the
+ * authoritative, server-side check in apollo-biz's {@code ItemService}, and as fast, non
+ * -authoritative feedback in apollo-portal's syntax-check endpoints.</p>
+ */
+public final class NamespaceContentSyntaxValidator {
+
+  // readTree() only parses the first JSON value in the input and silently ignores anything
+  // after it by default - e.g. "{\"a\":1} garbage" would otherwise be accepted as well-formed
+  private static final ObjectMapper OBJECT_MAPPER =
+      JsonMapper.builder().enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS).build();
+
+  private NamespaceContentSyntaxValidator() {}
+
+  /**
+   * @return {@code true} if {@code format}'s content is strictly checked for well-formedness by
+   *     {@link #validate}; {@code false} for properties/xml/txt, which aren't checked here.
+   */
+  public static boolean isStrictlyValidated(ConfigFileFormat format) {
+    return format == ConfigFileFormat.JSON || format == ConfigFileFormat.YAML
+        || format == ConfigFileFormat.YML;
+  }
+
+  /**
+   * Validates that {@code content} is well-formed for the given {@code format}. A no-op for
+   * formats {@link #isStrictlyValidated} doesn't cover, and for blank content.
+   *
+   * @throws IllegalArgumentException if {@code content} is not valid JSON/YAML
+   */
+  public static void validate(ConfigFileFormat format, String content) {
+    if (!isStrictlyValidated(format) || StringUtils.isBlank(content)) {
+      return;
+    }
+    try {
+      if (format == ConfigFileFormat.JSON) {
+        OBJECT_MAPPER.readTree(content);
+      } else {
+        // YAML / YML: must be a single well-formed document - not a multi-document
+        // (`---`-separated) stream, and without silently-overwritten duplicate keys
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+        Yaml yaml = new Yaml(new SafeConstructor(loaderOptions));
+        yaml.load(content);
+      }
+    } catch (Exception ex) {
+      throw new IllegalArgumentException(
+          "invalid " + format.getValue() + " content: " + ex.getMessage(), ex);
+    }
+  }
+}

--- a/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/NamespaceContentSyntaxValidatorTest.java
+++ b/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/NamespaceContentSyntaxValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import org.junit.jupiter.api.Test;
+
+class NamespaceContentSyntaxValidatorTest {
+
+  @Test
+  void isStrictlyValidatedTrueForJsonYamlYml() {
+    assertTrue(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.JSON));
+    assertTrue(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.YAML));
+    assertTrue(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.YML));
+  }
+
+  @Test
+  void isStrictlyValidatedFalseForOtherFormats() {
+    assertFalse(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.Properties));
+    assertFalse(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.XML));
+    assertFalse(NamespaceContentSyntaxValidator.isStrictlyValidated(ConfigFileFormat.TXT));
+  }
+
+  @Test
+  void validJsonPasses() {
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON,
+        "{\"name\": \"apollo\", \"age\": 1}"));
+  }
+
+  @Test
+  void malformedJsonThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON, "{\"name\": "));
+  }
+
+  @Test
+  void jsonWithTrailingTokensThrows() {
+    // readTree() otherwise silently ignores anything after the first well-formed JSON value
+    assertThrows(IllegalArgumentException.class, () -> NamespaceContentSyntaxValidator
+        .validate(ConfigFileFormat.JSON, "{\"name\": \"apollo\"} garbage"));
+  }
+
+  @Test
+  void jsonWithTrailingJsonValueThrows() {
+    assertThrows(IllegalArgumentException.class, () -> NamespaceContentSyntaxValidator
+        .validate(ConfigFileFormat.JSON, "{\"name\": \"apollo\"} {\"name\": \"apollo2\"}"));
+  }
+
+  @Test
+  void validYamlPasses() {
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.YAML,
+        "name: apollo\nage: 1"));
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.YML,
+        "name: apollo\nage: 1"));
+  }
+
+  @Test
+  void malformedYamlThrows() {
+    assertThrows(IllegalArgumentException.class, () -> NamespaceContentSyntaxValidator
+        .validate(ConfigFileFormat.YAML, "name: apollo\n  bad indent: - ["));
+  }
+
+  @Test
+  void yamlWithTrailingDocumentThrows() {
+    // a multi-document (`---`-separated) YAML stream is not a single well-formed document
+    assertThrows(IllegalArgumentException.class, () -> NamespaceContentSyntaxValidator
+        .validate(ConfigFileFormat.YAML, "name: apollo\n---\nname: apollo2"));
+  }
+
+  @Test
+  void yamlWithDuplicateKeysThrows() {
+    assertThrows(IllegalArgumentException.class, () -> NamespaceContentSyntaxValidator
+        .validate(ConfigFileFormat.YAML, "name: apollo\nname: apollo2"));
+  }
+
+  @Test
+  void nonStrictFormatsAreNeverValidated() {
+    // garbage content on properties/xml/txt namespaces is not this validator's concern
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.Properties,
+        "{ not json, not properties either"));
+    assertDoesNotThrow(
+        () -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.XML, "not xml at all"));
+    assertDoesNotThrow(
+        () -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.TXT, "anything goes"));
+  }
+
+  @Test
+  void blankContentIsAlwaysValid() {
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON, ""));
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON, null));
+    assertDoesNotThrow(() -> NamespaceContentSyntaxValidator.validate(ConfigFileFormat.YAML, "  "));
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxChecker.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxChecker.java
@@ -21,19 +21,14 @@ import com.ctrip.framework.apollo.common.utils.NamespaceContentSyntaxValidator;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.portal.entity.model.NamespaceTextModel;
-import java.nio.charset.StandardCharsets;
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.core.io.ByteArrayResource;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.LoaderOptions;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
-import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * Checks namespace text syntax shared by Portal WebAPI and OpenAPI controllers. This is fast,
  * non-authoritative feedback for the UI - the actual save is authoritatively enforced in
- * apollo-biz's {@code ItemService}.
+ * apollo-biz's {@code ItemService}. Both routes share {@link NamespaceContentSyntaxValidator} so
+ * a namespace can't pass this check with content the save path would then reject (e.g. a
+ * multi-document YAML stream, which Spring's YAML loader accepts but the single-document,
+ * authoritative check does not).
  */
 public final class NamespaceTextSyntaxChecker {
 
@@ -45,42 +40,10 @@ public final class NamespaceTextSyntaxChecker {
     }
 
     ConfigFileFormat format = model.getFormat();
-    if (format == ConfigFileFormat.YAML || format == ConfigFileFormat.YML) {
-      checkYamlSyntax(model.getConfigText());
-    } else if (format == ConfigFileFormat.JSON) {
-      checkJsonSyntax(model.getConfigText());
-    }
-  }
-
-  private static void checkYamlSyntax(String configText) {
-    TypeLimitedYamlPropertiesFactoryBean yamlPropertiesFactoryBean =
-        new TypeLimitedYamlPropertiesFactoryBean();
-    yamlPropertiesFactoryBean
-        .setResources(new ByteArrayResource(configText.getBytes(StandardCharsets.UTF_8)));
     try {
-      yamlPropertiesFactoryBean.getObject();
-    } catch (Exception ex) {
-      throw new BadRequestException(ex.getMessage());
-    }
-  }
-
-  private static void checkJsonSyntax(String configText) {
-    try {
-      NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON, configText);
+      NamespaceContentSyntaxValidator.validate(format, model.getConfigText());
     } catch (IllegalArgumentException ex) {
       throw new BadRequestException(ex.getMessage());
-    }
-  }
-
-  private static class TypeLimitedYamlPropertiesFactoryBean extends YamlPropertiesFactoryBean {
-
-    @Override
-    protected Yaml createYaml() {
-      LoaderOptions loaderOptions = new LoaderOptions();
-      loaderOptions.setAllowDuplicateKeys(false);
-      DumperOptions dumperOptions = new DumperOptions();
-      return new Yaml(new SafeConstructor(loaderOptions), new Representer(dumperOptions),
-          dumperOptions, loaderOptions);
     }
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxChecker.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxChecker.java
@@ -17,6 +17,7 @@
 package com.ctrip.framework.apollo.portal.util;
 
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.common.utils.NamespaceContentSyntaxValidator;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.portal.entity.model.NamespaceTextModel;
@@ -30,7 +31,9 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 /**
- * Checks namespace text syntax shared by Portal WebAPI and OpenAPI controllers.
+ * Checks namespace text syntax shared by Portal WebAPI and OpenAPI controllers. This is fast,
+ * non-authoritative feedback for the UI - the actual save is authoritatively enforced in
+ * apollo-biz's {@code ItemService}.
  */
 public final class NamespaceTextSyntaxChecker {
 
@@ -41,17 +44,30 @@ public final class NamespaceTextSyntaxChecker {
       return;
     }
 
-    if (model.getFormat() != ConfigFileFormat.YAML && model.getFormat() != ConfigFileFormat.YML) {
-      return;
+    ConfigFileFormat format = model.getFormat();
+    if (format == ConfigFileFormat.YAML || format == ConfigFileFormat.YML) {
+      checkYamlSyntax(model.getConfigText());
+    } else if (format == ConfigFileFormat.JSON) {
+      checkJsonSyntax(model.getConfigText());
     }
+  }
 
+  private static void checkYamlSyntax(String configText) {
     TypeLimitedYamlPropertiesFactoryBean yamlPropertiesFactoryBean =
         new TypeLimitedYamlPropertiesFactoryBean();
-    yamlPropertiesFactoryBean.setResources(
-        new ByteArrayResource(model.getConfigText().getBytes(StandardCharsets.UTF_8)));
+    yamlPropertiesFactoryBean
+        .setResources(new ByteArrayResource(configText.getBytes(StandardCharsets.UTF_8)));
     try {
       yamlPropertiesFactoryBean.getObject();
     } catch (Exception ex) {
+      throw new BadRequestException(ex.getMessage());
+    }
+  }
+
+  private static void checkJsonSyntax(String configText) {
+    try {
+      NamespaceContentSyntaxValidator.validate(ConfigFileFormat.JSON, configText);
+    } catch (IllegalArgumentException ex) {
       throw new BadRequestException(ex.getMessage());
     }
   }

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -293,7 +293,8 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                 scope.showNamespaceBody = namespace.showNamespaceBody ? true : scope.showBody;
                 namespace.viewItems = namespace.items;
                 namespace.isPropertiesFormat = namespace.format == 'properties';
-                namespace.isSyntaxCheckable = namespace.format == 'yaml' || namespace.format == 'yml';
+                namespace.isSyntaxCheckable = namespace.format == 'yaml' || namespace.format == 'yml'
+                    || namespace.format == 'json';
                 namespace.isTextEditing = false;
                 namespace.isTextFullscreen = false;
                 namespace.instanceViewType = namespace_instance_view_type.LATEST_RELEASE;

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxCheckerTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxCheckerTest.java
@@ -54,6 +54,23 @@ class NamespaceTextSyntaxCheckerTest {
   }
 
   @Test
+  void yamlWithMultipleDocumentsThrows() {
+    // Spring's YamlPropertiesFactoryBean (the portal's old syntax check) treats `---`-separated
+    // documents as valid, merged config - but the authoritative save path requires a single
+    // document, so this must be rejected here too, not just at save time
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("yaml", "name: apollo\n---\nname: apollo2")));
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("yml", "name: apollo\n---\nname: apollo2")));
+  }
+
+  @Test
+  void yamlWithDuplicateKeysThrows() {
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("yaml", "name: apollo\nname: apollo2")));
+  }
+
+  @Test
   void validJsonPasses() {
     assertDoesNotThrow(() -> NamespaceTextSyntaxChecker
         .check(model("json", "{\"name\": \"apollo\", \"age\": 1}")));

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxCheckerTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/util/NamespaceTextSyntaxCheckerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.portal.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.portal.entity.model.NamespaceTextModel;
+import org.junit.jupiter.api.Test;
+
+class NamespaceTextSyntaxCheckerTest {
+
+  @Test
+  void blankConfigTextIsAlwaysValid() {
+    assertDoesNotThrow(() -> NamespaceTextSyntaxChecker.check(model("yaml", "")));
+    assertDoesNotThrow(() -> NamespaceTextSyntaxChecker.check(model("json", null)));
+  }
+
+  @Test
+  void nonCheckedFormatsAreNeverValidated() {
+    assertDoesNotThrow(
+        () -> NamespaceTextSyntaxChecker.check(model("properties", "not = properties [[[")));
+    assertDoesNotThrow(() -> NamespaceTextSyntaxChecker.check(model("xml", "not xml at all")));
+    assertDoesNotThrow(() -> NamespaceTextSyntaxChecker.check(model("txt", "anything goes")));
+  }
+
+  @Test
+  void validYamlPasses() {
+    assertDoesNotThrow(
+        () -> NamespaceTextSyntaxChecker.check(model("yaml", "name: apollo\nage: 1")));
+    assertDoesNotThrow(
+        () -> NamespaceTextSyntaxChecker.check(model("yml", "name: apollo\nage: 1")));
+  }
+
+  @Test
+  void malformedYamlThrows() {
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("yaml", "name: apollo\n  bad indent: - [")));
+  }
+
+  @Test
+  void validJsonPasses() {
+    assertDoesNotThrow(() -> NamespaceTextSyntaxChecker
+        .check(model("json", "{\"name\": \"apollo\", \"age\": 1}")));
+  }
+
+  @Test
+  void malformedJsonThrows() {
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("json", "{\"name\": ")));
+  }
+
+  @Test
+  void jsonWithTrailingTokensThrows() {
+    // readTree() otherwise silently ignores anything after the first well-formed JSON value
+    assertThrows(BadRequestException.class,
+        () -> NamespaceTextSyntaxChecker.check(model("json", "{\"name\": \"apollo\"} garbage")));
+  }
+
+  private static NamespaceTextModel model(String format, String configText) {
+    NamespaceTextModel model = new NamespaceTextModel();
+    model.setFormat(format);
+    model.setConfigText(configText);
+    return model;
+  }
+}


### PR DESCRIPTION
Adds strict JSON/YAML well-formedness validation for namespace content, enforced server-side at the single authoritative save path regardless of entry point (Portal UI, Portal OpenAPI, or direct AdminService API calls).

- New shared `NamespaceContentSyntaxValidator` (apollo-common) checks that a `json`/`yml`/`yaml` namespace's content actually parses: valid JSON with no trailing tokens, and a single well-formed YAML document with no duplicate keys. Properties/xml/txt namespaces are untouched.
- Authoritative enforcement lives in apollo-biz's `ItemService.save()`/`update()` - the one choke point every save path (Portal whole-text save, single-item edit, OpenAPI, direct AdminService calls) funnels through.
- Portal's `NamespaceTextSyntaxChecker` now routes both JSON and YAML/YML through the same shared validator, so the fast, non-authoritative UI check and the authoritative save-time check agree - a namespace can no longer pass the Portal's syntax check with content (e.g. a multi-document YAML stream) that the save path then rejects.
- AdminService's item-create endpoint now resolves the namespace from the URL path instead of trusting the `namespaceId` field on the request body, closing a gap where a mismatched ID could bypass the target namespace's format-driven validation and persist the item under the wrong namespace.

This is deliberately scoped to well-formedness only, per discussion on #5659. Namespace-level JSON Schema storage/enforcement (declaring "this namespace's content must look like *this*") is a separate, larger feature with open questions on lifecycle, rollout/rollback, existing-content behavior, permissions, and public-namespace identity - tracked separately in #5662.

## What's the purpose of this PR

Today, yaml/yml namespaces get a syntax check only in the Portal (non-authoritative, and using a looser multi-document-tolerant parser than what's actually enforced at save time), and json namespaces get no check at all anywhere. This closes both gaps: every write path now rejects malformed json/yml/yaml content, and the Portal's pre-save feedback is guaranteed to match what the save path will actually accept.

## Which issue(s) this PR fixes

Part of #5659 (scoped to well-formedness validation; schema storage/enforcement is tracked in #5662)

## Brief changelog

- `apollo-common`: new `NamespaceContentSyntaxValidator` - validates JSON (via Jackson) and YAML/YML (via SnakeYAML, single document, no duplicate keys) content for well-formedness.
- `apollo-biz`: `ItemService.save()`/`update()` reject malformed content for json/yml/yaml namespaces via the shared validator; guards against a namespace with a blank `AppNamespace.format`.
- `apollo-adminservice`: `ItemController.create()` resolves the namespace from the URL and uses its ID, rather than trusting the request body's `namespaceId`.
- `apollo-portal`: `NamespaceTextSyntaxChecker` routes JSON and YAML/YML through the shared validator (replacing the old `YamlPropertiesFactoryBean`-based YAML check); JSON added to the syntax-checkable formats in the namespace panel UI.
- Tests: unit coverage for the validator itself, `ItemService` save/update rejection and acceptance across json/yml/yaml (including the blank-format regression case), `NamespaceTextSyntaxChecker` parity coverage (including multi-document and duplicate-key YAML), and an AdminService integration test for the namespace-ID-mismatch case.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).
