### PR TITLE
chore: upgrade to Spring Boot 4.1.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Apollo 3.0.0
 * [Feature: add formatted and raw JSON views in Portal](https://github.com/apolloconfig/apollo/pull/5657)
 * [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 * [Fix: strict JSON/YAML well-formedness validation at the authoritative save path](https://github.com/apolloconfig/apollo/pull/5660)
+* [Change: upgrade Apollo server baseline to Spring Boot 4.1.1 and Spring Cloud 2025.1.3](https://github.com/apolloconfig/apollo/pull/5671)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
@@ -48,7 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtil.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/util/AccessKeyUtil.java
@@ -22,7 +22,7 @@ import com.ctrip.framework.apollo.core.signature.Signature;
 import com.google.common.base.Strings;
 import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<apollo-java.version>2.5.0</apollo-java.version>
-		<spring-boot.version>4.0.5</spring-boot.version>
-		<spring-cloud.version>2025.1.1</spring-cloud.version>
+		<spring-boot.version>4.1.1</spring-boot.version>
+		<spring-cloud.version>2025.1.3</spring-cloud.version>
 		<spring-cloud-alibaba.version>2025.1.0.0</spring-cloud-alibaba.version>
 		<!-- sort by alphabet -->
 		<common-lang3.version>3.18.0</common-lang3.version>


### PR DESCRIPTION
## What's the purpose of this PR

Upgrade the Apollo server baseline from Spring Boot 4.0.5 to 4.1.1 and align the supporting Spring Cloud and Maven versions.

Spring Cloud 2025.1.3 no longer brings in Commons Lang 2 through Eureka, so this PR also migrates the two remaining implicit Commons Lang 2 imports to Commons Lang 3, which Apollo already manages directly.

Spring Cloud Alibaba remains at 2025.1.0.0. Nacos is an optional discovery-only profile, and its profile build is covered by the validation below.

## Which issue(s) this PR fixes:

None.

## Brief changelog

- Upgrade Spring Boot from 4.0.5 to 4.1.1.
- Upgrade Spring Cloud from 2025.1.1 to 2025.1.3.
- Upgrade the Maven Wrapper distribution from 3.5.4 to 3.9.16.
- Migrate `FastDateFormat` and `StringUtils` imports from Commons Lang 2 to Commons Lang 3.

## Tests

- `./mvnw -B --no-transfer-progress spotless:apply`
- `./mvnw -q -B --no-transfer-progress -Djacoco.skip=true test`
- `./mvnw -q -B --no-transfer-progress -Djacoco.skip=true -DskipTests package`
- `./mvnw -q -B --no-transfer-progress -Djacoco.skip=true -DskipTests -Pnacos-discovery -pl apollo-configservice,apollo-adminservice -am package`

The local tests used JDK 26 with JaCoCo disabled because the current JaCoCo version cannot instrument Java 26 bytecode. The regular Java 17/21 CI jobs will run the repository's standard coverage configuration.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything (equivalent full test run used `-Djacoco.skip=true` locally; standard coverage runs in CI).
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Upgraded the application’s Spring Boot baseline to 4.1.1.
  * Updated Spring Cloud to 2025.1.3.
  * Updated the Maven build tool to version 3.9.16.

* **Documentation**
  * Added release notes documenting the framework upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->