### PR TITLE
feat(openapi): add batch create/update/delete for namespace items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Apollo 3.0.0
 * [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 * [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 * [Fix: strict JSON/YAML well-formedness validation at the authoritative save path](https://github.com/apolloconfig/apollo/pull/5660)
+* [Feature: add batch create/update/delete OpenAPI operations for namespace items](https://github.com/apolloconfig/apollo/pull/5665)
 * [Change: upgrade Apollo server baseline to Spring Boot 4.1.1 and Spring Cloud 2025.1.3](https://github.com/apolloconfig/apollo/pull/5671)
 * [Fix: preserve last-modified metadata of unchanged items when revoking changes](https://github.com/apolloconfig/apollo/pull/5672)
 

--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -27,7 +27,7 @@
 	<artifactId>apollo-portal</artifactId>
 	<name>Apollo Portal</name>
 	<properties>
-		<apollo.openapi.spec.url>https://raw.githubusercontent.com/apolloconfig/apollo-openapi/v0.3.10/apollo-openapi.yaml</apollo.openapi.spec.url>
+		<apollo.openapi.spec.url>https://raw.githubusercontent.com/apolloconfig/apollo-openapi/v0.3.11/apollo-openapi.yaml</apollo.openapi.spec.url>
 		<github.path>${project.artifactId}</github.path>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 	</properties>

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ItemOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ItemOpenApiService.java
@@ -52,6 +52,15 @@ public interface ItemOpenApiService {
   void batchUpdateItemsByText(String appId, String env, String clusterName, String namespaceName,
       OpenNamespaceTextModel model, String operator);
 
+  void batchCreateItems(String appId, String env, String clusterName, String namespaceName,
+      List<OpenItemDTO> items, String operator);
+
+  void batchUpdateItems(String appId, String env, String clusterName, String namespaceName,
+      List<OpenItemDTO> items, String operator);
+
+  void batchDeleteItems(String appId, String env, String clusterName, String namespaceName,
+      List<String> keys, String operator);
+
   List<OpenItemDiffDTO> compareItems(String appId, String env, String clusterName,
       String namespaceName, OpenNamespaceSyncDTO model);
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiService.java
@@ -16,6 +16,7 @@
  */
 package com.ctrip.framework.apollo.openapi.server.service;
 
+import com.ctrip.framework.apollo.common.dto.ItemChangeSets;
 import com.ctrip.framework.apollo.common.dto.ItemDTO;
 import com.ctrip.framework.apollo.common.dto.NamespaceDTO;
 import com.ctrip.framework.apollo.common.dto.PageDTO;
@@ -178,6 +179,70 @@ public class ServerItemOpenApiService implements ItemOpenApiService {
   public void revertItems(String appId, String env, String clusterName, String namespaceName,
       String operator) {
     itemService.revokeItem(appId, Env.valueOf(env), clusterName, namespaceName, operator);
+  }
+
+  @Override
+  public void batchCreateItems(String appId, String env, String clusterName,
+      String namespaceName, List<OpenItemDTO> items, String operator) {
+    NamespaceDTO namespace =
+        namespaceService.loadNamespaceBaseInfo(appId, Env.valueOf(env), clusterName, namespaceName);
+
+    ItemChangeSets changeSets = new ItemChangeSets();
+    for (OpenItemDTO item : items) {
+      ItemDTO toCreate = OpenApiModelConverters.toItemDTO(item);
+      // protect
+      toCreate.setLineNum(0);
+      toCreate.setId(0);
+      toCreate.setNamespaceId(namespace.getId());
+      toCreate.setDataChangeCreatedBy(operator);
+      toCreate.setDataChangeLastModifiedBy(operator);
+      toCreate.setDataChangeLastModifiedTime(null);
+      toCreate.setDataChangeCreatedTime(null);
+      changeSets.addCreateItem(toCreate);
+    }
+    changeSets.setDataChangeLastModifiedBy(operator);
+
+    itemService.updateItems(appId, Env.valueOf(env), clusterName, namespaceName, changeSets);
+  }
+
+  @Override
+  public void batchUpdateItems(String appId, String env, String clusterName,
+      String namespaceName, List<OpenItemDTO> items, String operator) {
+    ItemChangeSets changeSets = new ItemChangeSets();
+    for (OpenItemDTO item : items) {
+      ItemDTO toUpdateItem = itemService
+          .loadItem(Env.valueOf(env), appId, clusterName, namespaceName, item.getKey());
+      if (toUpdateItem == null) {
+        throw NotFoundException.itemNotFound(appId, clusterName, namespaceName, item.getKey());
+      }
+      // protect. only value,type,comment,lastModifiedBy can be modified
+      toUpdateItem.setComment(item.getComment());
+      toUpdateItem.setType(item.getType());
+      toUpdateItem.setValue(item.getValue());
+      toUpdateItem.setDataChangeLastModifiedBy(operator);
+      changeSets.addUpdateItem(toUpdateItem);
+    }
+    changeSets.setDataChangeLastModifiedBy(operator);
+
+    itemService.updateItems(appId, Env.valueOf(env), clusterName, namespaceName, changeSets);
+  }
+
+  @Override
+  public void batchDeleteItems(String appId, String env, String clusterName,
+      String namespaceName, List<String> keys, String operator) {
+    ItemChangeSets changeSets = new ItemChangeSets();
+    for (String key : keys) {
+      ItemDTO toDeleteItem =
+          itemService.loadItem(Env.valueOf(env), appId, clusterName, namespaceName, key);
+      if (toDeleteItem == null) {
+        throw NotFoundException.itemNotFound(appId, clusterName, namespaceName, key);
+      }
+      toDeleteItem.setDataChangeLastModifiedBy(operator);
+      changeSets.addDeleteItem(toDeleteItem);
+    }
+    changeSets.setDataChangeLastModifiedBy(operator);
+
+    itemService.updateItems(appId, Env.valueOf(env), clusterName, namespaceName, changeSets);
   }
 
   private boolean isItemAlreadyExists(RuntimeException ex, String key) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiService.java
@@ -182,8 +182,8 @@ public class ServerItemOpenApiService implements ItemOpenApiService {
   }
 
   @Override
-  public void batchCreateItems(String appId, String env, String clusterName,
-      String namespaceName, List<OpenItemDTO> items, String operator) {
+  public void batchCreateItems(String appId, String env, String clusterName, String namespaceName,
+      List<OpenItemDTO> items, String operator) {
     NamespaceDTO namespace =
         namespaceService.loadNamespaceBaseInfo(appId, Env.valueOf(env), clusterName, namespaceName);
 
@@ -206,18 +206,20 @@ public class ServerItemOpenApiService implements ItemOpenApiService {
   }
 
   @Override
-  public void batchUpdateItems(String appId, String env, String clusterName,
-      String namespaceName, List<OpenItemDTO> items, String operator) {
+  public void batchUpdateItems(String appId, String env, String clusterName, String namespaceName,
+      List<OpenItemDTO> items, String operator) {
     ItemChangeSets changeSets = new ItemChangeSets();
     for (OpenItemDTO item : items) {
-      ItemDTO toUpdateItem = itemService
-          .loadItem(Env.valueOf(env), appId, clusterName, namespaceName, item.getKey());
+      ItemDTO toUpdateItem =
+          itemService.loadItem(Env.valueOf(env), appId, clusterName, namespaceName, item.getKey());
       if (toUpdateItem == null) {
         throw NotFoundException.itemNotFound(appId, clusterName, namespaceName, item.getKey());
       }
       // protect. only value,type,comment,lastModifiedBy can be modified
       toUpdateItem.setComment(item.getComment());
-      toUpdateItem.setType(item.getType());
+      if (item.getType() != null) {
+        toUpdateItem.setType(item.getType());
+      }
       toUpdateItem.setValue(item.getValue());
       toUpdateItem.setDataChangeLastModifiedBy(operator);
       changeSets.addUpdateItem(toUpdateItem);
@@ -228,8 +230,8 @@ public class ServerItemOpenApiService implements ItemOpenApiService {
   }
 
   @Override
-  public void batchDeleteItems(String appId, String env, String clusterName,
-      String namespaceName, List<String> keys, String operator) {
+  public void batchDeleteItems(String appId, String env, String clusterName, String namespaceName,
+      List<String> keys, String operator) {
     ItemChangeSets changeSets = new ItemChangeSets();
     for (String key : keys) {
       ItemDTO toDeleteItem =

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -235,6 +235,69 @@ public class ItemController implements ItemManagementApi {
     return ResponseEntity.ok().build();
   }
 
+  @PreAuthorize(
+      value = "@unifiedPermissionValidator.hasModifyNamespacePermission(#appId, #env, #clusterName, #namespaceName)")
+  @Override
+  public ResponseEntity<Void> batchCreateItems(String appId, String env, String clusterName,
+      String namespaceName, List<OpenItemDTO> items, String operator) {
+    checkItemList(items);
+    for (OpenItemDTO item : items) {
+      RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(item.getKey()),
+          "key should not be null or empty");
+      RequestPrecondition.checkArguments(!Objects.isNull(item.getValue()),
+          "value should not be null");
+      checkCommentLength(item.getComment());
+    }
+
+    String resolvedOperator = resolveOperator(operator, null);
+    this.itemOpenApiService.batchCreateItems(appId, env, clusterName, namespaceName, items,
+        resolvedOperator);
+    return ResponseEntity.ok().build();
+  }
+
+  @PreAuthorize(
+      value = "@unifiedPermissionValidator.hasModifyNamespacePermission(#appId, #env, #clusterName, #namespaceName)")
+  @Override
+  public ResponseEntity<Void> batchUpdateItems(String appId, String env, String clusterName,
+      String namespaceName, List<OpenItemDTO> items, String operator) {
+    checkItemList(items);
+    for (OpenItemDTO item : items) {
+      RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(item.getKey()),
+          "key should not be null or empty");
+      RequestPrecondition.checkArguments(!Objects.isNull(item.getValue()),
+          "value should not be null");
+      checkCommentLength(item.getComment());
+    }
+
+    String resolvedOperator = resolveOperator(operator, null);
+    this.itemOpenApiService.batchUpdateItems(appId, env, clusterName, namespaceName, items,
+        resolvedOperator);
+    return ResponseEntity.ok().build();
+  }
+
+  @PreAuthorize(
+      value = "@unifiedPermissionValidator.hasModifyNamespacePermission(#appId, #env, #clusterName, #namespaceName)")
+  @Override
+  public ResponseEntity<Void> batchDeleteItems(String appId, String env, String clusterName,
+      String namespaceName, List<String> keys, String operator) {
+    RequestPrecondition.checkArguments(keys != null && !keys.isEmpty(),
+        "keys can not be empty");
+    for (String key : keys) {
+      RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(key),
+          "key should not be null or empty");
+    }
+
+    String resolvedOperator = resolveOperator(operator, null);
+    this.itemOpenApiService.batchDeleteItems(appId, env, clusterName, namespaceName, keys,
+        resolvedOperator);
+    return ResponseEntity.ok().build();
+  }
+
+  private void checkItemList(List<OpenItemDTO> items) {
+    RequestPrecondition.checkArguments(items != null && !items.isEmpty(),
+        "items can not be empty");
+  }
+
   private void updateItemInternal(String appId, String env, String clusterName,
       String namespaceName, String key, boolean createIfNotExists, OpenItemDTO item,
       String operator) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -242,6 +242,7 @@ public class ItemController implements ItemManagementApi {
       String namespaceName, List<OpenItemDTO> items, String operator) {
     checkItemList(items);
     for (OpenItemDTO item : items) {
+      RequestPrecondition.checkArguments(item != null, "item payload can not be empty");
       RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(item.getKey()),
           "key should not be null or empty");
       RequestPrecondition.checkArguments(!Objects.isNull(item.getValue()),
@@ -262,6 +263,7 @@ public class ItemController implements ItemManagementApi {
       String namespaceName, List<OpenItemDTO> items, String operator) {
     checkItemList(items);
     for (OpenItemDTO item : items) {
+      RequestPrecondition.checkArguments(item != null, "item payload can not be empty");
       RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(item.getKey()),
           "key should not be null or empty");
       RequestPrecondition.checkArguments(!Objects.isNull(item.getValue()),
@@ -280,8 +282,7 @@ public class ItemController implements ItemManagementApi {
   @Override
   public ResponseEntity<Void> batchDeleteItems(String appId, String env, String clusterName,
       String namespaceName, List<String> keys, String operator) {
-    RequestPrecondition.checkArguments(keys != null && !keys.isEmpty(),
-        "keys can not be empty");
+    RequestPrecondition.checkArguments(keys != null && !keys.isEmpty(), "keys can not be empty");
     for (String key : keys) {
       RequestPrecondition.checkArguments(!StringUtils.isContainEmpty(key),
           "key should not be null or empty");
@@ -294,8 +295,7 @@ public class ItemController implements ItemManagementApi {
   }
 
   private void checkItemList(List<OpenItemDTO> items) {
-    RequestPrecondition.checkArguments(items != null && !items.isEmpty(),
-        "items can not be empty");
+    RequestPrecondition.checkArguments(items != null && !items.isEmpty(), "items can not be empty");
   }
 
   private void updateItemInternal(String appId, String env, String clusterName,

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiServiceTest.java
@@ -29,6 +29,7 @@ import com.ctrip.framework.apollo.common.dto.ItemDTO;
 import com.ctrip.framework.apollo.common.dto.NamespaceDTO;
 import com.ctrip.framework.apollo.common.dto.PageDTO;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.common.exception.NotFoundException;
 import com.ctrip.framework.apollo.openapi.model.OpenItemDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenItemDiffDTO;
 import com.ctrip.framework.apollo.openapi.model.OpenItemPageDTO;
@@ -195,6 +196,105 @@ class ServerItemOpenApiServiceTest {
     service.revertItems(APP_ID, ENV, CLUSTER, NAMESPACE, "operator");
 
     verify(itemService).revokeItem(APP_ID, Env.valueOf(ENV), CLUSTER, NAMESPACE, "operator");
+  }
+
+  @Test
+  void batchCreateItemsShouldStampNamespaceIdAndAuditFieldsForEachItem() {
+    NamespaceDTO namespace = new NamespaceDTO();
+    namespace.setId(88L);
+    when(namespaceService.loadNamespaceBaseInfo(APP_ID, Env.valueOf(ENV), CLUSTER, NAMESPACE))
+        .thenReturn(namespace);
+
+    List<OpenItemDTO> items =
+        List.of(openItem("timeout", "100"), openItem("retries", "3"));
+
+    service.batchCreateItems(APP_ID, ENV, CLUSTER, NAMESPACE, items, "operator");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemService).updateItems(eq(APP_ID), eq(Env.valueOf(ENV)), eq(CLUSTER), eq(NAMESPACE),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertThat(changeSets.getCreateItems()).extracting(ItemDTO::getKey)
+        .containsExactly("timeout", "retries");
+    assertThat(changeSets.getCreateItems()).allSatisfy(item -> {
+      assertThat(item.getNamespaceId()).isEqualTo(88L);
+      assertThat(item.getId()).isEqualTo(0);
+      assertThat(item.getDataChangeCreatedBy()).isEqualTo("operator");
+      assertThat(item.getDataChangeLastModifiedBy()).isEqualTo("operator");
+    });
+    assertThat(changeSets.getUpdateItems()).isEmpty();
+    assertThat(changeSets.getDeleteItems()).isEmpty();
+  }
+
+  @Test
+  void batchUpdateItemsShouldLoadEachItemAndPreserveIdentityFields() {
+    ItemDTO existing = item("timeout", "100");
+    existing.setId(99);
+    existing.setNamespaceId(10);
+    when(itemService.loadItem(Env.valueOf(ENV), APP_ID, CLUSTER, NAMESPACE, "timeout"))
+        .thenReturn(existing);
+
+    OpenItemDTO request = openItem("timeout", "200");
+    request.setComment("new comment");
+
+    service.batchUpdateItems(APP_ID, ENV, CLUSTER, NAMESPACE, List.of(request), "operator");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemService).updateItems(eq(APP_ID), eq(Env.valueOf(ENV)), eq(CLUSTER), eq(NAMESPACE),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertThat(changeSets.getUpdateItems()).hasSize(1);
+    ItemDTO delegated = changeSets.getUpdateItems().get(0);
+    assertThat(delegated.getId()).isEqualTo(99);
+    assertThat(delegated.getNamespaceId()).isEqualTo(10);
+    assertThat(delegated.getValue()).isEqualTo("200");
+    assertThat(delegated.getComment()).isEqualTo("new comment");
+    assertThat(delegated.getDataChangeLastModifiedBy()).isEqualTo("operator");
+  }
+
+  @Test
+  void batchUpdateItemsShouldRejectUnknownKey() {
+    when(itemService.loadItem(Env.valueOf(ENV), APP_ID, CLUSTER, NAMESPACE, "missing"))
+        .thenReturn(null);
+
+    List<OpenItemDTO> items = List.of(openItem("missing", "100"));
+
+    assertThatThrownBy(
+        () -> service.batchUpdateItems(APP_ID, ENV, CLUSTER, NAMESPACE, items, "operator"))
+        .isInstanceOf(NotFoundException.class);
+    verify(itemService, never()).updateItems(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void batchDeleteItemsShouldResolveEachKeyToItsInternalId() {
+    ItemDTO existing = item("timeout", "100");
+    existing.setId(99);
+    when(itemService.loadItem(Env.valueOf(ENV), APP_ID, CLUSTER, NAMESPACE, "timeout"))
+        .thenReturn(existing);
+
+    service.batchDeleteItems(APP_ID, ENV, CLUSTER, NAMESPACE, List.of("timeout"), "operator");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemService).updateItems(eq(APP_ID), eq(Env.valueOf(ENV)), eq(CLUSTER), eq(NAMESPACE),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertThat(changeSets.getDeleteItems()).hasSize(1);
+    assertThat(changeSets.getDeleteItems().get(0).getId()).isEqualTo(99);
+    assertThat(changeSets.getDeleteItems().get(0).getDataChangeLastModifiedBy())
+        .isEqualTo("operator");
+  }
+
+  @Test
+  void batchDeleteItemsShouldRejectUnknownKey() {
+    when(itemService.loadItem(Env.valueOf(ENV), APP_ID, CLUSTER, NAMESPACE, "missing"))
+        .thenReturn(null);
+
+    List<String> keys = List.of("missing");
+
+    assertThatThrownBy(
+        () -> service.batchDeleteItems(APP_ID, ENV, CLUSTER, NAMESPACE, keys, "operator"))
+        .isInstanceOf(NotFoundException.class);
+    verify(itemService, never()).updateItems(any(), any(), any(), any(), any());
   }
 
   @Test

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/server/service/ServerItemOpenApiServiceTest.java
@@ -205,8 +205,7 @@ class ServerItemOpenApiServiceTest {
     when(namespaceService.loadNamespaceBaseInfo(APP_ID, Env.valueOf(ENV), CLUSTER, NAMESPACE))
         .thenReturn(namespace);
 
-    List<OpenItemDTO> items =
-        List.of(openItem("timeout", "100"), openItem("retries", "3"));
+    List<OpenItemDTO> items = List.of(openItem("timeout", "100"), openItem("retries", "3"));
 
     service.batchCreateItems(APP_ID, ENV, CLUSTER, NAMESPACE, items, "operator");
 
@@ -214,8 +213,8 @@ class ServerItemOpenApiServiceTest {
     verify(itemService).updateItems(eq(APP_ID), eq(Env.valueOf(ENV)), eq(CLUSTER), eq(NAMESPACE),
         captor.capture());
     ItemChangeSets changeSets = captor.getValue();
-    assertThat(changeSets.getCreateItems()).extracting(ItemDTO::getKey)
-        .containsExactly("timeout", "retries");
+    assertThat(changeSets.getCreateItems()).extracting(ItemDTO::getKey).containsExactly("timeout",
+        "retries");
     assertThat(changeSets.getCreateItems()).allSatisfy(item -> {
       assertThat(item.getNamespaceId()).isEqualTo(88L);
       assertThat(item.getId()).isEqualTo(0);
@@ -250,6 +249,27 @@ class ServerItemOpenApiServiceTest {
     assertThat(delegated.getValue()).isEqualTo("200");
     assertThat(delegated.getComment()).isEqualTo("new comment");
     assertThat(delegated.getDataChangeLastModifiedBy()).isEqualTo("operator");
+  }
+
+  @Test
+  void batchUpdateItemsShouldPreserveExistingTypeWhenOmittedFromPayload() {
+    ItemDTO existing = item("timeout", "100");
+    existing.setType(5);
+    when(itemService.loadItem(Env.valueOf(ENV), APP_ID, CLUSTER, NAMESPACE, "timeout"))
+        .thenReturn(existing);
+
+    OpenItemDTO request = new OpenItemDTO();
+    request.setKey("timeout");
+    request.setValue("200");
+
+    service.batchUpdateItems(APP_ID, ENV, CLUSTER, NAMESPACE, List.of(request), "operator");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemService).updateItems(eq(APP_ID), eq(Env.valueOf(ENV)), eq(CLUSTER), eq(NAMESPACE),
+        captor.capture());
+    ItemDTO delegated = captor.getValue().getUpdateItems().get(0);
+    assertThat(delegated.getType()).isEqualTo(5);
+    assertThat(delegated.getValue()).isEqualTo("200");
   }
 
   @Test

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemControllerParamBindLowLevelTest.java
@@ -468,6 +468,34 @@ public class ItemControllerParamBindLowLevelTest {
   }
 
   @Test
+  public void batchCreateItemsShouldRejectNullElement() throws Exception {
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON).content("[null]"))
+        .andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchCreateItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
+  public void batchCreateItemsShouldRejectMissingConsumerOperatorEvenWithPayloadCreator()
+      throws Exception {
+    OpenItemDTO item = new OpenItemDTO();
+    item.setKey("timeout");
+    item.setValue("100");
+    item.setDataChangeCreatedBy("payload-creator");
+
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.singletonList(item)))).andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchCreateItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
   public void batchCreateItemsShouldDelegateWithResolvedOperator() throws Exception {
     OpenItemDTO item = new OpenItemDTO();
     item.setKey("timeout");
@@ -491,6 +519,17 @@ public class ItemControllerParamBindLowLevelTest {
         "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update",
         ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON)
         .content(gson.toJson(Collections.emptyList()))).andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchUpdateItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
+  public void batchUpdateItemsShouldRejectNullElement() throws Exception {
+    mockMvc.perform(put(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON).content("[null]"))
+        .andExpect(status().isBadRequest());
 
     verify(itemOpenApiService, never()).batchUpdateItems(anyString(), anyString(), anyString(),
         anyString(), any(List.class), anyString());

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemControllerParamBindLowLevelTest.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.openapi.v1.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +46,7 @@ import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -452,5 +454,88 @@ public class ItemControllerParamBindLowLevelTest {
     request.setSyncToNamespaces(Collections.singletonList(namespaceIdentifier));
     request.setSyncItems(Collections.emptyList());
     return request;
+  }
+
+  @Test
+  public void batchCreateItemsShouldRejectEmptyList() throws Exception {
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.emptyList()))).andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchCreateItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
+  public void batchCreateItemsShouldDelegateWithResolvedOperator() throws Exception {
+    OpenItemDTO item = new OpenItemDTO();
+    item.setKey("timeout");
+    item.setValue("100");
+
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create",
+        ENV, APP_ID, CLUSTER, NAMESPACE).param("operator", "api-operator")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.singletonList(item)))).andExpect(status().isOk());
+
+    ArgumentCaptor<List<OpenItemDTO>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(itemOpenApiService).batchCreateItems(eq(APP_ID), eq(ENV), eq(CLUSTER), eq(NAMESPACE),
+        itemsCaptor.capture(), eq("api-operator"));
+    assertThat(itemsCaptor.getValue()).extracting(OpenItemDTO::getKey).containsExactly("timeout");
+  }
+
+  @Test
+  public void batchUpdateItemsShouldRejectEmptyList() throws Exception {
+    mockMvc.perform(put(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.emptyList()))).andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchUpdateItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
+  public void batchUpdateItemsShouldDelegateWithResolvedOperator() throws Exception {
+    OpenItemDTO item = new OpenItemDTO();
+    item.setKey("timeout");
+    item.setValue("200");
+
+    mockMvc.perform(put(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update",
+        ENV, APP_ID, CLUSTER, NAMESPACE).param("operator", "api-operator")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.singletonList(item)))).andExpect(status().isOk());
+
+    ArgumentCaptor<List<OpenItemDTO>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(itemOpenApiService).batchUpdateItems(eq(APP_ID), eq(ENV), eq(CLUSTER), eq(NAMESPACE),
+        itemsCaptor.capture(), eq("api-operator"));
+    assertThat(itemsCaptor.getValue()).extracting(OpenItemDTO::getKey).containsExactly("timeout");
+  }
+
+  @Test
+  public void batchDeleteItemsShouldRejectEmptyList() throws Exception {
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-delete",
+        ENV, APP_ID, CLUSTER, NAMESPACE).contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.emptyList()))).andExpect(status().isBadRequest());
+
+    verify(itemOpenApiService, never()).batchDeleteItems(anyString(), anyString(), anyString(),
+        anyString(), any(List.class), anyString());
+  }
+
+  @Test
+  public void batchDeleteItemsShouldDelegateWithResolvedOperator() throws Exception {
+    mockMvc.perform(post(
+        "/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-delete",
+        ENV, APP_ID, CLUSTER, NAMESPACE).param("operator", "api-operator")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(gson.toJson(Collections.singletonList("timeout")))).andExpect(status().isOk());
+
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(List.class);
+    verify(itemOpenApiService).batchDeleteItems(eq(APP_ID), eq(ENV), eq(CLUSTER), eq(NAMESPACE),
+        keysCaptor.capture(), eq("api-operator"));
+    assertThat(keysCaptor.getValue()).containsExactly("timeout");
   }
 }

--- a/docs/en/portal/apollo-open-api-platform.md
+++ b/docs/en/portal/apollo-open-api-platform.md
@@ -868,6 +868,91 @@ http://{portal_address}/openapi/v1/apps/xxx-web/namespaces/application/roles/Mod
 
 * **Response Sample** : None
 
+##### 3.2.20 Batch create/update/delete configuration items
+
+> Available since Apollo 3.0.0. Contract: [`apollo-openapi` v0.3.11](https://github.com/apolloconfig/apollo-openapi/blob/v0.3.11/apollo-openapi.yaml).
+
+Submit a list of configuration items to create, update, or delete in a single call, instead of calling the single-item APIs repeatedly. The three operations are independent — there is no cross-operation atomicity (e.g. "create these and delete those in one transaction" requires two calls, producing two Commit records). Authorization matches the single-item APIs: the caller must have modify permission on the target Namespace (`@unifiedPermissionValidator.hasModifyNamespacePermission`).
+
+###### Batch create configuration items
+
+* **URL** :  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create
+* **Method** : POST
+* **Request Params** :
+
+| Parameter Name | Required | Type   | Description                                                                                  |
+| --------------- | -------- | ------ | ---------------------------------------------------------------------------------------------- |
+| operator        | false    | String | Operator for the created items, domain account; for consumer tokens falls back to each item's `dataChangeCreatedBy` when omitted |
+
+* **Request Body (JSON)** : an array of `OpenItemDTO`, same fields as [3.2.10 New configuration interface](#_3210-new-configuration-interface)
+
+* **Request body sample** :
+
+``` json
+[
+    {
+        "key":"timeout",
+        "value":"3000",
+        "comment":"timeout"
+    },
+    {
+        "key":"retries",
+        "value":"3",
+        "comment":"retry count"
+    }
+]
+```
+
+* **Response Sample** : None
+
+###### Batch update configuration items
+
+* **URL** :  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update
+* **Method** : PUT
+* **Request Params** :
+
+| Parameter Name | Required | Type   | Description                                |
+| --------------- | -------- | ------ | --------------------------------------------- |
+| operator        | false    | String | Operator for the updated items, domain account |
+
+* **Request Body (JSON)** : an array of `OpenItemDTO`; only `key`, `value`, `type`, and `comment` are used. Returns 404 if any `key` does not exist.
+
+* **Request body sample** :
+
+``` json
+[
+    {
+        "key":"timeout",
+        "value":"5000"
+    }
+]
+```
+
+* **Response Sample** : None
+
+###### Batch delete configuration items
+
+* **URL** :  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-delete
+* **Method** : POST
+* **Request Params** :
+
+| Parameter Name | Required | Type   | Description                                |
+| --------------- | -------- | ------ | --------------------------------------------- |
+| operator        | false    | String | Operator for the deleted items, domain account |
+
+* **Request Body (JSON)** : an array of item keys to delete. Returns 404 if any key does not exist.
+
+* **Request body sample** :
+
+``` json
+[
+    "timeout",
+    "retries"
+]
+```
+
+* **Response Sample** : None
+
 ### IV. Error code description
 
 Under normal circumstances, the Http status code returned by the interface is 200, the following lists the non-200 error code descriptions that Apollo will return.

--- a/docs/en/portal/apollo-open-api-platform.md
+++ b/docs/en/portal/apollo-open-api-platform.md
@@ -882,9 +882,9 @@ Submit a list of configuration items to create, update, or delete in a single ca
 
 | Parameter Name | Required | Type   | Description                                                                                  |
 | --------------- | -------- | ------ | ---------------------------------------------------------------------------------------------- |
-| operator        | false    | String | Operator for the created items, domain account; for consumer tokens falls back to each item's `dataChangeCreatedBy` when omitted |
+| operator        | false    | String | Operator for the created items, domain account |
 
-* **Request Body (JSON)** : an array of `OpenItemDTO`, same fields as [3.2.10 New configuration interface](#_3210-new-configuration-interface)
+* **Request Body (JSON)** : an array of `OpenItemDTO`, same fields as [3.2.10 New configuration interface](#3210-new-configuration-interface)
 
 * **Request body sample** :
 

--- a/docs/zh/portal/apollo-open-api-platform.md
+++ b/docs/zh/portal/apollo-open-api-platform.md
@@ -186,6 +186,7 @@ namespaceName | 所管理的Namespace的名称，如果是非properties格式，
 - [3.2.17 创建App并获取管理员权限](#_3217-创建App并获取管理员权限)
 - [3.2.18 用户管理](#_3218-用户管理)
 - [3.2.19 权限管理](#_3219-权限管理)
+- [3.2.20 批量新增/修改/删除配置项](#_3220-批量新增修改删除配置项)
 
 ##### 3.2.1 获取App的环境，集群信息
 
@@ -861,6 +862,91 @@ http://{portal_address}/openapi/v1/apps/xxx-web/namespaces/application/roles/Mod
 ```
 
 * **返回值 Sample** ： 无返回值
+
+##### 3.2.20 批量新增/修改/删除配置项
+
+> 自 Apollo 3.0.0 起可用。规范合同见 [`apollo-openapi` v0.3.11](https://github.com/apolloconfig/apollo-openapi/blob/v0.3.11/apollo-openapi.yaml)。
+
+用于一次性提交一批配置项进行创建、修改或删除，避免逐条调用单条配置项接口。三个接口各自独立，不提供跨接口的原子性（例如"新增一批同时删除另一批"需要调用两次，对应两条 Commit 记录）。鉴权与单条配置项接口一致：需要对目标 Namespace 具备修改权限（`@unifiedPermissionValidator.hasModifyNamespacePermission`）。
+
+###### 批量新增配置项
+
+* **URL** ：  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-create
+* **Method** ： POST
+* **Request Params** ：
+
+参数名 | 必选 | 类型 | 说明
+--- | --- | --- | ---
+operator | false | String | 新增配置的操作者，域账号；Consumer Token 未传时取请求体中每一项的 `dataChangeCreatedBy`
+
+* **请求内容(Request Body, JSON格式)** ：`OpenItemDTO` 数组，每一项字段同 [3.2.10 新增配置接口](#_3210-新增配置接口)
+
+* **Request body sample** :
+
+``` json
+[
+    {
+        "key":"timeout",
+        "value":"3000",
+        "comment":"超时时间"
+    },
+    {
+        "key":"retries",
+        "value":"3",
+        "comment":"重试次数"
+    }
+]
+```
+
+* **返回值** ：无
+
+###### 批量修改配置项
+
+* **URL** ：  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-update
+* **Method** ： PUT
+* **Request Params** ：
+
+参数名 | 必选 | 类型 | 说明
+--- | --- | --- | ---
+operator | false | String | 修改配置的操作者，域账号
+
+* **请求内容(Request Body, JSON格式)** ：`OpenItemDTO` 数组，只有 `key`、`value`、`type`、`comment` 会被使用；`key` 对应的配置项不存在时返回 404
+
+* **Request body sample** :
+
+``` json
+[
+    {
+        "key":"timeout",
+        "value":"5000"
+    }
+]
+```
+
+* **返回值** ：无
+
+###### 批量删除配置项
+
+* **URL** ：  http://{portal_address}/openapi/v1/envs/{env}/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/items/batch-delete
+* **Method** ： POST
+* **Request Params** ：
+
+参数名 | 必选 | 类型 | 说明
+--- | --- | --- | ---
+operator | false | String | 删除配置的操作者，域账号
+
+* **请求内容(Request Body, JSON格式)** ：待删除的配置项 key 数组；任意 key 不存在时返回 404
+
+* **Request body sample** :
+
+``` json
+[
+    "timeout",
+    "retries"
+]
+```
+
+* **返回值** ：无
 
 ### 四、错误码说明
 

--- a/docs/zh/portal/apollo-open-api-platform.md
+++ b/docs/zh/portal/apollo-open-api-platform.md
@@ -186,7 +186,7 @@ namespaceName | 所管理的Namespace的名称，如果是非properties格式，
 - [3.2.17 创建App并获取管理员权限](#_3217-创建App并获取管理员权限)
 - [3.2.18 用户管理](#_3218-用户管理)
 - [3.2.19 权限管理](#_3219-权限管理)
-- [3.2.20 批量新增/修改/删除配置项](#_3220-批量新增修改删除配置项)
+- [3.2.20 批量新增/修改/删除配置项](#3220-批量新增修改删除配置项)
 
 ##### 3.2.1 获取App的环境，集群信息
 
@@ -877,9 +877,9 @@ http://{portal_address}/openapi/v1/apps/xxx-web/namespaces/application/roles/Mod
 
 参数名 | 必选 | 类型 | 说明
 --- | --- | --- | ---
-operator | false | String | 新增配置的操作者，域账号；Consumer Token 未传时取请求体中每一项的 `dataChangeCreatedBy`
+operator | false | String | 新增配置的操作者，域账号
 
-* **请求内容(Request Body, JSON格式)** ：`OpenItemDTO` 数组，每一项字段同 [3.2.10 新增配置接口](#_3210-新增配置接口)
+* **请求内容(Request Body, JSON格式)** ：`OpenItemDTO` 数组，每一项字段同 [3.2.10 新增配置接口](#3210-新增配置接口)
 
 * **Request body sample** :
 


### PR DESCRIPTION
## Summary
- Add three new OpenAPI operations for namespace config items, backed by the existing internal `ItemChangeSets` batch plumbing (`ItemService.updateItems`):
  - `POST .../items/batch-create` — create a list of items
  - `PUT  .../items/batch-update` — update a list of items by key
  - `POST .../items/batch-delete` — delete a list of items by key
- Bump `apollo.openapi.spec.url` to `v0.3.11`, which defines the new contracts (companion spec PR: apolloconfig/apollo-openapi#37)
- Add unit tests for `ServerItemOpenApiService` and controller param binding
- Document the new endpoints in both `docs/zh` and `docs/en` OpenAPI platform docs

Closes #5666

## Motivation
The OpenAPI item endpoints previously only supported single-item create/update/delete (plus config-text replace and cross-namespace sync/diff). There was no way to submit a structured batch of creates/updates/deletes against a single namespace in one call. Item CUD is decoupled from release/publish, so no release-related handling was needed.

Three separate single-purpose endpoints (create/update/delete) were chosen over one combined change-set endpoint to match this spec's existing naming convention (`items/diff`, `items/synchronize`, `items/validation`, `items/revocation` are each a single action) and keep each request schema simple. Trade-off: no cross-type atomicity across a single call (a caller wanting both creates and deletes applied atomically needs 2 calls = 2 commits) — acceptable for the target batch-import/cleanup use case. See #5666 for the full discussion.

## Dependency
This PR depends on apolloconfig/apollo-openapi#37 being merged and tagged as `v0.3.11` before this branch's build will actually succeed against the real spec URL — `apollo.openapi.spec.url` in `pom.xml` already points at `https://raw.githubusercontent.com/apolloconfig/apollo-openapi/v0.3.11/...`, which won't resolve until that tag exists upstream. Locally this was verified by pointing the same property at a `file://` copy of the not-yet-merged spec via `-Dapollo.openapi.spec.url=...`.

## Test plan
- [x] `mvn -pl apollo-portal -am compile` (against local spec override)
- [x] `mvn -pl apollo-portal -am test` (full module, no regressions — 98/98 test classes pass)
- [x] `mvn -pl apollo-portal -am test -Dtest=ServerItemOpenApiServiceTest,ItemControllerParamBindLowLevelTest`
- [ ] Manual smoke test against a running portal once the spec tag is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI support for batch creation, updating, and deletion of namespace items.
  * Added validation and permission checks for batch item operations.
  * Updated the Apollo OpenAPI specification to version 0.3.11.

* **Documentation**
  * Added English and Chinese documentation covering batch API parameters, permissions, and error behavior.
  * Clarified operator handling for batch-create requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->