### PR TITLE
fix(portal): do not update unchanged items when revoking changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Apollo 3.0.0
 * [Feature: support configurable OIDC username claim (`spring.security.oidc.user-id-claim-name`) for the Apollo user identity](https://github.com/apolloconfig/apollo/pull/5655)
 * [Fix: strict JSON/YAML well-formedness validation at the authoritative save path](https://github.com/apolloconfig/apollo/pull/5660)
 * [Change: upgrade Apollo server baseline to Spring Boot 4.1.1 and Spring Cloud 2025.1.3](https://github.com/apolloconfig/apollo/pull/5671)
+* [Fix: preserve last-modified metadata of unchanged items when revoking changes](https://github.com/apolloconfig/apollo/pull/5672)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/18?closed=1)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
@@ -241,8 +241,7 @@ public class ItemService {
             0 == deletedItemDto.getLineNum() ? lineNum.get() : deletedItemDto.getLineNum();
         changeSets.addCreateItem(buildNormalItem(0L, namespaceId, key, deletedItemDto.getType(),
             value, deletedItemDto.getComment(), newLineNum));
-      } else if (!StringUtils.equals(oldItem.getValue(), value)
-          || lineNum.get() != oldItem.getLineNum()) {
+      } else if (!StringUtils.equals(oldItem.getValue(), value)) {
         changeSets.addUpdateItem(buildNormalItem(oldItem.getId(), namespaceId, key,
             oldItem.getType(), value, oldItem.getComment(), oldItem.getLineNum()));
       }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/ConfigServiceTest.java
@@ -198,6 +198,48 @@ public class ConfigServiceTest extends AbstractUnitTest {
   }
 
   @Test
+  public void testRevokeItemShouldNotUpdateWhenOnlyLineNumbersDiffer() {
+    String appId = "6666";
+    Env env = Env.DEV;
+    String clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
+    String namespaceName = ConfigConsts.NAMESPACE_APPLICATION;
+    long namespaceId = 123L;
+
+    NamespaceDTO namespace = generateNamespaceDTO(appId, clusterName, namespaceName);
+    namespace.setId(namespaceId);
+    ReleaseDTO release = new ReleaseDTO();
+    release.setConfigurations("{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}");
+
+    // persisted items share the same values as the release but have sparse/misaligned line numbers
+    ItemDTO itemA = new ItemDTO("a", "1", "comment", 5);
+    itemA.setId(1L);
+    itemA.setNamespaceId(namespaceId);
+    ItemDTO itemB = new ItemDTO("b", "2", "comment", 9);
+    itemB.setId(2L);
+    itemB.setNamespaceId(namespaceId);
+    ItemDTO itemC = new ItemDTO("c", "3", "comment", 20);
+    itemC.setId(3L);
+    itemC.setNamespaceId(namespaceId);
+
+    when(namespaceAPI.loadNamespace(appId, env, clusterName, namespaceName)).thenReturn(namespace);
+    when(releaseAPI.loadLatestRelease(appId, env, clusterName, namespaceName)).thenReturn(release);
+    when(itemAPI.findItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Arrays.asList(itemA, itemB, itemC));
+    when(itemAPI.findDeletedItems(appId, env, clusterName, namespaceName))
+        .thenReturn(Collections.emptyList());
+
+    configService.revokeItem(appId, env, clusterName, namespaceName, "test");
+
+    ArgumentCaptor<ItemChangeSets> captor = ArgumentCaptor.forClass(ItemChangeSets.class);
+    verify(itemAPI).updateItemsByChangeSet(eq(appId), eq(env), eq(clusterName), eq(namespaceName),
+        captor.capture());
+    ItemChangeSets changeSets = captor.getValue();
+    assertEquals(0, changeSets.getCreateItems().size());
+    assertEquals(0, changeSets.getUpdateItems().size());
+    assertEquals(0, changeSets.getDeleteItems().size());
+  }
+
+  @Test
   public void testRevokeItemShouldRestorePublishedFileContent() {
     String appId = "6666";
     Env env = Env.DEV;


### PR DESCRIPTION
## What's the purpose of this PR

Fix the `revokeItem` logic in `apollo-portal` so that revoking changes no longer produces spurious updates for items that were not actually modified.

**Root cause:** When revoking changes, `ItemService` compared each persisted item against the latest release and marked an item for update when either its value differed **or** its line number differed. Line numbers can shift whenever other items are added or removed (for example, deleting a middle row and publishing). As a result, every item below the shifted position was flagged for update even though its value was unchanged. On the server side this rewrote those items and reset their modification metadata (`DataChangeLastModifiedTime` / `DataChangeLastModifiedBy`) to the current time and current user, matching the behavior reported in the issue.

**Fix (minimal, value-only):** Restrict the update condition to value-only differences and ignore line-number shifts. Only items whose value actually changed are added to the update change set; pure line-number reordering no longer triggers an update, so unchanged items keep their original metadata.

```java
// before
} else if (!StringUtils.equals(oldItem.getValue(), value)
    || lineNum.get() != oldItem.getLineNum()) {
// after
} else if (!StringUtils.equals(oldItem.getValue(), value)) {
```

## Which issue(s) this PR fixes:
Fixes #4659

## Brief changelog

- `apollo-portal` `ItemService`: when revoking changes, only mark an item for update when its value differs from the released value; ignore line-number-only differences that occur when other items are added/removed. This prevents unchanged items from being rewritten and having their last-modified time/user reset.
- Added regression test `ConfigServiceTest#testRevokeItemShouldNotUpdateWhenOnlyLineNumbersDiffer`, which sets up persisted items sharing the same values as the latest release but with sparse/misaligned line numbers, invokes `revokeItem`, and asserts that the produced `ItemChangeSets` has 0 create, 0 update, and 0 delete items. This test fails (RED) against the previous condition and passes (GREEN) with the value-only fix.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).

---

### Validation (JDK 17)

```bash
./mvnw -B spotless:apply
./mvnw -B clean package jacoco:report -Dmaven.gitcommitid.skip=true
```

Both complete with 0 failures / 0 errors. The `apollo-portal` `ConfigServiceTest` suite runs 9 tests, 0 failures, 0 errors, including the new regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revoking configuration items no longer triggers unnecessary updates when only line numbers differ.
  * Preserves last-modified metadata for unchanged items.
  * Prevents unrelated item changes from being recorded when key/value content remains unchanged.

* **Tests**
  * Added coverage to verify that revocation produces no creates, updates, or deletes when only line positions differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
